### PR TITLE
[Inventory] Connect real Items and Inbox surfaces

### DIFF
--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -33,6 +33,7 @@ vi.mock("@/widgets/right-panels/RightPanels", () => ({
   ),
 }));
 vi.mock("@/features/lifelog/JournalShell", () => ({ default: ({ roles: roleOptions }: { roles: RoleDetail[] }) => <div data-testid="journal-shell">Journal · {roleOptions.map(({ name }) => name).join(", ")}</div> }));
+vi.mock("@/features/inventory/InventoryShell", () => ({ default: ({ surface }: { surface: string }) => <div data-testid="inventory-shell">Inventory · {surface}</div> }));
 vi.mock("@/features/role/RoleShell", () => ({ default: () => <div data-testid="role-shell">Role Shell</div> }));
 vi.mock("@/features/quests/JourneyShell", () => ({ default: () => <div data-testid="journey-shell">Journey Shell</div> }));
 vi.mock("@/shared/ui/ParticleBackground", () => ({ default: () => null }));
@@ -40,7 +41,7 @@ vi.mock("@/shared/ui/AmbientOverlay", () => ({ default: () => null }));
 vi.mock("@/shared/ui/SaoAlert", () => ({ default: () => null }));
 vi.mock("@/shared/ui/NotificationBell", () => ({ NotificationBell: () => null }));
 
-describe("Home shell에서 LifeLog surface를 routing할 때", () => {
+describe("Home shell에서 feature surface를 routing할 때", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     auth.state = { isAuthenticated: true, playerId: 7, isLoading: false, logout: vi.fn() };
@@ -71,6 +72,23 @@ describe("Home shell에서 LifeLog surface를 routing할 때", () => {
       expect(screen.getByTestId("role-shell")).toBeInTheDocument();
       fireEvent.click(screen.getByRole("button", { name: "Journey" }));
       expect(screen.getByTestId("journey-shell")).toBeInTheDocument();
+    });
+  });
+
+  describe("인증된 player가 Inventory를 선택하면", () => {
+    it("Items와 Inbox는 feature-owned shell에 연결하고 기존 Gear route는 유지한다", () => {
+      render(<Home />);
+
+      fireEvent.click(screen.getByRole("button", { name: "Inventory" }));
+      fireEvent.click(screen.getByRole("button", { name: "Items" }));
+      expect(screen.getByTestId("inventory-shell")).toHaveTextContent("Inventory · items");
+
+      fireEvent.click(screen.getByRole("button", { name: "Inbox" }));
+      expect(screen.getByTestId("inventory-shell")).toHaveTextContent("Inventory · inbox");
+
+      fireEvent.click(screen.getByRole("button", { name: "Gear" }));
+      expect(screen.queryByTestId("inventory-shell")).not.toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Weapon" })).toBeInTheDocument();
     });
   });
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -14,6 +14,7 @@ import { useAuth } from "@/features/auth/AuthContext";
 import JourneyShell from "@/features/quests/JourneyShell";
 import RoleShell from "@/features/role/RoleShell";
 import JournalShell from "@/features/lifelog/JournalShell";
+import InventoryShell from "@/features/inventory/InventoryShell";
 import { useRoles } from "@/features/role/useRoles";
 import { usePanScroll } from "@/shared/hooks/usePanScroll";
 import { MOCK_CHARACTER_SHEET } from "@/features/player/mock";
@@ -54,11 +55,7 @@ import {
   SOCIAL_LISTS,
 } from "@/features/social/model";
 import { LISTING_FORM_FIELDS } from "@/features/market/model";
-import {
-  makeGearLists,
-  INVENTORY_INBOX_LIST,
-  INVENTORY_ITEMS_LIST,
-} from "@/features/inventory/model";
+import { makeGearLists } from "@/features/inventory/model";
 import {
   MARKET_SHOP_CATALOG_LIST,
   MARKET_SHOP_MY_LISTINGS,
@@ -74,11 +71,10 @@ import { UI_CONSTS } from "@/shared/lib/uiConsts";
 import { useToast } from "@/context/ToastContext";
 import { NotificationBell } from "@/shared/ui/NotificationBell";
 import { getEquippedGearApi, equipGearApi, unequipGearApi } from "@/lib/api/endpoints/equipment.api";
-import { claimMailApi, deleteMailApi } from "@/lib/api/endpoints/inventory.api";
 import { requestJoinPartyApi, requestJoinGuildApi, unfollowApi } from "@/lib/api/endpoints/social.api";
 import { reserveShopItemApi, confirmShopPurchaseApi, cancelListingApi, createListingApi } from "@/lib/api/endpoints/market.api";
 import { MOCK_SHOP_ITEMS } from "@/lib/api/mock/market.mock";
-import { MOCK_INVENTORY_ITEMS, MOCK_MAIL_ITEMS } from "@/lib/api/mock/inventory.mock";
+import { MOCK_INVENTORY_ITEMS } from "@/lib/api/mock/inventory.mock";
 import { getEquipSlotId } from "@/features/inventory/model";
 import type { EquipmentSlotInfo } from "@/shared/api/types";
 
@@ -90,9 +86,7 @@ type SurfaceFocusState = {
 type DetailSelectionKey =
   | "player"
   | "skills"
-  | "inventoryItems"
   | "inventoryGear"
-  | "inventoryInbox"
   | "social"
   | "lifelog"
   | "marketWallet"
@@ -111,9 +105,7 @@ function createDefaultDetailSelections(): Record<DetailSelectionKey, string | nu
   return {
     player: null,
     skills: null,
-    inventoryItems: null,
     inventoryGear: null,
-    inventoryInbox: null,
     social: null,
     lifelog: null,
     marketWallet: null,
@@ -239,30 +231,7 @@ function buildPanels(
   }
 
   if (selectedMain === "inventory") {
-    if (selectedMainSub === "items") {
-      const selectedItem = findById(INVENTORY_ITEMS_LIST, selectedDetailByKey.inventoryItems);
-
-      panelStack.push({
-        id: "inventory-items-list",
-        kind: "list",
-        title: "Items List",
-        items: INVENTORY_ITEMS_LIST,
-        selectedId: selectedDetailByKey.inventoryItems ?? undefined,
-        context: { main: "inventory", route: "inventory-items-list" },
-      });
-
-      if (selectedItem) {
-        panelStack.push({
-          id: `inventory-items-detail-${selectedItem.id}`,
-          kind: "placeholder",
-          title: selectedItem.detailTitle ?? "Item Detail",
-          description: selectedItem.detailDescription,
-          rows: selectedItem.detailRows,
-        });
-      }
-
-      return { panelStack, socialContext: null };
-    }
+    if (selectedMainSub === "items" || selectedMainSub === "inbox") return { panelStack, socialContext: null };
 
     if (selectedMainSub === "gear") {
       const selectedPart =
@@ -305,27 +274,6 @@ function buildPanels(
       }
 
       return { panelStack, socialContext: null };
-    }
-
-    const selectedItem = findById(INVENTORY_INBOX_LIST, selectedDetailByKey.inventoryInbox);
-
-    panelStack.push({
-      id: "inventory-inbox-list",
-      kind: "list",
-      title: "Mail List",
-      items: INVENTORY_INBOX_LIST,
-      selectedId: selectedDetailByKey.inventoryInbox ?? undefined,
-      context: { main: "inventory", route: "inventory-inbox-list" },
-    });
-
-    if (selectedItem) {
-      panelStack.push({
-        id: `inventory-inbox-detail-${selectedItem.id}`,
-        kind: "placeholder",
-        title: "Mail Detail",
-        description: selectedItem.detailDescription,
-        rows: selectedItem.detailRows,
-      });
     }
 
     return { panelStack, socialContext: null };
@@ -663,7 +611,7 @@ export default function Home() {
       });
     }
     if (main === "skills") updateDetailSelections({ skills: null });
-    if (main === "inventory") updateDetailSelections({ inventoryItems: null, inventoryGear: null, inventoryInbox: null });
+    if (main === "inventory") updateDetailSelections({ inventoryGear: null });
     if (main === "social") updateDetailSelections({ social: null });
     if (main === "lifelog") {
       updateDetailSelections({ lifelog: null });
@@ -825,7 +773,7 @@ export default function Home() {
     }
 
     if (panel.kind === "list") {
-      const { player, skills, inventoryItems, inventoryGear, inventoryInbox, social,
+      const { player, skills, inventoryGear, social,
               lifelog, marketWallet, marketCatalog, marketMyListings, marketTradeFriend } = selectedDetailByKey;
 
       if (panel.context.route === "player-list") {
@@ -833,9 +781,7 @@ export default function Home() {
         updateDetailSelections({ player: tog(player) });
       }
       if (panel.context.route === "skills-list") updateDetailSelections({ skills: tog(skills) });
-      if (panel.context.route === "inventory-items-list") updateDetailSelections({ inventoryItems: tog(inventoryItems) });
       if (panel.context.route === "inventory-gear-list") updateDetailSelections({ inventoryGear: tog(inventoryGear) });
-      if (panel.context.route === "inventory-inbox-list") updateDetailSelections({ inventoryInbox: tog(inventoryInbox) });
       if (panel.context.route === "social-list") updateDetailSelections({ social: tog(social) });
       if (panel.context.route === "lifelog-list") {
         setActiveFormPanel(null); setEditingItemId(null);
@@ -1071,23 +1017,6 @@ export default function Home() {
         });
       }
 
-    } else if (actionType === "claim") {
-      const mailId = Number(itemId);
-      const mail = MOCK_MAIL_ITEMS.find((m) => m.mailId === mailId);
-      if (!mail) return;
-      setPendingAction({
-        title: "아이템 수령",
-        message: `${mail.itemName} x${mail.quantity}을(를) 수령하시겠습니까?`,
-        onConfirm: async () => {
-          try {
-            await claimMailApi(mail.slotIndex, mail.quantity);
-            showToast({ variant: "success", title: "수령 완료", body: `${mail.itemName} x${mail.quantity}` });
-          } catch {
-            showToast({ variant: "error", title: "수령 실패", body: "다시 시도해주세요." });
-          }
-        },
-      });
-
     } else if (actionType === "cancel") {
       if (selectedMain === "market") {
         const listingId = Number(itemId);
@@ -1124,45 +1053,12 @@ export default function Home() {
           },
         });
       } else {
-        const isMailbox = selectedMain === "inventory" && sub === "inbox";
-        const mailId = Number(itemId);
-        const mail = isMailbox ? MOCK_MAIL_ITEMS.find((m) => m.mailId === mailId) : null;
         setPendingAction({
           title: "삭제",
-          message: mail ? `${mail.itemName} 메일을 삭제하시겠습니까?` : "이 항목을 삭제하시겠습니까?",
-          onConfirm: async () => {
-            if (mail) {
-              try {
-                await deleteMailApi(mail.slotIndex);
-                showToast({ variant: "info", title: "메일 삭제됨", body: mail.itemName });
-              } catch {
-                showToast({ variant: "error", title: "삭제 실패", body: "다시 시도해주세요." });
-              }
-            }
-          },
+          message: "이 항목을 삭제하시겠습니까?",
+          onConfirm: async () => {},
         });
       }
-
-    } else if (actionType === "sell") {
-      const itemInstanceId = Number(itemId);
-      const invItem = MOCK_INVENTORY_ITEMS.find((i) => i.itemInstanceId === itemInstanceId);
-      if (!invItem) return;
-      setSelectedSubByMain((prev) => ({ ...prev, market: "shop" }));
-      setSelectedMarketShopSectionId("my-listings");
-      setSelectedMain("market");
-      openForm(
-        "listing-create",
-        "New Listing",
-        LISTING_FORM_FIELDS,
-        "등록하기",
-        {
-          itemName: invItem.itemName,
-          price: "",
-          quantity: String(invItem.quantity),
-          _itemInstanceId: String(invItem.itemInstanceId),
-          _itemId: String(invItem.itemId),
-        },
-      );
 
     } else if (actionType === "gift") {
       // Friend gift action from long press — push gift panel
@@ -1454,6 +1350,16 @@ export default function Home() {
             </div>
           ) : selectedMain === "quests" ? (
             <JourneyShell />
+          ) : selectedMain === "inventory" && (selectedSubByMain.inventory === "items" || selectedSubByMain.inventory === "inbox") ? (
+            <div className="flex w-fit items-center gap-3">
+              <RightPanels
+                selectedMain="inventory"
+                panelStack={panelStack.slice(0, 1)}
+                panelStackKey="inventory-real-menu"
+                onPanelItemSelect={handlePanelItemSelect}
+              />
+              <InventoryShell surface={selectedSubByMain.inventory === "items" ? "items" : "inbox"} />
+            </div>
           ) : selectedMain === "lifelog" && selectedSubByMain.lifelog === "journal" ? (
             <div className="flex w-fit items-center gap-3">
               <RightPanels

--- a/features/inventory/InventoryShell.test.tsx
+++ b/features/inventory/InventoryShell.test.tsx
@@ -1,0 +1,171 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { InventoryEntriesResponse, InventoryEntry, MailboxEntriesResponse, MailEntry } from "@/shared/api/types";
+import InventoryShell from "./InventoryShell";
+
+const api = vi.hoisted(() => ({
+  claimMailApi: vi.fn(),
+  deleteMailApi: vi.fn(),
+  getInventoryApi: vi.fn(),
+  getMailboxApi: vi.fn(),
+}));
+
+vi.mock("@/lib/api/endpoints/inventory.api", () => api);
+vi.mock("@/shared/ui/PanelCard", () => ({
+  default: ({ label, slotLabel, subtitle, onClick }: { label: string; slotLabel: string; subtitle?: string; onClick?: () => void }) => (
+    <button type="button" data-testid="inventory-entry" onClick={onClick}>{label} · {slotLabel} · {subtitle}</button>
+  ),
+}));
+
+const item: InventoryEntry = {
+  itemInstanceId: 501,
+  slotIndex: 2,
+  itemId: 101,
+  itemName: "Server Sword",
+  category: "WEAPON",
+  type: "SWORD",
+  rarity: "RARE",
+  stackable: false,
+  maxStack: 1,
+  quantity: 1,
+  bound: true,
+  durability: 0,
+  instanceAttrs: { atk: 12 },
+};
+
+const mail: MailEntry = {
+  mailId: 701,
+  slotIndex: 4,
+  itemId: 301,
+  itemName: "Server Potion",
+  category: "CONSUMABLE",
+  type: "POTION",
+  rarity: "COMMON",
+  stackable: true,
+  maxStack: 99,
+  quantity: 3,
+  bound: false,
+  durability: null,
+  instanceAttrs: {},
+};
+
+const inventory: InventoryEntriesResponse = { entries: [item] };
+const mailbox: MailboxEntriesResponse = { entries: [mail] };
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => { resolve = resolvePromise; });
+  return { promise, resolve };
+}
+
+describe("Inventory Items와 Inbox surface를 사용할 때", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+    api.getInventoryApi.mockResolvedValue(inventory);
+    api.getMailboxApi.mockResolvedValue(mailbox);
+    api.claimMailApi.mockResolvedValue(undefined);
+    api.deleteMailApi.mockResolvedValue(undefined);
+  });
+
+  describe("Items를 조회하고 itemInstanceId로 선택하면", () => {
+    it("loading 후 server list/detail을 표시하고 generic sell/remove action은 노출하지 않는다", async () => {
+      const response = deferred<InventoryEntriesResponse>();
+      api.getInventoryApi.mockReturnValue(response.promise);
+      render(<InventoryShell surface="items" />);
+      expect(screen.getByText("Loading Items...")).toBeInTheDocument();
+
+      await act(async () => {
+        response.resolve(inventory);
+        await response.promise;
+      });
+      fireEvent.click(await screen.findByRole("button", { name: /Server Sword/ }));
+
+      expect(screen.getByText("Item instance ID: 501")).toBeInTheDocument();
+      expect(screen.getByText("Durability: 0")).toBeInTheDocument();
+      expect(screen.getByText(/Instance attrs:.*"atk":12/)).toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: /sell|remove/i })).not.toBeInTheDocument();
+    });
+
+    it("error의 Retry가 authoritative empty Items state를 표시한다", async () => {
+      api.getInventoryApi.mockRejectedValueOnce(new Error("Items unavailable")).mockResolvedValueOnce({ entries: [] });
+      render(<InventoryShell surface="items" />);
+
+      expect(await screen.findByRole("alert")).toHaveTextContent("Items unavailable");
+      fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+      expect(await screen.findByText("No Items.")).toBeInTheDocument();
+    });
+  });
+
+  describe("Inbox를 조회하고 mailId로 선택하면", () => {
+    it("loading 후 server list/detail과 nullable durability를 표시한다", async () => {
+      const response = deferred<MailboxEntriesResponse>();
+      api.getMailboxApi.mockReturnValue(response.promise);
+      render(<InventoryShell surface="inbox" />);
+      expect(screen.getByText("Loading Inbox...")).toBeInTheDocument();
+
+      await act(async () => {
+        response.resolve(mailbox);
+        await response.promise;
+      });
+      fireEvent.click(await screen.findByRole("button", { name: /Server Potion/ }));
+
+      expect(screen.getByText("Mail ID: 701")).toBeInTheDocument();
+      expect(screen.getByText("Slot index: 4")).toBeInTheDocument();
+      expect(screen.getByText("Durability: Not recorded")).toBeInTheDocument();
+    });
+
+    it("error의 Retry가 authoritative empty Inbox state를 표시한다", async () => {
+      api.getMailboxApi.mockRejectedValueOnce(new Error("Inbox unavailable")).mockResolvedValueOnce({ entries: [] });
+      render(<InventoryShell surface="inbox" />);
+
+      expect(await screen.findByRole("alert")).toHaveTextContent("Inbox unavailable");
+      fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+      expect(await screen.findByText("No mail.")).toBeInTheDocument();
+    });
+  });
+
+  describe("Inbox claim을 확인하면", () => {
+    it("authoritative payload를 한 번만 보내고 pending 동안 duplicate action을 막은 뒤 두 list를 reload한다", async () => {
+      const request = deferred<void>();
+      api.claimMailApi.mockReturnValue(request.promise);
+      render(<InventoryShell surface="inbox" />);
+      fireEvent.click(await screen.findByRole("button", { name: /Server Potion/ }));
+
+      fireEvent.click(screen.getByRole("button", { name: "Claim" }));
+      expect(window.confirm).toHaveBeenCalledWith("Claim Server Potion x3?");
+      expect(api.claimMailApi).toHaveBeenCalledWith({ slotIndex: 4, quantity: 3 });
+      expect(screen.getByRole("button", { name: "Working..." })).toBeDisabled();
+      fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+      expect(api.deleteMailApi).not.toHaveBeenCalled();
+
+      api.getInventoryApi.mockResolvedValue({ entries: [{ ...item, quantity: 2 }] });
+      api.getMailboxApi.mockResolvedValue({ entries: [] });
+      await act(async () => {
+        request.resolve();
+        await request.promise;
+      });
+
+      await waitFor(() => expect(screen.getByText("No mail.")).toBeInTheDocument());
+      expect(api.getInventoryApi).toHaveBeenCalledTimes(2);
+      expect(api.getMailboxApi).toHaveBeenCalledTimes(2);
+    });
+
+    it("Delete 확인은 선택한 mail의 slotIndex로 요청하고 mailbox를 reload한다", async () => {
+      render(<InventoryShell surface="inbox" />);
+      fireEvent.click(await screen.findByRole("button", { name: /Server Potion/ }));
+      api.getMailboxApi.mockResolvedValue({ entries: [] });
+
+      fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+      expect(window.confirm).toHaveBeenCalledWith("Delete Server Potion mail?");
+      await waitFor(() => expect(api.deleteMailApi).toHaveBeenCalledWith({ slotIndex: 4 }));
+      await waitFor(() => expect(screen.getByText("No mail.")).toBeInTheDocument());
+      expect(api.getInventoryApi).toHaveBeenCalledTimes(1);
+      expect(api.getMailboxApi).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/features/inventory/InventoryShell.tsx
+++ b/features/inventory/InventoryShell.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { useState } from "react";
+
+import type { InventoryEntry, MailEntry } from "@/shared/api/types";
+import { SAO } from "@/shared/design/tokens";
+import PanelCard from "@/shared/ui/PanelCard";
+import { PanelFrame } from "@/widgets/right-panels/ui/PanelFrame";
+import { GoldRow, InfoCard } from "@/widgets/right-panels/ui/Rows";
+import { actionBtnStyle } from "@/widgets/right-panels/ui/styles";
+import { useInventoryQueries } from "./useInventoryQueries";
+
+export type InventorySurface = "items" | "inbox";
+
+const secondaryButton = {
+  border: `1px solid ${SAO.color.border.panel}`,
+  background: SAO.color.bg.inset,
+  color: SAO.color.text.secondary,
+  borderRadius: SAO.radius.panel,
+  padding: "7px 10px",
+  fontSize: "0.68rem",
+  letterSpacing: "0.08em",
+} as const;
+
+function ErrorState({ text, retry }: { text: string; retry: () => void }) {
+  return (
+    <div className="space-y-2 px-3">
+      <p role="alert" className="text-xs" style={{ color: SAO.color.action.red }}>{text}</p>
+      <button type="button" style={secondaryButton} onClick={retry}>Retry</button>
+    </div>
+  );
+}
+
+function Attrs({ attrs }: { attrs: Record<string, unknown> }) {
+  return <GoldRow>Instance attrs: {Object.keys(attrs).length > 0 ? JSON.stringify(attrs) : "None"}</GoldRow>;
+}
+
+function ItemDetail({ item }: { item: InventoryEntry }) {
+  return (
+    <div className="space-y-1.5 px-3">
+      <InfoCard>{item.itemName}</InfoCard>
+      <GoldRow>Item instance ID: {item.itemInstanceId}</GoldRow>
+      <GoldRow>Slot index: {item.slotIndex}</GoldRow>
+      <GoldRow>Item ID: {item.itemId}</GoldRow>
+      <GoldRow>Category: {item.category}</GoldRow>
+      <GoldRow>Type: {item.type}</GoldRow>
+      <GoldRow>Rarity: {item.rarity}</GoldRow>
+      <GoldRow>Quantity: {item.quantity}</GoldRow>
+      <GoldRow>Stackable: {String(item.stackable)}</GoldRow>
+      <GoldRow>Max stack: {item.maxStack}</GoldRow>
+      <GoldRow>Bound: {String(item.bound)}</GoldRow>
+      <GoldRow>Durability: {item.durability ?? "Not recorded"}</GoldRow>
+      <Attrs attrs={item.instanceAttrs} />
+    </div>
+  );
+}
+
+function MailDetail({ mail, pending, onClaim, onDelete }: { mail: MailEntry; pending: boolean; onClaim: () => void; onDelete: () => void }) {
+  return (
+    <div className="space-y-1.5 px-3">
+      <InfoCard>{mail.itemName}</InfoCard>
+      <GoldRow>Mail ID: {mail.mailId}</GoldRow>
+      <GoldRow>Slot index: {mail.slotIndex}</GoldRow>
+      <GoldRow>Item ID: {mail.itemId}</GoldRow>
+      <GoldRow>Category: {mail.category}</GoldRow>
+      <GoldRow>Type: {mail.type}</GoldRow>
+      <GoldRow>Rarity: {mail.rarity}</GoldRow>
+      <GoldRow>Quantity: {mail.quantity}</GoldRow>
+      <GoldRow>Stackable: {String(mail.stackable)}</GoldRow>
+      <GoldRow>Max stack: {mail.maxStack}</GoldRow>
+      <GoldRow>Bound: {String(mail.bound)}</GoldRow>
+      <GoldRow>Durability: {mail.durability ?? "Not recorded"}</GoldRow>
+      <Attrs attrs={mail.instanceAttrs} />
+      <div className="flex gap-2 pt-2">
+        <button type="button" disabled={pending} style={{ ...actionBtnStyle, flex: 1 }} onClick={onClaim}>{pending ? "Working..." : "Claim"}</button>
+        <button type="button" disabled={pending} style={secondaryButton} onClick={onDelete}>Delete</button>
+      </div>
+    </div>
+  );
+}
+
+export default function InventoryShell({ surface }: { surface: InventorySurface }) {
+  const queries = useInventoryQueries();
+  const [selectedItemInstanceId, setSelectedItemInstanceId] = useState<number | null>(null);
+  const [selectedMailId, setSelectedMailId] = useState<number | null>(null);
+  const selectedItem = queries.inventory.data.entries.find(({ itemInstanceId }) => itemInstanceId === selectedItemInstanceId) ?? null;
+  const selectedMail = queries.mailbox.data.entries.find(({ mailId }) => mailId === selectedMailId) ?? null;
+  const items = surface === "items";
+  const query = items ? queries.inventory : queries.mailbox;
+
+  return (
+    <div className="relative flex min-w-0 w-fit flex-row flex-nowrap items-center gap-3" data-testid="inventory-shell">
+      <PanelFrame title={items ? "Items" : "Inbox"} depth={1}>
+        <div className="space-y-3">
+          {query.loading && query.data.entries.length === 0 ? <InfoCard>Loading {items ? "Items" : "Inbox"}...</InfoCard> : null}
+          {query.error ? <ErrorState text={query.error} retry={() => void query.reload()} /> : null}
+          {!query.loading && !query.error && query.data.entries.length === 0 ? <InfoCard>No {items ? "Items" : "mail"}.</InfoCard> : null}
+          {queries.mutationError ? <p role="alert" className="px-3 text-xs" style={{ color: SAO.color.action.red }}>{queries.mutationError}</p> : null}
+          <div className="space-y-2">
+            {items
+              ? queries.inventory.data.entries.map((item, index) => (
+                <PanelCard
+                  key={item.itemInstanceId}
+                  label={item.itemName}
+                  slotLabel={`x${item.quantity}`}
+                  subtitle={`${item.rarity} · ${item.category} · ${item.type} · Slot ${item.slotIndex}`}
+                  selected={selectedItemInstanceId === item.itemInstanceId}
+                  index={index}
+                  onClick={() => setSelectedItemInstanceId(item.itemInstanceId)}
+                />
+              ))
+              : queries.mailbox.data.entries.map((mail, index) => (
+                <PanelCard
+                  key={mail.mailId}
+                  label={mail.itemName}
+                  slotLabel={`x${mail.quantity}`}
+                  subtitle={`${mail.rarity} · ${mail.category} · ${mail.type} · Slot ${mail.slotIndex}`}
+                  selected={selectedMailId === mail.mailId}
+                  index={index}
+                  onClick={() => setSelectedMailId(mail.mailId)}
+                />
+              ))}
+          </div>
+        </div>
+      </PanelFrame>
+
+      <PanelFrame title={items ? "Item Detail" : "Mail Detail"} depth={0}>
+        {items && !selectedItem ? <InfoCard>Select an Item.</InfoCard> : null}
+        {!items && !selectedMail ? <InfoCard>Select mail.</InfoCard> : null}
+        {items && selectedItem ? <ItemDetail item={selectedItem} /> : null}
+        {!items && selectedMail ? (
+          <MailDetail
+            mail={selectedMail}
+            pending={queries.pendingKey !== null}
+            onClaim={() => {
+              if (window.confirm(`Claim ${selectedMail.itemName} x${selectedMail.quantity}?`)) void queries.claimMail(selectedMail);
+            }}
+            onDelete={() => {
+              if (window.confirm(`Delete ${selectedMail.itemName} mail?`)) void queries.deleteMail(selectedMail);
+            }}
+          />
+        ) : null}
+      </PanelFrame>
+    </div>
+  );
+}

--- a/features/inventory/model.ts
+++ b/features/inventory/model.ts
@@ -1,5 +1,5 @@
 import type { InventoryGearPartId, PanelDataItem } from "@/entities/nav";
-import type { InventoryEntry, MailEntry } from "@/shared/api/types";
+import type { InventoryEntry } from "@/shared/api/types";
 import type { EquipmentSlotInfo } from "@/shared/api/types";
 import {
   MOCK_GEAR_ACCESSORIES,
@@ -7,7 +7,6 @@ import {
   MOCK_GEAR_BOOTS,
   MOCK_GEAR_WEAPONS,
   MOCK_INVENTORY_ITEMS,
-  MOCK_MAIL_ITEMS,
 } from "@/lib/api/mock/inventory.mock";
 
 const SLOT_CODES_BY_CATEGORY: Record<string, string[]> = {
@@ -24,32 +23,6 @@ export function getEquipSlotId(itemInstanceId: number, equippedGear: EquipmentSl
   const emptySlot = equippedGear.find((s) => slotCodes.includes(s.slotCode) && s.itemInstanceId === null);
   if (emptySlot) return emptySlot.slotId;
   return equippedGear.find((s) => s.slotCode === slotCodes[0])?.slotId ?? 1;
-}
-
-function inventoryItemToPanel(item: InventoryEntry): PanelDataItem {
-  const attrs = item.instanceAttrs as Record<string, number> ?? {};
-  const attrStr = Object.entries(attrs)
-    .filter(([, v]) => typeof v === "number")
-    .map(([k, v]) => `${k.toUpperCase()} +${v}`)
-    .join(" / ");
-
-  return {
-    id: String(item.itemInstanceId),
-    label: item.itemName,
-    slotLabel: `x${item.quantity}`,
-    subtitle: `${item.rarity} | ${item.category} | ${item.type}`,
-    detailTitle: item.itemName,
-    detailDescription: `${item.type} — ${item.category}`,
-    detailRows: [
-      `희귀도: ${item.rarity}`,
-      `타입: ${item.type}`,
-      `수량: ${item.quantity}`,
-      ...(item.durability != null ? [`내구도: ${item.durability}`] : []),
-      `귀속: ${item.bound ? "귀속됨" : "귀속 안됨"}`,
-      ...(attrStr ? [`스탯: ${attrStr}`] : []),
-    ],
-    actions: item.bound ? [] : [{ type: "sell" as const, label: "판매" }],
-  };
 }
 
 function gearItemToPanel(item: InventoryEntry, equippedSlots: EquipmentSlotInfo[]): PanelDataItem {
@@ -80,33 +53,6 @@ function gearItemToPanel(item: InventoryEntry, equippedSlots: EquipmentSlotInfo[
   };
 }
 
-function mailToPanel(mail: MailEntry): PanelDataItem {
-  const from = String(mail.instanceAttrs?.from ?? "Unknown");
-  const message = String(mail.instanceAttrs?.message ?? "");
-
-  return {
-    id: String(mail.mailId),
-    label: mail.itemName,
-    slotLabel: `x${mail.quantity}`,
-    subtitle: `${from} | ${mail.rarity}`,
-    detailTitle: mail.itemName,
-    detailDescription: message,
-    detailRows: [
-      `발신자: ${from}`,
-      `아이템: ${mail.itemName}`,
-      `수량: ${mail.quantity}`,
-      `희귀도: ${mail.rarity}`,
-      ...(message ? [`메모: ${message}`] : []),
-    ],
-    actions: [
-      { type: "claim", label: "수령" },
-      { type: "delete", label: "삭제" },
-    ],
-  };
-}
-
-export const INVENTORY_ITEMS_LIST: PanelDataItem[] = MOCK_INVENTORY_ITEMS.map(inventoryItemToPanel);
-
 export function makeGearLists(equippedSlots: EquipmentSlotInfo[]): Record<InventoryGearPartId, PanelDataItem[]> {
   return {
     weapon: MOCK_GEAR_WEAPONS.map((item) => gearItemToPanel(item, equippedSlots)),
@@ -117,5 +63,3 @@ export function makeGearLists(equippedSlots: EquipmentSlotInfo[]): Record<Invent
 }
 
 export const INVENTORY_GEAR_LISTS: Record<InventoryGearPartId, PanelDataItem[]> = makeGearLists([]);
-
-export const INVENTORY_INBOX_LIST: PanelDataItem[] = MOCK_MAIL_ITEMS.map(mailToPanel);

--- a/features/inventory/useInventoryQueries.test.tsx
+++ b/features/inventory/useInventoryQueries.test.tsx
@@ -1,0 +1,170 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { InventoryEntriesResponse, InventoryEntry, MailboxEntriesResponse, MailEntry } from "@/shared/api/types";
+import { useInventoryQueries } from "./useInventoryQueries";
+
+const api = vi.hoisted(() => ({
+  claimMailApi: vi.fn(),
+  deleteMailApi: vi.fn(),
+  getInventoryApi: vi.fn(),
+  getMailboxApi: vi.fn(),
+}));
+
+vi.mock("@/lib/api/endpoints/inventory.api", () => api);
+
+const item: InventoryEntry = {
+  itemInstanceId: 501,
+  slotIndex: 2,
+  itemId: 101,
+  itemName: "Server Sword",
+  category: "WEAPON",
+  type: "SWORD",
+  rarity: "RARE",
+  stackable: false,
+  maxStack: 1,
+  quantity: 1,
+  bound: true,
+  durability: 88,
+  instanceAttrs: { atk: 12 },
+};
+
+const mail: MailEntry = {
+  mailId: 701,
+  slotIndex: 4,
+  itemId: 301,
+  itemName: "Server Potion",
+  category: "CONSUMABLE",
+  type: "POTION",
+  rarity: "COMMON",
+  stackable: true,
+  maxStack: 99,
+  quantity: 3,
+  bound: false,
+  durability: null,
+  instanceAttrs: {},
+};
+
+const inventory: InventoryEntriesResponse = { entries: [item] };
+const mailbox: MailboxEntriesResponse = { entries: [mail] };
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+}
+
+describe("Inventory server query state를 관리할 때", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api.getInventoryApi.mockResolvedValue(inventory);
+    api.getMailboxApi.mockResolvedValue(mailbox);
+    api.claimMailApi.mockResolvedValue(undefined);
+    api.deleteMailApi.mockResolvedValue(undefined);
+  });
+
+  describe("Claim 결과가 성공인지 확정되지 않으면", () => {
+    it("중복 mutation을 막고 mailbox와 inventory를 모두 authoritative reload한다", async () => {
+      const request = deferred<void>();
+      api.claimMailApi.mockReturnValue(request.promise);
+      const { result } = renderHook(() => useInventoryQueries());
+      await waitFor(() => expect(result.current.mailbox.data).toEqual(mailbox));
+
+      act(() => {
+        void result.current.claimMail(mail);
+        void result.current.claimMail(mail);
+      });
+      expect(api.claimMailApi).toHaveBeenCalledTimes(1);
+      expect(result.current.mailbox.data.entries).toEqual([mail]);
+
+      api.getInventoryApi.mockResolvedValue({ entries: [{ ...item, quantity: 2 }] });
+      api.getMailboxApi.mockResolvedValue({ entries: [] });
+      await act(async () => {
+        request.reject(new Error("connection lost"));
+        await request.promise.catch(() => undefined);
+      });
+
+      await waitFor(() => expect(result.current.pendingKey).toBeNull());
+      expect(api.getInventoryApi).toHaveBeenCalledTimes(2);
+      expect(api.getMailboxApi).toHaveBeenCalledTimes(2);
+      expect(result.current.mailbox.data.entries).toEqual([]);
+      expect(result.current.inventory.data.entries[0].quantity).toBe(2);
+      expect(result.current.mutationError).toContain("Server state was reloaded");
+    });
+  });
+
+  describe("Mail Delete를 수행하면", () => {
+    it("요청 중에는 server entry를 유지하고 ambiguous failure 후에도 mailbox만 reload한다", async () => {
+      const request = deferred<void>();
+      api.deleteMailApi.mockReturnValue(request.promise);
+      const { result } = renderHook(() => useInventoryQueries());
+      await waitFor(() => expect(result.current.mailbox.data).toEqual(mailbox));
+
+      act(() => { void result.current.deleteMail(mail); });
+      expect(result.current.mailbox.data.entries).toEqual([mail]);
+      api.getMailboxApi.mockResolvedValue({ entries: [] });
+      await act(async () => {
+        request.reject(new Error("delete response lost"));
+        await request.promise.catch(() => undefined);
+      });
+
+      await waitFor(() => expect(result.current.mailbox.data.entries).toEqual([]));
+      expect(api.deleteMailApi).toHaveBeenCalledWith({ slotIndex: 4 });
+      expect(api.getMailboxApi).toHaveBeenCalledTimes(2);
+      expect(api.getInventoryApi).toHaveBeenCalledTimes(1);
+      expect(result.current.mutationError).toContain("Server state was reloaded");
+    });
+  });
+
+  describe("겹친 list request가 역순으로 끝나면", () => {
+    it("stale Inventory success가 최신 Items를 덮어쓰지 않는다", async () => {
+      const stale = deferred<InventoryEntriesResponse>();
+      const latest = deferred<InventoryEntriesResponse>();
+      const latestInventory = { entries: [{ ...item, itemInstanceId: 999, itemName: "Latest Item" }] };
+      api.getInventoryApi.mockReturnValueOnce(stale.promise).mockReturnValueOnce(latest.promise);
+      const { result } = renderHook(() => useInventoryQueries());
+      await waitFor(() => expect(api.getInventoryApi).toHaveBeenCalledTimes(1));
+
+      act(() => { void result.current.inventory.reload(); });
+      await act(async () => {
+        latest.resolve(latestInventory);
+        await latest.promise;
+      });
+      expect(result.current.inventory.data).toEqual(latestInventory);
+
+      await act(async () => {
+        stale.resolve(inventory);
+        await stale.promise;
+      });
+      expect(result.current.inventory.data).toEqual(latestInventory);
+      expect(result.current.inventory.loading).toBe(false);
+    });
+
+    it("stale Mailbox error가 최신 Inbox의 data/loading/error를 바꾸지 않는다", async () => {
+      const stale = deferred<MailboxEntriesResponse>();
+      const latest = deferred<MailboxEntriesResponse>();
+      const latestMailbox = { entries: [{ ...mail, mailId: 999, itemName: "Latest Mail" }] };
+      api.getMailboxApi.mockReturnValueOnce(stale.promise).mockReturnValueOnce(latest.promise);
+      const { result } = renderHook(() => useInventoryQueries());
+      await waitFor(() => expect(api.getMailboxApi).toHaveBeenCalledTimes(1));
+
+      act(() => { void result.current.mailbox.reload(); });
+      await act(async () => {
+        latest.resolve(latestMailbox);
+        await latest.promise;
+      });
+      await act(async () => {
+        stale.reject(new Error("stale mailbox failure"));
+        await stale.promise.catch(() => undefined);
+      });
+
+      expect(result.current.mailbox.data).toEqual(latestMailbox);
+      expect(result.current.mailbox.loading).toBe(false);
+      expect(result.current.mailbox.error).toBeNull();
+    });
+  });
+});

--- a/features/inventory/useInventoryQueries.ts
+++ b/features/inventory/useInventoryQueries.ts
@@ -1,0 +1,87 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import type { InventoryEntriesResponse, MailboxEntriesResponse, MailEntry } from "@/shared/api/types";
+import { claimMailApi, deleteMailApi, getInventoryApi, getMailboxApi } from "@/lib/api/endpoints/inventory.api";
+
+type QueryState<T> = {
+  data: T;
+  loading: boolean;
+  error: string | null;
+  reload: () => Promise<T | undefined>;
+};
+
+function message(caught: unknown, fallback: string): string {
+  return caught instanceof Error ? caught.message : fallback;
+}
+
+function useLatestQuery<T>(initial: T, load: () => Promise<T>, fallback: string): QueryState<T> {
+  const [data, setData] = useState(initial);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const requestId = useRef(0);
+
+  const reload = useCallback(async () => {
+    const currentRequestId = ++requestId.current;
+    setLoading(true);
+    setError(null);
+    try {
+      const next = await load();
+      if (currentRequestId === requestId.current) setData(next);
+      return next;
+    } catch (caught) {
+      if (currentRequestId === requestId.current) setError(message(caught, fallback));
+      return undefined;
+    } finally {
+      if (currentRequestId === requestId.current) setLoading(false);
+    }
+  }, [fallback, load]);
+
+  useEffect(() => { void reload(); }, [reload]);
+  return { data, loading, error, reload };
+}
+
+const loadInventory = () => getInventoryApi();
+const loadMailbox = () => getMailboxApi();
+
+export function useInventoryQueries() {
+  const inventory = useLatestQuery<InventoryEntriesResponse>({ entries: [] }, loadInventory, "Unable to load Items.");
+  const mailbox = useLatestQuery<MailboxEntriesResponse>({ entries: [] }, loadMailbox, "Unable to load Inbox.");
+  const mutationLocked = useRef(false);
+  const [pendingKey, setPendingKey] = useState<string | null>(null);
+  const [mutationError, setMutationError] = useState<string | null>(null);
+
+  const runMutation = async (key: string, request: () => Promise<void>, recover: () => Promise<unknown>) => {
+    if (mutationLocked.current) return;
+    mutationLocked.current = true;
+    setPendingKey(key);
+    setMutationError(null);
+    let requestError: unknown = null;
+    try {
+      await request();
+    } catch (caught) {
+      requestError = caught;
+    }
+    await recover();
+    if (requestError) {
+      setMutationError(`Request outcome was not confirmed. Server state was reloaded. ${message(requestError, "")}`.trim());
+    }
+    mutationLocked.current = false;
+    setPendingKey(null);
+  };
+
+  const claimMail = (mail: MailEntry) => runMutation(
+    `claim-${mail.mailId}`,
+    () => claimMailApi({ slotIndex: mail.slotIndex, quantity: mail.quantity }),
+    () => Promise.all([mailbox.reload(), inventory.reload()]),
+  );
+
+  const deleteMail = (mail: MailEntry) => runMutation(
+    `delete-${mail.mailId}`,
+    () => deleteMailApi({ slotIndex: mail.slotIndex }),
+    () => mailbox.reload(),
+  );
+
+  return { inventory, mailbox, pendingKey, mutationError, claimMail, deleteMail };
+}

--- a/lib/api/endpoints/inventory.api.test.ts
+++ b/lib/api/endpoints/inventory.api.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  claimMailApi,
+  deleteMailApi,
+  getInventoryApi,
+  getMailboxApi,
+} from "./inventory.api";
+import { inventoryMock } from "../mock/inventory.mock";
+
+const client = vi.hoisted(() => ({
+  apiDelete: vi.fn(),
+  apiGet: vi.fn(),
+  apiPost: vi.fn(),
+}));
+
+vi.mock("@/shared/api/client", () => ({ USE_MOCK: false, ...client }));
+
+describe("Inventory와 Mailbox를 실제 backend에 연결할 때", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    inventoryMock.reset();
+  });
+
+  describe("현재 player의 Items와 Inbox를 조회하면", () => {
+    it("identity query나 /inventory/me 없이 canonical list endpoint를 사용한다", async () => {
+      client.apiGet.mockResolvedValue({ entries: [] });
+
+      await getInventoryApi();
+      await getMailboxApi();
+
+      expect(client.apiGet).toHaveBeenNthCalledWith(1, "/api/v1/inventory");
+      expect(client.apiGet).toHaveBeenNthCalledWith(2, "/api/v1/mailbox");
+      expect(client.apiGet.mock.calls.flat().join(" ")).not.toContain("/inventory/me");
+    });
+  });
+
+  describe("Inbox entry를 변경하면", () => {
+    it("claim은 authoritative slotIndex와 quantity를 JSON body로 보낸다", async () => {
+      client.apiPost.mockResolvedValue(undefined);
+
+      await claimMailApi({ slotIndex: 4, quantity: 3 });
+
+      expect(client.apiPost).toHaveBeenCalledWith("/api/v1/mailbox/claim", { slotIndex: 4, quantity: 3 });
+    });
+
+    it("delete는 query string 대신 verified DELETE body를 보낸다", async () => {
+      client.apiDelete.mockResolvedValue(undefined);
+
+      await deleteMailApi({ slotIndex: 7 });
+
+      expect(client.apiDelete).toHaveBeenCalledWith("/api/v1/mailbox", { slotIndex: 7 });
+      expect(client.apiDelete.mock.calls[0][0]).not.toContain("?");
+    });
+  });
+
+  describe("mock mode contract를 사용하면", () => {
+    it("Inventory와 Mailbox list를 meta 없이 real entries shape로 제공한다", () => {
+      const inventory = inventoryMock.inventory();
+      const mailbox = inventoryMock.mailbox();
+
+      expect(Object.keys(inventory)).toEqual(["entries"]);
+      expect(Object.keys(mailbox)).toEqual(["entries"]);
+      expect(inventory.entries[0]).toEqual(expect.objectContaining({
+        itemInstanceId: expect.any(Number),
+        slotIndex: expect.any(Number),
+        durability: expect.any(Number),
+        instanceAttrs: expect.any(Object),
+      }));
+      expect(mailbox.entries[0]).toEqual(expect.objectContaining({
+        mailId: expect.any(Number),
+        slotIndex: expect.any(Number),
+        durability: null,
+        instanceAttrs: expect.any(Object),
+      }));
+    });
+  });
+});

--- a/lib/api/endpoints/inventory.api.ts
+++ b/lib/api/endpoints/inventory.api.ts
@@ -1,66 +1,30 @@
-import { USE_MOCK, apiGet, apiPost, apiDelete } from "../client";
-import {
-  MOCK_GEAR_ACCESSORIES,
-  MOCK_GEAR_ARMOR,
-  MOCK_GEAR_BOOTS,
-  MOCK_GEAR_WEAPONS,
-  MOCK_INVENTORY_ITEMS,
-  MOCK_INVENTORY_META,
-  MOCK_MAIL_ITEMS,
-  MOCK_MAIL_META,
-} from "../mock/inventory.mock";
-import type { InventoryEntry, InventoryMeta, MailEntry } from "../types";
+import { USE_MOCK, apiDelete, apiGet, apiPost } from "@/shared/api/client";
+import type {
+  InventoryEntriesResponse,
+  MailboxClaimRequest,
+  MailboxDeleteRequest,
+  MailboxEntriesResponse,
+} from "@/shared/api/types";
+import { inventoryMock } from "../mock/inventory.mock";
 
-export async function getInventoryApi(): Promise<{
-  meta: InventoryMeta;
-  entries: InventoryEntry[];
-}> {
-  if (USE_MOCK) return { meta: MOCK_INVENTORY_META, entries: MOCK_INVENTORY_ITEMS };
-  return apiGet("/api/v1/inventory/me/view");
+export function getInventoryApi(): Promise<InventoryEntriesResponse> {
+  return USE_MOCK
+    ? Promise.resolve(inventoryMock.inventory())
+    : apiGet<InventoryEntriesResponse>("/api/v1/inventory");
 }
 
-export async function getGearBySlotApi(
-  slot: "weapon" | "armor" | "accessory" | "boots",
-): Promise<InventoryEntry[]> {
-  if (USE_MOCK) {
-    const map = {
-      weapon: MOCK_GEAR_WEAPONS,
-      armor: MOCK_GEAR_ARMOR,
-      accessory: MOCK_GEAR_ACCESSORIES,
-      boots: MOCK_GEAR_BOOTS,
-    };
-    return map[slot];
-  }
-  const res = await apiGet<{ entries: InventoryEntry[] }>(
-    `/api/v1/inventory/me/entries?category=${slot}`,
-  );
-  return res.entries;
+export function getMailboxApi(): Promise<MailboxEntriesResponse> {
+  return USE_MOCK
+    ? Promise.resolve(inventoryMock.mailbox())
+    : apiGet<MailboxEntriesResponse>("/api/v1/mailbox");
 }
 
-export async function getMailboxApi(): Promise<{
-  meta: InventoryMeta;
-  entries: MailEntry[];
-}> {
-  if (USE_MOCK) return { meta: MOCK_MAIL_META, entries: MOCK_MAIL_ITEMS };
-  return apiGet("/api/v1/mailbox");
+export async function claimMailApi(body: MailboxClaimRequest): Promise<void> {
+  if (USE_MOCK) return inventoryMock.claim(body);
+  await apiPost<void>("/api/v1/mailbox/claim", body);
 }
 
-export async function claimMailApi(slotIndex: number, quantity: number): Promise<void> {
-  if (USE_MOCK) return;
-  await apiPost("/api/v1/mailbox/claim", { slotIndex, quantity });
-}
-
-export async function claimAllMailApi(claims: Array<{ slotIndex: number; quantity: number }>): Promise<void> {
-  if (USE_MOCK) return;
-  await apiPost("/api/v1/mailbox/claim/all", { claims });
-}
-
-export async function deleteMailApi(slotIndex: number): Promise<void> {
-  if (USE_MOCK) return;
-  await apiDelete(`/api/v1/mailbox?slotIndex=${slotIndex}`);
-}
-
-export async function removeInventoryItemApi(slotIndex: number, quantity: number): Promise<void> {
-  if (USE_MOCK) return;
-  await apiDelete(`/api/v1/inventory/remove?slotIndex=${slotIndex}&quantity=${quantity}`);
+export async function deleteMailApi(body: MailboxDeleteRequest): Promise<void> {
+  if (USE_MOCK) return inventoryMock.deleteMail(body);
+  await apiDelete<void>("/api/v1/mailbox", body);
 }

--- a/lib/api/mock/inventory.mock.ts
+++ b/lib/api/mock/inventory.mock.ts
@@ -1,10 +1,4 @@
-import type { InventoryEntry, InventoryMeta, MailEntry } from "../types";
-
-export const MOCK_INVENTORY_META: InventoryMeta = {
-  capacitySlots: 120,
-  usedSlots: 68,
-  freeSlots: 52,
-};
+import type { InventoryEntry, MailboxClaimRequest, MailboxDeleteRequest, MailEntry } from "../types";
 
 export const MOCK_INVENTORY_ITEMS: InventoryEntry[] = [
   { itemInstanceId: 1, slotIndex: 0, itemId: 1001, itemName: "Elucidator", category: "Weapon", type: "Sword", rarity: "Legendary", stackable: false, maxStack: 1, quantity: 1, bound: true, durability: 98, instanceAttrs: { atk: 850, crit: 18 } },
@@ -45,12 +39,6 @@ export const MOCK_GEAR_BOOTS: InventoryEntry[] = MOCK_INVENTORY_ITEMS.filter(
   (item) => item.category === "Boots",
 );
 
-export const MOCK_MAIL_META: InventoryMeta = {
-  capacitySlots: 30,
-  usedSlots: 8,
-  freeSlots: 22,
-};
-
 export const MOCK_MAIL_ITEMS: MailEntry[] = [
   { mailId: 1, slotIndex: 0, itemId: 8001, itemName: "HP Potion (L)", category: "Consumable", type: "Potion", rarity: "Uncommon", stackable: true, maxStack: 99, quantity: 10, bound: false, durability: null, instanceAttrs: { from: "System", message: "Daily login reward!" } },
   { mailId: 2, slotIndex: 1, itemId: 5002, itemName: "Mithril Ingot", category: "Material", type: "Ingot", rarity: "Rare", stackable: true, maxStack: 100, quantity: 3, bound: false, durability: null, instanceAttrs: { from: "AsunaMail", message: "I saved these for you :)" } },
@@ -61,3 +49,48 @@ export const MOCK_MAIL_ITEMS: MailEntry[] = [
   { mailId: 7, slotIndex: 6, itemId: 6002, itemName: "Crafting Blueprint", category: "Misc", type: "Blueprint", rarity: "Rare", stackable: false, maxStack: 1, quantity: 1, bound: false, durability: null, instanceAttrs: { from: "Lisbeth", message: "Special sword blueprint I found!" } },
   { mailId: 8, slotIndex: 7, itemId: 3004, itemName: "Revive Crystal", category: "Consumable", type: "Crystal", rarity: "Epic", stackable: true, maxStack: 3, quantity: 1, bound: false, durability: null, instanceAttrs: { from: "Asuna", message: "Keep this safe, okay?" } },
 ];
+
+const copy = <T,>(value: T): T => structuredClone(value);
+let inventoryEntries = copy(MOCK_INVENTORY_ITEMS);
+let mailboxEntries = copy(MOCK_MAIL_ITEMS);
+
+export const inventoryMock = {
+  inventory: () => ({ entries: copy(inventoryEntries) }),
+  mailbox: () => ({ entries: copy(mailboxEntries) }),
+  claim: ({ slotIndex, quantity }: MailboxClaimRequest) => {
+    const mail = mailboxEntries.find((entry) => entry.slotIndex === slotIndex);
+    if (!mail || quantity < 1 || quantity > mail.quantity) throw new Error("Mailbox entry not found or quantity is invalid.");
+    const stack = mail.stackable
+      ? inventoryEntries.find((entry) => entry.itemId === mail.itemId && entry.quantity + quantity <= entry.maxStack)
+      : undefined;
+    if (stack) {
+      inventoryEntries = inventoryEntries.map((entry) => entry.itemInstanceId === stack.itemInstanceId
+        ? { ...entry, quantity: entry.quantity + quantity }
+        : entry);
+    } else {
+      const usedSlots = new Set(inventoryEntries.map(({ slotIndex: current }) => current));
+      let inventorySlot = 0;
+      while (usedSlots.has(inventorySlot)) inventorySlot += 1;
+      const { mailId: _mailId, slotIndex: _slotIndex, ...item } = mail;
+      void _mailId;
+      void _slotIndex;
+      inventoryEntries = [...inventoryEntries, {
+        ...item,
+        itemInstanceId: Math.max(0, ...inventoryEntries.map(({ itemInstanceId }) => itemInstanceId)) + 1,
+        slotIndex: inventorySlot,
+        quantity,
+      }];
+    }
+    mailboxEntries = quantity === mail.quantity
+      ? mailboxEntries.filter((entry) => entry.mailId !== mail.mailId)
+      : mailboxEntries.map((entry) => entry.mailId === mail.mailId ? { ...entry, quantity: entry.quantity - quantity } : entry);
+  },
+  deleteMail: ({ slotIndex }: MailboxDeleteRequest) => {
+    if (!mailboxEntries.some((entry) => entry.slotIndex === slotIndex)) throw new Error("Mailbox entry not found.");
+    mailboxEntries = mailboxEntries.filter((entry) => entry.slotIndex !== slotIndex);
+  },
+  reset: () => {
+    inventoryEntries = copy(MOCK_INVENTORY_ITEMS);
+    mailboxEntries = copy(MOCK_MAIL_ITEMS);
+  },
+};

--- a/shared/api/types/inventory.ts
+++ b/shared/api/types/inventory.ts
@@ -1,9 +1,3 @@
-export interface InventoryMeta {
-  capacitySlots: number;
-  usedSlots: number;
-  freeSlots: number;
-}
-
 export interface InventoryEntry {
   itemInstanceId: number;
   slotIndex: number;
@@ -20,8 +14,7 @@ export interface InventoryEntry {
   instanceAttrs: Record<string, unknown>;
 }
 
-export interface InventoryView {
-  meta: InventoryMeta;
+export interface InventoryEntriesResponse {
   entries: InventoryEntry[];
 }
 
@@ -39,4 +32,18 @@ export interface MailEntry {
   bound: boolean;
   durability: number | null;
   instanceAttrs: Record<string, unknown>;
+}
+
+export interface MailboxEntriesResponse {
+  entries: MailEntry[];
+}
+
+export interface MailboxClaimRequest {
+  slotIndex: number;
+  quantity: number;
+}
+
+export interface MailboxDeleteRequest {
+  slotIndex: number;
+  idempotencyKey?: string;
 }


### PR DESCRIPTION
## Purpose
Replace stale mock/runtime Inventory Items and Inbox behavior with the current backend player Inventory/Mailbox contracts.

## Delivered
- real Inventory Items list
- real Inbox list
- server-backed item/mail identity and detail presentation
- mailbox claim flow
- mailbox delete flow
- authoritative reload after mutations
- loading/empty/error/retry states
- latest-request-wins query safety
- real-contract mock mode
- removal of active `/inventory/me` assumptions

## Backend contracts
Connected:
- GET `/api/v1/inventory`
- GET `/api/v1/mailbox`
- POST `/api/v1/mailbox/claim`
- DELETE `/api/v1/mailbox`

Additional current Inventory operations are used only where the existing UI has a valid matching action.

## Boundaries preserved
- Current Player identity remains implicit
- Gear/equipment behavior is preserved
- no Inventory backend redesign
- no optimistic final mailbox/inventory state
- no global state library

## Tests
Coverage includes API contract mapping, Items/Inbox query states, mutation recovery, stale-request protection, mock parity, and Gear/Role/Journey/Journal/auth regressions.

## Validation
- lint
- targeted tests
- full tests
- build

Closes #12

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated inventory Items and Inbox views with loading, error, empty, and retry states.
  * Added item and mail selection details, including metadata and durability information.
  * Added mail claiming and deletion with confirmation prompts and duplicate-action protection.
  * Inventory and mailbox data now refresh automatically after successful or uncertain actions.

* **Bug Fixes**
  * Improved handling of stale requests and preserved current data during updates.
  * Added clearer error handling for inventory and mailbox operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->