### PR TITLE
[Inventory] Connect real Gear and equipment composition

### DIFF
--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -16,7 +16,6 @@ vi.mock("@/features/auth/AuthContext", () => ({ useAuth: () => auth.state }));
 vi.mock("@/features/role/useRoles", () => ({ useRoles: () => ({ roles, isLoading: false, error: null, refresh: vi.fn() }) }));
 vi.mock("@/context/ToastContext", () => ({ useToast: () => ({ showToast: vi.fn() }) }));
 vi.mock("@/shared/hooks/usePanScroll", () => ({ usePanScroll: vi.fn() }));
-vi.mock("@/lib/api/endpoints/equipment.api", () => ({ getEquippedGearApi: vi.fn().mockResolvedValue([]), equipGearApi: vi.fn(), unequipGearApi: vi.fn() }));
 vi.mock("@/widgets/left-context/LeftContext", () => ({ default: () => null }));
 vi.mock("@/widgets/orb-nav/OrbNav", () => ({
   default: ({ items, onSelect }: { items: Array<{ id: MainNavId; label: string }>; onSelect: (id: MainNavId) => void }) => (
@@ -34,6 +33,7 @@ vi.mock("@/widgets/right-panels/RightPanels", () => ({
 }));
 vi.mock("@/features/lifelog/JournalShell", () => ({ default: ({ roles: roleOptions }: { roles: RoleDetail[] }) => <div data-testid="journal-shell">Journal · {roleOptions.map(({ name }) => name).join(", ")}</div> }));
 vi.mock("@/features/inventory/InventoryShell", () => ({ default: ({ surface }: { surface: string }) => <div data-testid="inventory-shell">Inventory · {surface}</div> }));
+vi.mock("@/features/inventory/GearShell", () => ({ default: () => <div data-testid="gear-shell">Gear Shell</div> }));
 vi.mock("@/features/role/RoleShell", () => ({ default: () => <div data-testid="role-shell">Role Shell</div> }));
 vi.mock("@/features/quests/JourneyShell", () => ({ default: () => <div data-testid="journey-shell">Journey Shell</div> }));
 vi.mock("@/shared/ui/ParticleBackground", () => ({ default: () => null }));
@@ -88,7 +88,7 @@ describe("Home shell에서 feature surface를 routing할 때", () => {
 
       fireEvent.click(screen.getByRole("button", { name: "Gear" }));
       expect(screen.queryByTestId("inventory-shell")).not.toBeInTheDocument();
-      expect(screen.getByRole("button", { name: "Weapon" })).toBeInTheDocument();
+      expect(screen.getByTestId("gear-shell")).toBeInTheDocument();
     });
   });
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,12 +15,12 @@ import JourneyShell from "@/features/quests/JourneyShell";
 import RoleShell from "@/features/role/RoleShell";
 import JournalShell from "@/features/lifelog/JournalShell";
 import InventoryShell from "@/features/inventory/InventoryShell";
+import GearShell from "@/features/inventory/GearShell";
 import { useRoles } from "@/features/role/useRoles";
 import { usePanScroll } from "@/shared/hooks/usePanScroll";
 import { MOCK_CHARACTER_SHEET } from "@/features/player/mock";
 import {
   DEFAULT_SUB_SELECTIONS,
-  INVENTORY_GEAR_PARTS,
   MAIN_NAV_ITEMS,
   MAIN_PANEL_TITLES,
   MARKET_SHOP_SECTIONS,
@@ -55,7 +55,6 @@ import {
   SOCIAL_LISTS,
 } from "@/features/social/model";
 import { LISTING_FORM_FIELDS } from "@/features/market/model";
-import { makeGearLists } from "@/features/inventory/model";
 import {
   MARKET_SHOP_CATALOG_LIST,
   MARKET_SHOP_MY_LISTINGS,
@@ -70,13 +69,9 @@ import { bringToFrontStable } from "@/shared/lib/reorder";
 import { UI_CONSTS } from "@/shared/lib/uiConsts";
 import { useToast } from "@/context/ToastContext";
 import { NotificationBell } from "@/shared/ui/NotificationBell";
-import { getEquippedGearApi, equipGearApi, unequipGearApi } from "@/lib/api/endpoints/equipment.api";
 import { requestJoinPartyApi, requestJoinGuildApi, unfollowApi } from "@/lib/api/endpoints/social.api";
 import { reserveShopItemApi, confirmShopPurchaseApi, cancelListingApi, createListingApi } from "@/lib/api/endpoints/market.api";
 import { MOCK_SHOP_ITEMS } from "@/lib/api/mock/market.mock";
-import { MOCK_INVENTORY_ITEMS } from "@/lib/api/mock/inventory.mock";
-import { getEquipSlotId } from "@/features/inventory/model";
-import type { EquipmentSlotInfo } from "@/shared/api/types";
 
 type SurfaceFocusState = {
   counter: number;
@@ -86,7 +81,6 @@ type SurfaceFocusState = {
 type DetailSelectionKey =
   | "player"
   | "skills"
-  | "inventoryGear"
   | "social"
   | "lifelog"
   | "marketWallet"
@@ -105,7 +99,6 @@ function createDefaultDetailSelections(): Record<DetailSelectionKey, string | nu
   return {
     player: null,
     skills: null,
-    inventoryGear: null,
     social: null,
     lifelog: null,
     marketWallet: null,
@@ -131,14 +124,12 @@ function selectedSubForMain(selectedMain: MainNavId, selectedSubByMain: Record<M
 function buildPanels(
   selectedMain: MainNavId,
   selectedSubByMain: Record<MainNavId, string | null>,
-  selectedInventoryGearPartId: string | null,
   selectedMarketShopSectionId: string | null,
   selectedDetailByKey: Record<DetailSelectionKey, string | null>,
   selectedPlayerCategoryBySub: Record<PlayerSubId, string | null>,
   selectedLifelogCategoryBySub: Record<LifelogSubId, string | null>,
   editingItemId: string | null,
   hasActiveForm: boolean,
-  equippedGear: EquipmentSlotInfo[],
 ): { panelStack: PanelStackItem[]; socialContext: SocialContextData | null } {
   const mainItems = SUBMENUS_BY_MAIN[selectedMain];
   const selectedMainSub = selectedSubForMain(selectedMain, selectedSubByMain);
@@ -231,51 +222,6 @@ function buildPanels(
   }
 
   if (selectedMain === "inventory") {
-    if (selectedMainSub === "items" || selectedMainSub === "inbox") return { panelStack, socialContext: null };
-
-    if (selectedMainSub === "gear") {
-      const selectedPart =
-        INVENTORY_GEAR_PARTS.find((item) => item.id === selectedInventoryGearPartId)?.id ?? null;
-
-      panelStack.push({
-        id: "inventory-gear-part-menu",
-        kind: "menu",
-        title: "Gear Parts",
-        items: INVENTORY_GEAR_PARTS,
-        selectedId: selectedPart ?? undefined,
-        context: { main: "inventory", route: "inventory-gear-menu" },
-      });
-
-      if (!selectedPart) {
-        return { panelStack, socialContext: null };
-      }
-
-      const dynamicGearLists = makeGearLists(equippedGear);
-      const gearList = dynamicGearLists[selectedPart as keyof typeof dynamicGearLists] ?? [];
-      const selectedItem = findById(gearList, selectedDetailByKey.inventoryGear);
-
-      panelStack.push({
-        id: `inventory-gear-list-${selectedPart}`,
-        kind: "list",
-        title: "Owned List",
-        items: gearList,
-        selectedId: selectedDetailByKey.inventoryGear ?? undefined,
-        context: { main: "inventory", route: "inventory-gear-list" },
-      });
-
-      if (selectedItem) {
-        panelStack.push({
-          id: `inventory-gear-detail-${selectedItem.id}`,
-          kind: "placeholder",
-          title: selectedItem.detailTitle ?? "Gear Detail",
-          description: selectedItem.detailDescription,
-          rows: selectedItem.detailRows,
-        });
-      }
-
-      return { panelStack, socialContext: null };
-    }
-
     return { panelStack, socialContext: null };
   }
 
@@ -539,11 +485,6 @@ export default function Home() {
   usePanScroll(viewportRef);
 
   const { showToast } = useToast();
-  const [equippedGear, setEquippedGear] = useState<EquipmentSlotInfo[]>([]);
-  useEffect(() => {
-    if (playerId) getEquippedGearApi().then(setEquippedGear);
-  }, [playerId]);
-
   const [logoutAlertOpen, setLogoutAlertOpen] = useState(false);
 
   useEffect(() => {
@@ -557,7 +498,6 @@ export default function Home() {
   const [selectedSubByMain, setSelectedSubByMain] = useState<Record<MainNavId, string | null>>({
     ...DEFAULT_SUB_SELECTIONS,
   });
-  const [selectedInventoryGearPartId, setSelectedInventoryGearPartId] = useState<string | null>(null);
   const [selectedMarketShopSectionId, setSelectedMarketShopSectionId] = useState<string | null>(null);
   const [selectedPlayerCategoryBySub, setSelectedPlayerCategoryBySub] = useState<Record<PlayerSubId, string | null>>({
     achievement: null, credentials: null, title: null, interests: null,
@@ -611,7 +551,6 @@ export default function Home() {
       });
     }
     if (main === "skills") updateDetailSelections({ skills: null });
-    if (main === "inventory") updateDetailSelections({ inventoryGear: null });
     if (main === "social") updateDetailSelections({ social: null });
     if (main === "lifelog") {
       updateDetailSelections({ lifelog: null });
@@ -639,26 +578,22 @@ export default function Home() {
       buildPanels(
         selectedMain,
         selectedSubByMain,
-        selectedInventoryGearPartId,
         selectedMarketShopSectionId,
         selectedDetailByKey,
         selectedPlayerCategoryBySub,
         selectedLifelogCategoryBySub,
         editingItemId,
         Boolean(activeFormPanel),
-        equippedGear,
       ),
     [
       selectedMain,
       selectedSubByMain,
-      selectedInventoryGearPartId,
       selectedMarketShopSectionId,
       selectedDetailByKey,
       selectedPlayerCategoryBySub,
       selectedLifelogCategoryBySub,
       editingItemId,
       activeFormPanel,
-      equippedGear,
     ],
   );
 
@@ -694,7 +629,6 @@ export default function Home() {
 
     setSelectedMain(nextMain);
     setSelectedSubByMain({ ...DEFAULT_SUB_SELECTIONS });
-    setSelectedInventoryGearPartId(null);
     setSelectedMarketShopSectionId(null);
     setSelectedDetailByKey(createDefaultDetailSelections());
     setSelectedPlayerCategoryBySub({ achievement: null, credentials: null, title: null, interests: null });
@@ -727,7 +661,6 @@ export default function Home() {
         const next = tog(current);
         setSelectedSubByMain((prev) => ({ ...prev, [panel.context.main]: next }));
         clearDetailSelectionsForMain(panel.context.main, next ?? undefined);
-        if (panel.context.main === "inventory") setSelectedInventoryGearPartId(null);
         if (panel.context.main === "market") setSelectedMarketShopSectionId(null);
         setActiveFormPanel(null);
         setEditingItemId(null);
@@ -754,12 +687,6 @@ export default function Home() {
         return;
       }
 
-      if (panel.context.route === "inventory-gear-menu") {
-        setSelectedInventoryGearPartId(tog(selectedInventoryGearPartId));
-        updateDetailSelections({ inventoryGear: null });
-        return;
-      }
-
       if (panel.context.route === "market-shop-menu") {
         setSelectedMarketShopSectionId(tog(selectedMarketShopSectionId));
         updateDetailSelections({ marketCatalog: null, marketMyListings: null });
@@ -773,7 +700,7 @@ export default function Home() {
     }
 
     if (panel.kind === "list") {
-      const { player, skills, inventoryGear, social,
+      const { player, skills, social,
               lifelog, marketWallet, marketCatalog, marketMyListings, marketTradeFriend } = selectedDetailByKey;
 
       if (panel.context.route === "player-list") {
@@ -781,7 +708,6 @@ export default function Home() {
         updateDetailSelections({ player: tog(player) });
       }
       if (panel.context.route === "skills-list") updateDetailSelections({ skills: tog(skills) });
-      if (panel.context.route === "inventory-gear-list") updateDetailSelections({ inventoryGear: tog(inventoryGear) });
       if (panel.context.route === "social-list") updateDetailSelections({ social: tog(social) });
       if (panel.context.route === "lifelog-list") {
         setActiveFormPanel(null); setEditingItemId(null);
@@ -904,53 +830,6 @@ export default function Home() {
       } else if (selectedMain === "lifelog" && sub === "media") {
         openForm("media-edit", "Edit Media", MEDIA_FORM_FIELDS, "수정하기");
       }
-
-    } else if (actionType === "equip") {
-      // Gear equip flow
-      const itemInstanceId = Number(itemId);
-      const mockItem = MOCK_INVENTORY_ITEMS.find((i) => i.itemInstanceId === itemInstanceId);
-      if (!mockItem) return;
-      const slotId = getEquipSlotId(itemInstanceId, equippedGear);
-      const targetSlot = equippedGear.find((s) => s.slotId === slotId);
-      const slotName = targetSlot?.slotName ?? "슬롯";
-      const occupiedBy = targetSlot?.itemName;
-
-      setPendingAction({
-        title: "아이템 장착",
-        message: occupiedBy
-          ? `${mockItem.itemName}을(를) ${slotName}에 장착합니다.\n기존 장착: ${occupiedBy}`
-          : `${mockItem.itemName}을(를) ${slotName}에 장착하시겠습니까?`,
-        onConfirm: async () => {
-          try {
-            await equipGearApi(slotId, itemInstanceId);
-            const updated = await getEquippedGearApi();
-            setEquippedGear(updated);
-            showToast({ variant: "success", title: "장착 완료", body: `${mockItem.itemName} → ${slotName}` });
-          } catch {
-            showToast({ variant: "error", title: "장착 실패", body: "다시 시도해주세요." });
-          }
-        },
-      });
-
-    } else if (actionType === "unequip") {
-      const itemInstanceId = Number(itemId);
-      const slot = equippedGear.find((s) => s.itemInstanceId === itemInstanceId);
-      if (!slot) return;
-
-      setPendingAction({
-        title: "장착 해제",
-        message: `${slot.itemName ?? "아이템"}을(를) ${slot.slotName}에서 해제하시겠습니까?`,
-        onConfirm: async () => {
-          try {
-            await unequipGearApi(slot.slotId);
-            const updated = await getEquippedGearApi();
-            setEquippedGear(updated);
-            showToast({ variant: "info", title: "장착 해제", body: `${slot.itemName ?? "아이템"}이(가) 해제되었습니다.` });
-          } catch {
-            showToast({ variant: "error", title: "해제 실패", body: "다시 시도해주세요." });
-          }
-        },
-      });
 
     } else if (actionType === "start") {
       if (selectedMain === "social" && sub === "party") {
@@ -1350,7 +1229,7 @@ export default function Home() {
             </div>
           ) : selectedMain === "quests" ? (
             <JourneyShell />
-          ) : selectedMain === "inventory" && (selectedSubByMain.inventory === "items" || selectedSubByMain.inventory === "inbox") ? (
+          ) : selectedMain === "inventory" && selectedSubByMain.inventory ? (
             <div className="flex w-fit items-center gap-3">
               <RightPanels
                 selectedMain="inventory"
@@ -1358,7 +1237,9 @@ export default function Home() {
                 panelStackKey="inventory-real-menu"
                 onPanelItemSelect={handlePanelItemSelect}
               />
-              <InventoryShell surface={selectedSubByMain.inventory === "items" ? "items" : "inbox"} />
+              {selectedSubByMain.inventory === "gear"
+                ? <GearShell />
+                : <InventoryShell surface={selectedSubByMain.inventory === "items" ? "items" : "inbox"} />}
             </div>
           ) : selectedMain === "lifelog" && selectedSubByMain.lifelog === "journal" ? (
             <div className="flex w-fit items-center gap-3">

--- a/features/inventory/GearShell.test.tsx
+++ b/features/inventory/GearShell.test.tsx
@@ -31,10 +31,12 @@ const currentBlade: InventoryEntry = {
 };
 const newBlade: InventoryEntry = { ...currentBlade, itemInstanceId: 502, slotIndex: 2, itemId: 102, itemName: "New Blade", rarity: "EPIC" };
 const armor: InventoryEntry = { ...currentBlade, itemInstanceId: 601, slotIndex: 3, itemId: 201, itemName: "Chest Armor", category: "ARMOR", type: "CHEST" };
+const boots: InventoryEntry = { ...armor, itemInstanceId: 602, itemName: "Windrunner Boots", type: "ETC" };
 const equipment: EquipmentSlotInfo[] = [
   { slotId: 21, slotCode: "MAIN_HAND", slotName: "Main Hand", slotCategory: "WEAPON", slotRole: "MAIN", itemInstanceId: null },
   { slotId: 22, slotCode: "OFF_HAND", slotName: "Off Hand", slotCategory: "WEAPON", slotRole: "OFFHAND", itemInstanceId: 501 },
   { slotId: 31, slotCode: "CHEST", slotName: "Chest", slotCategory: "CHEST", slotRole: "SINGLE", itemInstanceId: 999 },
+  { slotId: 41, slotCode: "FEET", slotName: "Feet", slotCategory: "FEET", slotRole: "SINGLE", itemInstanceId: 602 },
 ];
 
 function makeState(slotData = equipment, entries = [currentBlade, newBlade, armor]) {
@@ -97,6 +99,24 @@ describe("Gear surface를 사용할 때", () => {
 
       expect(window.confirm).toHaveBeenCalledWith("Unequip itemInstanceId 999 from Chest?");
       expect(hook.current.unequip).toHaveBeenCalledWith(31);
+    });
+  });
+
+  describe("선택한 pair의 호환성을 현재 계약으로 증명할 수 없으면", () => {
+    it("설명을 표시하고 Equip을 막지만 occupied slot의 Unequip은 허용한다", () => {
+      hook.current = makeState(equipment, [currentBlade, newBlade, armor, boots]);
+      render(<GearShell />);
+      fireEvent.click(screen.getByRole("button", { name: /Boots/ }));
+      fireEvent.click(screen.getByRole("button", { name: /Feet/ }));
+      fireEvent.click(screen.getByRole("button", { name: /^Windrunner Boots · x1/ }));
+
+      expect(screen.getByRole("alert")).toHaveTextContent("Compatibility is not available for this slot in the current item contract.");
+      expect(screen.getByRole("button", { name: "Equip" })).toBeDisabled();
+      fireEvent.click(screen.getByRole("button", { name: "Equip" }));
+      expect(hook.current.equip).not.toHaveBeenCalled();
+
+      fireEvent.click(screen.getByRole("button", { name: "Unequip" }));
+      expect(hook.current.unequip).toHaveBeenCalledWith(41);
     });
   });
 

--- a/features/inventory/GearShell.test.tsx
+++ b/features/inventory/GearShell.test.tsx
@@ -1,0 +1,148 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { EquipmentSlotInfo, InventoryEntry } from "@/shared/api/types";
+import { composeEquipmentSlots } from "./model";
+import GearShell from "./GearShell";
+
+const hook = vi.hoisted(() => ({ current: {} as ReturnType<typeof makeState> }));
+
+vi.mock("./useEquipmentQueries", () => ({ useEquipmentQueries: () => hook.current }));
+vi.mock("@/shared/ui/PanelCard", () => ({
+  default: ({ label, slotLabel, subtitle, disabled, onClick }: { label: string; slotLabel: string; subtitle?: string; disabled?: boolean; onClick?: () => void }) => (
+    <button type="button" disabled={disabled} onClick={onClick}>{label} · {slotLabel} · {subtitle}</button>
+  ),
+}));
+
+const currentBlade: InventoryEntry = {
+  itemInstanceId: 501,
+  slotIndex: 1,
+  itemId: 101,
+  itemName: "Current Blade",
+  category: "WEAPON",
+  type: "SWORD",
+  rarity: "RARE",
+  stackable: false,
+  maxStack: 1,
+  quantity: 1,
+  bound: true,
+  durability: 80,
+  instanceAttrs: { atk: 10 },
+};
+const newBlade: InventoryEntry = { ...currentBlade, itemInstanceId: 502, slotIndex: 2, itemId: 102, itemName: "New Blade", rarity: "EPIC" };
+const armor: InventoryEntry = { ...currentBlade, itemInstanceId: 601, slotIndex: 3, itemId: 201, itemName: "Chest Armor", category: "ARMOR", type: "CHEST" };
+const equipment: EquipmentSlotInfo[] = [
+  { slotId: 21, slotCode: "MAIN_HAND", slotName: "Main Hand", slotCategory: "WEAPON", slotRole: "MAIN", itemInstanceId: null },
+  { slotId: 22, slotCode: "OFF_HAND", slotName: "Off Hand", slotCategory: "WEAPON", slotRole: "OFFHAND", itemInstanceId: 501 },
+  { slotId: 31, slotCode: "CHEST", slotName: "Chest", slotCategory: "CHEST", slotRole: "SINGLE", itemInstanceId: 999 },
+];
+
+function makeState(slotData = equipment, entries = [currentBlade, newBlade, armor]) {
+  return {
+    equipment: { data: slotData, loading: false, error: null as string | null, reload: vi.fn() },
+    inventory: { data: { entries }, loading: false, error: null as string | null, reload: vi.fn() },
+    slots: composeEquipmentSlots(slotData, entries),
+    pendingKey: null as string | null,
+    mutationError: null as string | null,
+    equip: vi.fn(),
+    unequip: vi.fn(),
+  };
+}
+
+describe("Gear surface를 사용할 때", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+    hook.current = makeState();
+  });
+
+  describe("여러 Weapon slot 중 target을 선택해 교체하면", () => {
+    it("명시한 empty slot과 candidate를 확인한 뒤 실제 slotId로 equip한다", () => {
+      render(<GearShell />);
+      fireEvent.click(screen.getByRole("button", { name: /Weapon/ }));
+      fireEvent.click(screen.getByRole("button", { name: /Main Hand/ }));
+      fireEvent.click(screen.getByRole("button", { name: /New Blade/ }));
+      fireEvent.click(screen.getByRole("button", { name: "Equip" }));
+
+      expect(window.confirm).toHaveBeenCalledWith("Equip New Blade to Main Hand?");
+      expect(hook.current.equip).toHaveBeenCalledWith(21, 502);
+    });
+
+    it("candidate만 선택해서는 equip하지 않고 명시한 실제 slotId로만 요청한다", () => {
+      render(<GearShell />);
+      fireEvent.click(screen.getByRole("button", { name: /Weapon/ }));
+      fireEvent.click(screen.getByRole("button", { name: /New Blade/ }));
+      expect(screen.queryByRole("button", { name: "Equip" })).not.toBeInTheDocument();
+      expect(hook.current.equip).not.toHaveBeenCalled();
+
+      fireEvent.click(screen.getByRole("button", { name: /Off Hand/ }));
+      fireEvent.click(screen.getByRole("button", { name: "Equip" }));
+
+      expect(window.confirm).toHaveBeenCalledWith("Replace Current Blade in Off Hand with New Blade?");
+      expect(hook.current.equip).toHaveBeenCalledWith(22, 502);
+      expect(hook.current.equip).not.toHaveBeenCalledWith(1, expect.anything());
+    });
+  });
+
+  describe("occupied slot의 Inventory enrichment가 없으면", () => {
+    it("empty로 표시하지 않고 itemInstanceId를 보존하며 slotId로 unequip한다", () => {
+      render(<GearShell />);
+      fireEvent.click(screen.getByRole("button", { name: /Armor/ }));
+      const slot = screen.getByRole("button", { name: /Chest.*Item details unavailable.*itemInstanceId 999/ });
+      expect(slot).not.toHaveTextContent("Empty");
+      fireEvent.click(slot);
+
+      expect(screen.getByText("Equipped: Item details unavailable · itemInstanceId 999")).toBeInTheDocument();
+      fireEvent.click(screen.getByRole("button", { name: "Unequip" }));
+
+      expect(window.confirm).toHaveBeenCalledWith("Unequip itemInstanceId 999 from Chest?");
+      expect(hook.current.unequip).toHaveBeenCalledWith(31);
+    });
+  });
+
+  describe("Equipment 또는 Inventory query가 비정상이면", () => {
+    it("loading, error/retry, no-slot, no-candidate state를 각각 표시한다", () => {
+      hook.current = makeState([], []);
+      hook.current.equipment.loading = true;
+      hook.current.inventory.loading = true;
+      const { rerender } = render(<GearShell />);
+      fireEvent.click(screen.getByRole("button", { name: /Weapon/ }));
+      expect(screen.getByText("Loading Equipment...")).toBeInTheDocument();
+      expect(screen.getByText("Loading Inventory candidates...")).toBeInTheDocument();
+
+      hook.current = makeState([], []);
+      hook.current.equipment.error = "Equipment unavailable";
+      hook.current.inventory.error = "Inventory unavailable";
+      rerender(<GearShell />);
+      expect(screen.getAllByRole("alert").map((node) => node.textContent)).toEqual(["Equipment unavailable", "Inventory unavailable"]);
+      fireEvent.click(screen.getAllByRole("button", { name: "Retry" })[0]);
+      fireEvent.click(screen.getAllByRole("button", { name: "Retry" })[1]);
+      expect(hook.current.equipment.reload).toHaveBeenCalledTimes(1);
+      expect(hook.current.inventory.reload).toHaveBeenCalledTimes(1);
+
+      hook.current = makeState([], []);
+      rerender(<GearShell />);
+      expect(screen.getByText("No matching Equipment slots.")).toBeInTheDocument();
+      expect(screen.getByText("No candidate Items.")).toBeInTheDocument();
+    });
+  });
+
+  describe("authoritative reload에서 selection identity가 사라지면", () => {
+    it("removed candidate와 removed slot selection을 순서대로 clear한다", async () => {
+      const { rerender } = render(<GearShell />);
+      fireEvent.click(screen.getByRole("button", { name: /Weapon/ }));
+      fireEvent.click(screen.getByRole("button", { name: /Off Hand/ }));
+      fireEvent.click(screen.getByRole("button", { name: /New Blade/ }));
+      expect(screen.getByText(/Candidate: New Blade/)).toBeInTheDocument();
+
+      hook.current = makeState(equipment, [currentBlade, armor]);
+      rerender(<GearShell />);
+      await waitFor(() => expect(screen.getByText("Select an Inventory candidate to equip.")).toBeInTheDocument());
+      expect(screen.getByRole("button", { name: "Equip" })).toBeDisabled();
+
+      hook.current = makeState([equipment[0], equipment[2]], [currentBlade, armor]);
+      rerender(<GearShell />);
+      await waitFor(() => expect(screen.queryByText("Slot ID: 22")).not.toBeInTheDocument());
+    });
+  });
+});

--- a/features/inventory/GearShell.tsx
+++ b/features/inventory/GearShell.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import { INVENTORY_GEAR_PARTS } from "@/entities/nav";
+import type { InventoryGearPartId } from "@/entities/nav";
+import { SAO } from "@/shared/design/tokens";
+import PanelCard from "@/shared/ui/PanelCard";
+import { PanelFrame } from "@/widgets/right-panels/ui/PanelFrame";
+import { GoldRow, InfoCard } from "@/widgets/right-panels/ui/Rows";
+import { actionBtnStyle } from "@/widgets/right-panels/ui/styles";
+import { candidatesForGearPart, slotsForGearPart } from "./model";
+import { useEquipmentQueries } from "./useEquipmentQueries";
+
+const secondaryButton = {
+  border: `1px solid ${SAO.color.border.panel}`,
+  background: SAO.color.bg.inset,
+  color: SAO.color.text.secondary,
+  borderRadius: SAO.radius.panel,
+  padding: "7px 10px",
+  fontSize: "0.68rem",
+  letterSpacing: "0.08em",
+} as const;
+
+function ErrorState({ text, retry }: { text: string; retry: () => void }) {
+  return (
+    <div className="space-y-2 px-3">
+      <p role="alert" className="text-xs" style={{ color: SAO.color.action.red }}>{text}</p>
+      <button type="button" style={secondaryButton} onClick={retry}>Retry</button>
+    </div>
+  );
+}
+
+export default function GearShell() {
+  const queries = useEquipmentQueries();
+  const [part, setPart] = useState<InventoryGearPartId | null>(null);
+  const [selectedSlotId, setSelectedSlotId] = useState<number | null>(null);
+  const [selectedItemInstanceId, setSelectedItemInstanceId] = useState<number | null>(null);
+  const slots = useMemo(() => part ? slotsForGearPart(queries.slots, part) : [], [part, queries.slots]);
+  const candidates = useMemo(
+    () => part ? candidatesForGearPart(queries.inventory.data.entries, part) : [],
+    [part, queries.inventory.data.entries],
+  );
+  const selectedSlot = slots.find(({ slot }) => slot.slotId === selectedSlotId) ?? null;
+  const selectedCandidate = candidates.find(({ itemInstanceId }) => itemInstanceId === selectedItemInstanceId) ?? null;
+  const pending = queries.pendingKey !== null;
+
+  useEffect(() => {
+    if (selectedSlotId !== null && !slots.some(({ slot }) => slot.slotId === selectedSlotId)) setSelectedSlotId(null);
+  }, [selectedSlotId, slots]);
+
+  useEffect(() => {
+    if (selectedItemInstanceId !== null && !candidates.some(({ itemInstanceId }) => itemInstanceId === selectedItemInstanceId)) setSelectedItemInstanceId(null);
+  }, [candidates, selectedItemInstanceId]);
+
+  return (
+    <div className="relative flex min-w-0 w-fit flex-row flex-nowrap items-center gap-3" data-testid="gear-shell">
+      <PanelFrame title="Gear Parts" depth={3}>
+        <div className="space-y-2">
+          {INVENTORY_GEAR_PARTS.map((item, index) => (
+            <PanelCard
+              key={item.id}
+              label={item.label}
+              slotLabel={item.slotLabel}
+              selected={part === item.id}
+              index={index}
+              onClick={() => {
+                setPart(item.id as InventoryGearPartId);
+                setSelectedSlotId(null);
+                setSelectedItemInstanceId(null);
+              }}
+            />
+          ))}
+        </div>
+      </PanelFrame>
+
+      {part ? (
+        <PanelFrame title="Equipment Slots" depth={2}>
+          <div className="space-y-3">
+            {queries.equipment.loading && queries.equipment.data.length === 0 ? <InfoCard>Loading Equipment...</InfoCard> : null}
+            {queries.equipment.error ? <ErrorState text={queries.equipment.error} retry={() => void queries.equipment.reload()} /> : null}
+            {!queries.equipment.loading && !queries.equipment.error && slots.length === 0 ? <InfoCard>No matching Equipment slots.</InfoCard> : null}
+            <div className="space-y-2">
+              {slots.map(({ slot, item, enrichmentMissing }, index) => (
+                <PanelCard
+                  key={slot.slotId}
+                  label={slot.slotName}
+                  slotLabel={slot.slotRole.slice(0, 2)}
+                  subtitle={slot.itemInstanceId === null
+                    ? `${slot.slotCode} · Empty`
+                    : enrichmentMissing
+                      ? `${slot.slotCode} · Occupied · Item details unavailable · itemInstanceId ${slot.itemInstanceId}`
+                      : `${slot.slotCode} · ${item?.itemName} · ${item?.rarity}`}
+                  selected={selectedSlotId === slot.slotId}
+                  index={index}
+                  onClick={() => setSelectedSlotId(slot.slotId)}
+                />
+              ))}
+            </div>
+          </div>
+        </PanelFrame>
+      ) : null}
+
+      {part ? (
+        <PanelFrame title="Inventory Candidates" depth={1}>
+          <div className="space-y-3">
+            {queries.inventory.loading && queries.inventory.data.entries.length === 0 ? <InfoCard>Loading Inventory candidates...</InfoCard> : null}
+            {queries.inventory.error ? <ErrorState text={queries.inventory.error} retry={() => void queries.inventory.reload()} /> : null}
+            {!queries.inventory.loading && !queries.inventory.error && candidates.length === 0 ? <InfoCard>No candidate Items.</InfoCard> : null}
+            <div className="space-y-2">
+              {candidates.map((item, index) => (
+                <PanelCard
+                  key={item.itemInstanceId}
+                  label={item.itemName}
+                  slotLabel={`x${item.quantity}`}
+                  subtitle={`${item.rarity} · ${item.category} · ${item.type}`}
+                  selected={selectedItemInstanceId === item.itemInstanceId}
+                  index={index}
+                  onClick={() => setSelectedItemInstanceId(item.itemInstanceId)}
+                />
+              ))}
+            </div>
+          </div>
+        </PanelFrame>
+      ) : null}
+
+      {selectedSlot ? (
+        <PanelFrame title="Gear Action" depth={0}>
+          <div className="space-y-2 px-3">
+            <InfoCard>{selectedSlot.slot.slotName}</InfoCard>
+            <GoldRow>Slot ID: {selectedSlot.slot.slotId}</GoldRow>
+            <GoldRow>Slot code: {selectedSlot.slot.slotCode}</GoldRow>
+            <GoldRow>Category: {selectedSlot.slot.slotCategory}</GoldRow>
+            <GoldRow>Role: {selectedSlot.slot.slotRole}</GoldRow>
+            {selectedSlot.slot.itemInstanceId === null ? <GoldRow>Equipped: Empty</GoldRow> : null}
+            {selectedSlot.item ? <GoldRow>Equipped: {selectedSlot.item.itemName} · {selectedSlot.item.rarity}</GoldRow> : null}
+            {selectedSlot.enrichmentMissing ? <GoldRow>Equipped: Item details unavailable · itemInstanceId {selectedSlot.slot.itemInstanceId}</GoldRow> : null}
+            {selectedCandidate ? <GoldRow>Candidate: {selectedCandidate.itemName} · itemInstanceId {selectedCandidate.itemInstanceId}</GoldRow> : <InfoCard>Select an Inventory candidate to equip.</InfoCard>}
+            {queries.mutationError ? <p role="alert" className="text-xs" style={{ color: SAO.color.action.red }}>{queries.mutationError}</p> : null}
+            <div className="flex gap-2 pt-2">
+              <button
+                type="button"
+                disabled={pending || !selectedCandidate || selectedSlot.slot.itemInstanceId === selectedCandidate?.itemInstanceId}
+                style={{ ...actionBtnStyle, flex: 1 }}
+                onClick={() => {
+                  if (!selectedCandidate) return;
+                  const current = selectedSlot.item?.itemName
+                    ?? (selectedSlot.slot.itemInstanceId === null ? null : `itemInstanceId ${selectedSlot.slot.itemInstanceId}`);
+                  const prompt = current
+                    ? `Replace ${current} in ${selectedSlot.slot.slotName} with ${selectedCandidate.itemName}?`
+                    : `Equip ${selectedCandidate.itemName} to ${selectedSlot.slot.slotName}?`;
+                  if (window.confirm(prompt)) void queries.equip(selectedSlot.slot.slotId, selectedCandidate.itemInstanceId);
+                }}
+              >{pending ? "Working..." : "Equip"}</button>
+              {selectedSlot.slot.itemInstanceId !== null ? (
+                <button
+                  type="button"
+                  disabled={pending}
+                  style={secondaryButton}
+                  onClick={() => {
+                    const item = selectedSlot.item?.itemName ?? `itemInstanceId ${selectedSlot.slot.itemInstanceId}`;
+                    if (window.confirm(`Unequip ${item} from ${selectedSlot.slot.slotName}?`)) void queries.unequip(selectedSlot.slot.slotId);
+                  }}
+                >Unequip</button>
+              ) : null}
+            </div>
+          </div>
+        </PanelFrame>
+      ) : null}
+    </div>
+  );
+}

--- a/features/inventory/GearShell.tsx
+++ b/features/inventory/GearShell.tsx
@@ -9,7 +9,7 @@ import PanelCard from "@/shared/ui/PanelCard";
 import { PanelFrame } from "@/widgets/right-panels/ui/PanelFrame";
 import { GoldRow, InfoCard } from "@/widgets/right-panels/ui/Rows";
 import { actionBtnStyle } from "@/widgets/right-panels/ui/styles";
-import { candidatesForGearPart, slotsForGearPart } from "./model";
+import { candidatesForGearPart, getEquipCompatibility, slotsForGearPart } from "./model";
 import { useEquipmentQueries } from "./useEquipmentQueries";
 
 const secondaryButton = {
@@ -43,6 +43,9 @@ export default function GearShell() {
   );
   const selectedSlot = slots.find(({ slot }) => slot.slotId === selectedSlotId) ?? null;
   const selectedCandidate = candidates.find(({ itemInstanceId }) => itemInstanceId === selectedItemInstanceId) ?? null;
+  const compatibility = selectedSlot && selectedCandidate
+    ? getEquipCompatibility(selectedSlot.slot, selectedCandidate)
+    : null;
   const pending = queries.pendingKey !== null;
 
   useEffect(() => {
@@ -136,14 +139,15 @@ export default function GearShell() {
             {selectedSlot.item ? <GoldRow>Equipped: {selectedSlot.item.itemName} · {selectedSlot.item.rarity}</GoldRow> : null}
             {selectedSlot.enrichmentMissing ? <GoldRow>Equipped: Item details unavailable · itemInstanceId {selectedSlot.slot.itemInstanceId}</GoldRow> : null}
             {selectedCandidate ? <GoldRow>Candidate: {selectedCandidate.itemName} · itemInstanceId {selectedCandidate.itemInstanceId}</GoldRow> : <InfoCard>Select an Inventory candidate to equip.</InfoCard>}
+            {compatibility && compatibility.status !== "VERIFIED" ? <p role="alert" className="text-xs" style={{ color: SAO.color.action.red }}>{compatibility.reason}</p> : null}
             {queries.mutationError ? <p role="alert" className="text-xs" style={{ color: SAO.color.action.red }}>{queries.mutationError}</p> : null}
             <div className="flex gap-2 pt-2">
               <button
                 type="button"
-                disabled={pending || !selectedCandidate || selectedSlot.slot.itemInstanceId === selectedCandidate?.itemInstanceId}
+                disabled={pending || compatibility?.status !== "VERIFIED" || selectedSlot.slot.itemInstanceId === selectedCandidate?.itemInstanceId}
                 style={{ ...actionBtnStyle, flex: 1 }}
                 onClick={() => {
-                  if (!selectedCandidate) return;
+                  if (!selectedCandidate || compatibility?.status !== "VERIFIED") return;
                   const current = selectedSlot.item?.itemName
                     ?? (selectedSlot.slot.itemInstanceId === null ? null : `itemInstanceId ${selectedSlot.slot.itemInstanceId}`);
                   const prompt = current

--- a/features/inventory/model.test.ts
+++ b/features/inventory/model.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import type { EquipmentSlotInfo, InventoryEntry } from "@/shared/api/types";
+import { candidatesForGearPart, composeEquipmentSlots, slotsForGearPart } from "./model";
+
+const slots: EquipmentSlotInfo[] = [
+  { slotId: 21, slotCode: "MAIN_HAND", slotName: "Main Hand", slotCategory: "WEAPON", slotRole: "MAIN", itemInstanceId: 501 },
+  { slotId: 22, slotCode: "OFF_HAND", slotName: "Off Hand", slotCategory: "WEAPON", slotRole: "OFFHAND", itemInstanceId: null },
+  { slotId: 31, slotCode: "CHEST", slotName: "Chest", slotCategory: "CHEST", slotRole: "SINGLE", itemInstanceId: 999 },
+  { slotId: 41, slotCode: "FEET", slotName: "Feet", slotCategory: "FEET", slotRole: "SINGLE", itemInstanceId: null },
+];
+
+const inventory: InventoryEntry[] = [
+  { itemInstanceId: 501, slotIndex: 3, itemId: 101, itemName: "Server Sword", category: "WEAPON", type: "SWORD", rarity: "RARE", stackable: false, maxStack: 1, quantity: 1, bound: true, durability: 88, instanceAttrs: { atk: 12 } },
+  { itemInstanceId: 601, slotIndex: 4, itemId: 201, itemName: "Server Armor", category: "ARMOR", type: "CHEST", rarity: "EPIC", stackable: false, maxStack: 1, quantity: 1, bound: true, durability: 77, instanceAttrs: { def: 20 } },
+  { itemInstanceId: 701, slotIndex: 5, itemId: 301, itemName: "Server Ring", category: "ACCESSORY", type: "RING", rarity: "COMMON", stackable: false, maxStack: 1, quantity: 1, bound: false, durability: null, instanceAttrs: {} },
+];
+
+describe("Equipment와 Inventory를 Gear read model로 조합할 때", () => {
+  describe("slot의 itemInstanceId가 Inventory와 일치하면", () => {
+    it("slot identity를 유지하고 실제 Inventory display fields로 enrich한다", () => {
+      const composed = composeEquipmentSlots(slots, inventory);
+
+      expect(composed[0]).toEqual({ slot: slots[0], item: inventory[0], enrichmentMissing: false });
+      expect(composed[1]).toEqual({ slot: slots[1], item: null, enrichmentMissing: false });
+    });
+  });
+
+  describe("occupied slot의 Inventory enrichment가 없으면", () => {
+    it("empty로 바꾸지 않고 slot과 itemInstanceId를 보존한다", () => {
+      const composed = composeEquipmentSlots(slots, inventory);
+
+      expect(composed[2]).toEqual({ slot: slots[2], item: null, enrichmentMissing: true });
+      expect(composed[2].slot.itemInstanceId).toBe(999);
+    });
+  });
+
+  describe("Gear subsection을 선택하면", () => {
+    it("검증된 slot category mapping과 coarse Inventory category mapping만 적용한다", () => {
+      const composed = composeEquipmentSlots(slots, inventory);
+
+      expect(slotsForGearPart(composed, "weapon").map(({ slot }) => slot.slotId)).toEqual([21, 22]);
+      expect(slotsForGearPart(composed, "armor").map(({ slot }) => slot.slotId)).toEqual([31]);
+      expect(slotsForGearPart(composed, "boots").map(({ slot }) => slot.slotId)).toEqual([41]);
+      expect(candidatesForGearPart(inventory, "weapon").map(({ itemInstanceId }) => itemInstanceId)).toEqual([501]);
+      expect(candidatesForGearPart(inventory, "armor").map(({ itemInstanceId }) => itemInstanceId)).toEqual([601]);
+      expect(candidatesForGearPart(inventory, "boots").map(({ itemInstanceId }) => itemInstanceId)).toEqual([601]);
+      expect(candidatesForGearPart(inventory, "accessory").map(({ itemInstanceId }) => itemInstanceId)).toEqual([701]);
+    });
+  });
+});

--- a/features/inventory/model.test.ts
+++ b/features/inventory/model.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import type { EquipmentSlotInfo, InventoryEntry } from "@/shared/api/types";
-import { candidatesForGearPart, composeEquipmentSlots, slotsForGearPart } from "./model";
+import { candidatesForGearPart, composeEquipmentSlots, getEquipCompatibility, slotsForGearPart } from "./model";
 
 const slots: EquipmentSlotInfo[] = [
   { slotId: 21, slotCode: "MAIN_HAND", slotName: "Main Hand", slotCategory: "WEAPON", slotRole: "MAIN", itemInstanceId: 501 },
@@ -15,6 +15,11 @@ const inventory: InventoryEntry[] = [
   { itemInstanceId: 601, slotIndex: 4, itemId: 201, itemName: "Server Armor", category: "ARMOR", type: "CHEST", rarity: "EPIC", stackable: false, maxStack: 1, quantity: 1, bound: true, durability: 77, instanceAttrs: { def: 20 } },
   { itemInstanceId: 701, slotIndex: 5, itemId: 301, itemName: "Server Ring", category: "ACCESSORY", type: "RING", rarity: "COMMON", stackable: false, maxStack: 1, quantity: 1, bound: false, durability: null, instanceAttrs: {} },
 ];
+
+const slot = (slotCategory: string): EquipmentSlotInfo => ({ ...slots[0], slotCategory });
+const item = (category: string, type: string, itemName = "Contract Item"): InventoryEntry => ({
+  ...inventory[0], category, type, itemName,
+});
 
 describe("Equipment와 Inventory를 Gear read model로 조합할 때", () => {
   describe("slot의 itemInstanceId가 Inventory와 일치하면", () => {
@@ -46,6 +51,38 @@ describe("Equipment와 Inventory를 Gear read model로 조합할 때", () => {
       expect(candidatesForGearPart(inventory, "armor").map(({ itemInstanceId }) => itemInstanceId)).toEqual([601]);
       expect(candidatesForGearPart(inventory, "boots").map(({ itemInstanceId }) => itemInstanceId)).toEqual([601]);
       expect(candidatesForGearPart(inventory, "accessory").map(({ itemInstanceId }) => itemInstanceId)).toEqual([701]);
+    });
+  });
+
+  describe("선택한 slot과 item의 호환성을 판정하면", () => {
+    it.each([
+      ["WEAPON", "WEAPON", "SWORD"],
+      ["HEAD", "ARMOR", "HELMET"],
+      ["CHEST", "ARMOR", "CHEST"],
+      ["RING", "ACCESSORY", "RING"],
+    ])("%s slot의 현재 계약으로 증명되는 pair만 VERIFIED다", (slotCategory, category, type) => {
+      expect(getEquipCompatibility(slot(slotCategory), item(category, type))).toEqual({ status: "VERIFIED" });
+    });
+
+    it.each([
+      ["CHEST", "ARMOR", "HELMET"],
+      ["HEAD", "ARMOR", "CHEST"],
+    ])("%s slot에 다른 명시적 slot type은 INCOMPATIBLE이다", (slotCategory, category, type) => {
+      expect(getEquipCompatibility(slot(slotCategory), item(category, type)).status).toBe("INCOMPATIBLE");
+    });
+
+    it.each([
+      ["FEET", "ARMOR", "ETC"],
+      ["LEGS", "ARMOR", "ETC"],
+      ["HANDS", "ARMOR", "ETC"],
+      ["NECK", "ACCESSORY", "ETC"],
+      ["TRINKET", "ACCESSORY", "ETC"],
+    ])("%s slot의 ETC item은 호환성을 추론하지 않는다", (slotCategory, category, type) => {
+      expect(getEquipCompatibility(slot(slotCategory), item(category, type)).status).toBe("UNVERIFIABLE");
+    });
+
+    it("item name에 slot 단어가 있어도 호환성 증거로 사용하지 않는다", () => {
+      expect(getEquipCompatibility(slot("HEAD"), item("ARMOR", "ETC", "Definitely Helmet"))).toMatchObject({ status: "UNVERIFIABLE" });
     });
   });
 });

--- a/features/inventory/model.ts
+++ b/features/inventory/model.ts
@@ -7,6 +7,14 @@ export type EquipmentSlotView = {
   enrichmentMissing: boolean;
 };
 
+export type EquipCompatibility =
+  | { status: "VERIFIED" }
+  | { status: "INCOMPATIBLE"; reason: string }
+  | { status: "UNVERIFIABLE"; reason: string };
+
+const INCOMPATIBLE_REASON = "This item is incompatible with the selected Equipment slot.";
+const UNVERIFIABLE_REASON = "Compatibility is not available for this slot in the current item contract.";
+
 const SLOT_CATEGORIES: Record<InventoryGearPartId, readonly string[]> = {
   weapon: ["WEAPON"],
   armor: ["HEAD", "CHEST", "LEGS", "HANDS"],
@@ -35,4 +43,30 @@ export function slotsForGearPart(slots: EquipmentSlotView[], part: InventoryGear
 
 export function candidatesForGearPart(inventory: InventoryEntry[], part: InventoryGearPartId): InventoryEntry[] {
   return inventory.filter(({ category }) => category === ITEM_CATEGORY[part]);
+}
+
+export function getEquipCompatibility(slot: EquipmentSlotInfo, item: InventoryEntry): EquipCompatibility {
+  if (slot.slotCategory === "WEAPON") {
+    return item.category === "WEAPON" ? { status: "VERIFIED" } : { status: "INCOMPATIBLE", reason: INCOMPATIBLE_REASON };
+  }
+
+  const expectedCategory = ["HEAD", "CHEST", "LEGS", "HANDS", "FEET"].includes(slot.slotCategory)
+    ? "ARMOR"
+    : ["NECK", "RING", "TRINKET"].includes(slot.slotCategory) ? "ACCESSORY" : null;
+  if (!expectedCategory) return { status: "UNVERIFIABLE", reason: UNVERIFIABLE_REASON };
+  if (item.category !== expectedCategory) return { status: "INCOMPATIBLE", reason: INCOMPATIBLE_REASON };
+
+  const verifiedType = slot.slotCategory === "HEAD" ? "HELMET"
+    : slot.slotCategory === "CHEST" ? "CHEST"
+      : slot.slotCategory === "RING" ? "RING" : null;
+  if (!verifiedType) {
+    const knownOtherSlotType = ["HELMET", "CHEST", "RING"].includes(item.type);
+    return knownOtherSlotType
+      ? { status: "INCOMPATIBLE", reason: INCOMPATIBLE_REASON }
+      : { status: "UNVERIFIABLE", reason: UNVERIFIABLE_REASON };
+  }
+  if (item.type === verifiedType) return { status: "VERIFIED" };
+  return item.type === "ETC"
+    ? { status: "UNVERIFIABLE", reason: UNVERIFIABLE_REASON }
+    : { status: "INCOMPATIBLE", reason: INCOMPATIBLE_REASON };
 }

--- a/features/inventory/model.ts
+++ b/features/inventory/model.ts
@@ -1,65 +1,38 @@
-import type { InventoryGearPartId, PanelDataItem } from "@/entities/nav";
-import type { InventoryEntry } from "@/shared/api/types";
-import type { EquipmentSlotInfo } from "@/shared/api/types";
-import {
-  MOCK_GEAR_ACCESSORIES,
-  MOCK_GEAR_ARMOR,
-  MOCK_GEAR_BOOTS,
-  MOCK_GEAR_WEAPONS,
-  MOCK_INVENTORY_ITEMS,
-} from "@/lib/api/mock/inventory.mock";
+import type { InventoryGearPartId } from "@/entities/nav";
+import type { EquipmentSlotInfo, InventoryEntry } from "@/shared/api/types";
 
-const SLOT_CODES_BY_CATEGORY: Record<string, string[]> = {
-  Weapon: ["MAIN_HAND", "OFF_HAND"],
-  Armor: ["CHEST"],
-  Boots: ["BOOTS"],
-  Accessory: ["ACCESSORY_1", "ACCESSORY_2"],
+export type EquipmentSlotView = {
+  slot: EquipmentSlotInfo;
+  item: InventoryEntry | null;
+  enrichmentMissing: boolean;
 };
 
-export function getEquipSlotId(itemInstanceId: number, equippedGear: EquipmentSlotInfo[]): number {
-  const item = MOCK_INVENTORY_ITEMS.find((i) => i.itemInstanceId === itemInstanceId);
-  if (!item) return 1;
-  const slotCodes = SLOT_CODES_BY_CATEGORY[item.category] ?? ["MAIN_HAND"];
-  const emptySlot = equippedGear.find((s) => slotCodes.includes(s.slotCode) && s.itemInstanceId === null);
-  if (emptySlot) return emptySlot.slotId;
-  return equippedGear.find((s) => s.slotCode === slotCodes[0])?.slotId ?? 1;
+const SLOT_CATEGORIES: Record<InventoryGearPartId, readonly string[]> = {
+  weapon: ["WEAPON"],
+  armor: ["HEAD", "CHEST", "LEGS", "HANDS"],
+  accessory: ["NECK", "RING", "TRINKET"],
+  boots: ["FEET"],
+};
+
+const ITEM_CATEGORY: Record<InventoryGearPartId, string> = {
+  weapon: "WEAPON",
+  armor: "ARMOR",
+  accessory: "ACCESSORY",
+  boots: "ARMOR",
+};
+
+export function composeEquipmentSlots(slots: EquipmentSlotInfo[], inventory: InventoryEntry[]): EquipmentSlotView[] {
+  const items = new Map(inventory.map((item) => [item.itemInstanceId, item]));
+  return slots.map((slot) => {
+    const item = slot.itemInstanceId === null ? null : items.get(slot.itemInstanceId) ?? null;
+    return { slot, item, enrichmentMissing: slot.itemInstanceId !== null && item === null };
+  });
 }
 
-function gearItemToPanel(item: InventoryEntry, equippedSlots: EquipmentSlotInfo[]): PanelDataItem {
-  const equippedIn = equippedSlots.find((s) => s.itemInstanceId === item.itemInstanceId);
-  const attrs = item.instanceAttrs as Record<string, number> ?? {};
-  const attrStr = Object.entries(attrs)
-    .filter(([, v]) => typeof v === "number")
-    .map(([k, v]) => `${k.toUpperCase()} +${v}`)
-    .join(" / ");
-
-  return {
-    id: String(item.itemInstanceId),
-    label: item.itemName,
-    slotLabel: equippedIn ? equippedIn.slotName : "미장착",
-    subtitle: `${item.rarity} | ${item.type}${equippedIn ? ` | ${equippedIn.slotName}` : ""}`,
-    detailTitle: item.itemName,
-    detailDescription: `${item.type} — ${item.category}`,
-    detailRows: [
-      `희귀도: ${item.rarity}`,
-      `타입: ${item.type}`,
-      `내구도: ${item.durability ?? "∞"}`,
-      ...(attrStr ? [`스탯: ${attrStr}`] : []),
-      equippedIn ? `장착 슬롯: ${equippedIn.slotName}` : "미장착",
-    ],
-    actions: equippedIn
-      ? [{ type: "unequip", label: "장착 해제" }]
-      : [{ type: "equip", label: "장착하기" }],
-  };
+export function slotsForGearPart(slots: EquipmentSlotView[], part: InventoryGearPartId): EquipmentSlotView[] {
+  return slots.filter(({ slot }) => SLOT_CATEGORIES[part].includes(slot.slotCategory));
 }
 
-export function makeGearLists(equippedSlots: EquipmentSlotInfo[]): Record<InventoryGearPartId, PanelDataItem[]> {
-  return {
-    weapon: MOCK_GEAR_WEAPONS.map((item) => gearItemToPanel(item, equippedSlots)),
-    armor: MOCK_GEAR_ARMOR.map((item) => gearItemToPanel(item, equippedSlots)),
-    accessory: MOCK_GEAR_ACCESSORIES.map((item) => gearItemToPanel(item, equippedSlots)),
-    boots: MOCK_GEAR_BOOTS.map((item) => gearItemToPanel(item, equippedSlots)),
-  };
+export function candidatesForGearPart(inventory: InventoryEntry[], part: InventoryGearPartId): InventoryEntry[] {
+  return inventory.filter(({ category }) => category === ITEM_CATEGORY[part]);
 }
-
-export const INVENTORY_GEAR_LISTS: Record<InventoryGearPartId, PanelDataItem[]> = makeGearLists([]);

--- a/features/inventory/useEquipmentQueries.test.tsx
+++ b/features/inventory/useEquipmentQueries.test.tsx
@@ -1,0 +1,220 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { EquipmentSlotInfo, InventoryEntriesResponse, InventoryEntry } from "@/shared/api/types";
+import { ApiError } from "@/shared/api/client";
+import { useEquipmentQueries } from "./useEquipmentQueries";
+
+const equipmentApi = vi.hoisted(() => ({
+  equipGearApi: vi.fn(),
+  getEquippedGearApi: vi.fn(),
+  unequipGearApi: vi.fn(),
+}));
+const inventoryApi = vi.hoisted(() => ({
+  claimMailApi: vi.fn(),
+  deleteMailApi: vi.fn(),
+  getInventoryApi: vi.fn(),
+  getMailboxApi: vi.fn(),
+}));
+
+vi.mock("@/lib/api/endpoints/equipment.api", () => equipmentApi);
+vi.mock("@/lib/api/endpoints/inventory.api", () => inventoryApi);
+
+const item: InventoryEntry = {
+  itemInstanceId: 501,
+  slotIndex: 3,
+  itemId: 101,
+  itemName: "Server Sword",
+  category: "WEAPON",
+  type: "SWORD",
+  rarity: "RARE",
+  stackable: false,
+  maxStack: 1,
+  quantity: 1,
+  bound: true,
+  durability: 88,
+  instanceAttrs: { atk: 12 },
+};
+const inventory: InventoryEntriesResponse = { entries: [item] };
+const slots: EquipmentSlotInfo[] = [
+  { slotId: 21, slotCode: "MAIN_HAND", slotName: "Main Hand", slotCategory: "WEAPON", slotRole: "MAIN", itemInstanceId: null },
+];
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+}
+
+describe("Gear server query state를 관리할 때", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    equipmentApi.getEquippedGearApi.mockResolvedValue(slots);
+    equipmentApi.equipGearApi.mockResolvedValue({ slotId: 21, itemInstanceId: 501 });
+    equipmentApi.unequipGearApi.mockResolvedValue({ slotId: 21 });
+    inventoryApi.getInventoryApi.mockResolvedValue(inventory);
+  });
+
+  describe("Gear read model을 처음 불러오면", () => {
+    it("Equipment와 좁은 Inventory query만 호출하고 Mailbox는 조회하지 않는다", async () => {
+      const { result } = renderHook(() => useEquipmentQueries());
+
+      await waitFor(() => expect(result.current.slots).toHaveLength(1));
+      expect(result.current.slots[0].item).toBeNull();
+      expect(equipmentApi.getEquippedGearApi).toHaveBeenCalledTimes(1);
+      expect(inventoryApi.getInventoryApi).toHaveBeenCalledTimes(1);
+      expect(inventoryApi.getMailboxApi).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Equip 결과가 성공인지 확정되지 않으면", () => {
+    it("duplicate submit을 막고 Equipment와 Inventory를 authoritative reload한다", async () => {
+      const request = deferred<{ slotId: number; itemInstanceId: number }>();
+      equipmentApi.equipGearApi.mockReturnValue(request.promise);
+      const { result } = renderHook(() => useEquipmentQueries());
+      await waitFor(() => expect(result.current.slots).toHaveLength(1));
+
+      let mutation!: Promise<void>;
+      act(() => {
+        mutation = result.current.equip(21, 501);
+        void result.current.equip(21, 501);
+      });
+      expect(equipmentApi.equipGearApi).toHaveBeenCalledTimes(1);
+      expect(result.current.slots[0].slot.itemInstanceId).toBeNull();
+      equipmentApi.getEquippedGearApi.mockResolvedValue([{ ...slots[0], itemInstanceId: 501 }]);
+
+      await act(async () => {
+        request.reject(new Error("connection lost"));
+        await mutation;
+      });
+
+      expect(equipmentApi.getEquippedGearApi).toHaveBeenCalledTimes(2);
+      expect(inventoryApi.getInventoryApi).toHaveBeenCalledTimes(2);
+      expect(result.current.slots[0].slot.itemInstanceId).toBe(501);
+      expect(result.current.slots[0].item?.itemName).toBe("Server Sword");
+      expect(result.current.mutationError).toContain("Server state was reloaded");
+    });
+  });
+
+  describe("Unequip을 요청하면", () => {
+    it("duplicate submit을 막고 ambiguous failure 후에도 두 authoritative query를 reload한다", async () => {
+      const occupied = [{ ...slots[0], itemInstanceId: 501 }];
+      const request = deferred<{ slotId: number }>();
+      equipmentApi.getEquippedGearApi.mockResolvedValue(occupied);
+      equipmentApi.unequipGearApi.mockReturnValue(request.promise);
+      const { result } = renderHook(() => useEquipmentQueries());
+      await waitFor(() => expect(result.current.slots[0]?.slot.itemInstanceId).toBe(501));
+
+      let mutation!: Promise<void>;
+      act(() => {
+        mutation = result.current.unequip(21);
+        void result.current.unequip(21);
+      });
+      expect(equipmentApi.unequipGearApi).toHaveBeenCalledTimes(1);
+      equipmentApi.getEquippedGearApi.mockResolvedValue(slots);
+
+      await act(async () => {
+        request.reject(new Error("response lost"));
+        await mutation;
+      });
+
+      expect(result.current.slots[0].slot.itemInstanceId).toBeNull();
+      expect(equipmentApi.getEquippedGearApi).toHaveBeenCalledTimes(2);
+      expect(inventoryApi.getInventoryApi).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("backend가 Equip을 명시적으로 거절하면", () => {
+    it("server message를 표시하고 authoritative reload state를 유지한다", async () => {
+      equipmentApi.equipGearApi.mockRejectedValue(new ApiError(409, "PEQ-409", "Item is already equipped"));
+      const { result } = renderHook(() => useEquipmentQueries());
+      await waitFor(() => expect(result.current.slots).toHaveLength(1));
+
+      await act(async () => { await result.current.equip(21, 501); });
+
+      expect(result.current.mutationError).toBe("Equipment request was rejected. Server state was reloaded. Item is already equipped");
+      expect(equipmentApi.getEquippedGearApi).toHaveBeenCalledTimes(2);
+      expect(inventoryApi.getInventoryApi).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("pre-mutation Equipment request가 recovery 뒤에 끝나면", () => {
+    it("stale success가 recovery state를 덮어쓰지 않는다", async () => {
+      const stale = deferred<EquipmentSlotInfo[]>();
+      const recovered = [{ ...slots[0], itemInstanceId: 501 }];
+      equipmentApi.getEquippedGearApi.mockReturnValueOnce(stale.promise).mockResolvedValueOnce(recovered);
+      const { result } = renderHook(() => useEquipmentQueries());
+      await waitFor(() => expect(equipmentApi.getEquippedGearApi).toHaveBeenCalledTimes(1));
+
+      await act(async () => { await result.current.equip(21, 501); });
+      expect(result.current.equipment.data).toEqual(recovered);
+
+      await act(async () => {
+        stale.resolve(slots);
+        await stale.promise;
+      });
+      expect(result.current.equipment.data).toEqual(recovered);
+      expect(result.current.equipment.error).toBeNull();
+    });
+
+    it("stale error가 recovery state와 loading/error를 바꾸지 않는다", async () => {
+      const stale = deferred<EquipmentSlotInfo[]>();
+      const recovered = [{ ...slots[0], itemInstanceId: 501 }];
+      equipmentApi.getEquippedGearApi.mockReturnValueOnce(stale.promise).mockResolvedValueOnce(recovered);
+      const { result } = renderHook(() => useEquipmentQueries());
+      await waitFor(() => expect(equipmentApi.getEquippedGearApi).toHaveBeenCalledTimes(1));
+
+      await act(async () => { await result.current.equip(21, 501); });
+      await act(async () => {
+        stale.reject(new Error("stale equipment failure"));
+        await stale.promise.catch(() => undefined);
+      });
+
+      expect(result.current.equipment.data).toEqual(recovered);
+      expect(result.current.equipment.loading).toBe(false);
+      expect(result.current.equipment.error).toBeNull();
+    });
+  });
+
+  describe("pre-mutation Inventory request가 recovery 뒤에 끝나면", () => {
+    it("stale success가 recovered Inventory enrichment를 덮어쓰지 않는다", async () => {
+      const stale = deferred<InventoryEntriesResponse>();
+      const recovered = { entries: [{ ...item, itemName: "Recovered Sword" }] };
+      inventoryApi.getInventoryApi.mockReturnValueOnce(stale.promise).mockResolvedValueOnce(recovered);
+      const { result } = renderHook(() => useEquipmentQueries());
+      await waitFor(() => expect(inventoryApi.getInventoryApi).toHaveBeenCalledTimes(1));
+
+      await act(async () => { await result.current.equip(21, 501); });
+      expect(result.current.inventory.data).toEqual(recovered);
+
+      await act(async () => {
+        stale.resolve(inventory);
+        await stale.promise;
+      });
+      expect(result.current.inventory.data).toEqual(recovered);
+      expect(result.current.inventory.error).toBeNull();
+    });
+
+    it("stale error가 recovered Inventory data/loading/error를 바꾸지 않는다", async () => {
+      const stale = deferred<InventoryEntriesResponse>();
+      const recovered = { entries: [{ ...item, itemName: "Recovered Sword" }] };
+      inventoryApi.getInventoryApi.mockReturnValueOnce(stale.promise).mockResolvedValueOnce(recovered);
+      const { result } = renderHook(() => useEquipmentQueries());
+      await waitFor(() => expect(inventoryApi.getInventoryApi).toHaveBeenCalledTimes(1));
+
+      await act(async () => { await result.current.equip(21, 501); });
+      await act(async () => {
+        stale.reject(new Error("stale Inventory failure"));
+        await stale.promise.catch(() => undefined);
+      });
+
+      expect(result.current.inventory.data).toEqual(recovered);
+      expect(result.current.inventory.loading).toBe(false);
+      expect(result.current.inventory.error).toBeNull();
+    });
+  });
+});

--- a/features/inventory/useEquipmentQueries.test.tsx
+++ b/features/inventory/useEquipmentQueries.test.tsx
@@ -76,7 +76,7 @@ describe("Gear server query state를 관리할 때", () => {
       const request = deferred<{ slotId: number; itemInstanceId: number }>();
       equipmentApi.equipGearApi.mockReturnValue(request.promise);
       const { result } = renderHook(() => useEquipmentQueries());
-      await waitFor(() => expect(result.current.slots).toHaveLength(1));
+      await waitFor(() => expect(result.current.inventory.data.entries).toHaveLength(1));
 
       let mutation!: Promise<void>;
       act(() => {
@@ -100,11 +100,37 @@ describe("Gear server query state를 관리할 때", () => {
     });
   });
 
+  describe("직접 Equip action을 호출한 pair가 검증되지 않으면", () => {
+    it.each([
+      ["CHEST", "ARMOR", "HELMET", "incompatible"],
+      ["HEAD", "ARMOR", "CHEST", "incompatible"],
+      ["FEET", "ARMOR", "ETC", "not available"],
+      ["LEGS", "ARMOR", "ETC", "not available"],
+      ["HANDS", "ARMOR", "ETC", "not available"],
+      ["NECK", "ACCESSORY", "ETC", "not available"],
+      ["TRINKET", "ACCESSORY", "ETC", "not available"],
+    ])("%s slot과 %s/%s item은 API 호출로 우회되지 않는다", async (slotCategory, category, type, reason) => {
+      equipmentApi.getEquippedGearApi.mockResolvedValue([{ ...slots[0], slotCategory }]);
+      inventoryApi.getInventoryApi.mockResolvedValue({ entries: [{ ...item, category, type }] });
+      const { result, unmount } = renderHook(() => useEquipmentQueries());
+      await waitFor(() => expect(result.current.inventory.data.entries).toHaveLength(1));
+
+      await act(async () => { await result.current.equip(21, 501); });
+
+      expect(equipmentApi.equipGearApi).not.toHaveBeenCalled();
+      expect(result.current.mutationError).toContain(reason);
+      expect(equipmentApi.getEquippedGearApi).toHaveBeenCalledTimes(1);
+      expect(inventoryApi.getInventoryApi).toHaveBeenCalledTimes(1);
+      unmount();
+    });
+  });
+
   describe("Unequip을 요청하면", () => {
-    it("duplicate submit을 막고 ambiguous failure 후에도 두 authoritative query를 reload한다", async () => {
-      const occupied = [{ ...slots[0], itemInstanceId: 501 }];
+    it("UNVERIFIABLE occupied slot도 해제하며 duplicate submit과 ambiguous failure를 복구한다", async () => {
+      const occupied = [{ ...slots[0], slotCategory: "FEET", itemInstanceId: 501 }];
       const request = deferred<{ slotId: number }>();
       equipmentApi.getEquippedGearApi.mockResolvedValue(occupied);
+      inventoryApi.getInventoryApi.mockResolvedValue({ entries: [{ ...item, category: "ARMOR", type: "ETC" }] });
       equipmentApi.unequipGearApi.mockReturnValue(request.promise);
       const { result } = renderHook(() => useEquipmentQueries());
       await waitFor(() => expect(result.current.slots[0]?.slot.itemInstanceId).toBe(501));
@@ -132,7 +158,7 @@ describe("Gear server query state를 관리할 때", () => {
     it("server message를 표시하고 authoritative reload state를 유지한다", async () => {
       equipmentApi.equipGearApi.mockRejectedValue(new ApiError(409, "PEQ-409", "Item is already equipped"));
       const { result } = renderHook(() => useEquipmentQueries());
-      await waitFor(() => expect(result.current.slots).toHaveLength(1));
+      await waitFor(() => expect(result.current.inventory.data.entries).toHaveLength(1));
 
       await act(async () => { await result.current.equip(21, 501); });
 
@@ -146,9 +172,10 @@ describe("Gear server query state를 관리할 때", () => {
     it("stale success가 recovery state를 덮어쓰지 않는다", async () => {
       const stale = deferred<EquipmentSlotInfo[]>();
       const recovered = [{ ...slots[0], itemInstanceId: 501 }];
-      equipmentApi.getEquippedGearApi.mockReturnValueOnce(stale.promise).mockResolvedValueOnce(recovered);
       const { result } = renderHook(() => useEquipmentQueries());
-      await waitFor(() => expect(equipmentApi.getEquippedGearApi).toHaveBeenCalledTimes(1));
+      await waitFor(() => expect(result.current.inventory.data.entries).toHaveLength(1));
+      equipmentApi.getEquippedGearApi.mockReturnValueOnce(stale.promise).mockResolvedValueOnce(recovered);
+      act(() => { void result.current.equipment.reload(); });
 
       await act(async () => { await result.current.equip(21, 501); });
       expect(result.current.equipment.data).toEqual(recovered);
@@ -164,9 +191,10 @@ describe("Gear server query state를 관리할 때", () => {
     it("stale error가 recovery state와 loading/error를 바꾸지 않는다", async () => {
       const stale = deferred<EquipmentSlotInfo[]>();
       const recovered = [{ ...slots[0], itemInstanceId: 501 }];
-      equipmentApi.getEquippedGearApi.mockReturnValueOnce(stale.promise).mockResolvedValueOnce(recovered);
       const { result } = renderHook(() => useEquipmentQueries());
-      await waitFor(() => expect(equipmentApi.getEquippedGearApi).toHaveBeenCalledTimes(1));
+      await waitFor(() => expect(result.current.inventory.data.entries).toHaveLength(1));
+      equipmentApi.getEquippedGearApi.mockReturnValueOnce(stale.promise).mockResolvedValueOnce(recovered);
+      act(() => { void result.current.equipment.reload(); });
 
       await act(async () => { await result.current.equip(21, 501); });
       await act(async () => {
@@ -184,9 +212,10 @@ describe("Gear server query state를 관리할 때", () => {
     it("stale success가 recovered Inventory enrichment를 덮어쓰지 않는다", async () => {
       const stale = deferred<InventoryEntriesResponse>();
       const recovered = { entries: [{ ...item, itemName: "Recovered Sword" }] };
-      inventoryApi.getInventoryApi.mockReturnValueOnce(stale.promise).mockResolvedValueOnce(recovered);
       const { result } = renderHook(() => useEquipmentQueries());
-      await waitFor(() => expect(inventoryApi.getInventoryApi).toHaveBeenCalledTimes(1));
+      await waitFor(() => expect(result.current.inventory.data.entries).toHaveLength(1));
+      inventoryApi.getInventoryApi.mockReturnValueOnce(stale.promise).mockResolvedValueOnce(recovered);
+      act(() => { void result.current.inventory.reload(); });
 
       await act(async () => { await result.current.equip(21, 501); });
       expect(result.current.inventory.data).toEqual(recovered);
@@ -202,9 +231,10 @@ describe("Gear server query state를 관리할 때", () => {
     it("stale error가 recovered Inventory data/loading/error를 바꾸지 않는다", async () => {
       const stale = deferred<InventoryEntriesResponse>();
       const recovered = { entries: [{ ...item, itemName: "Recovered Sword" }] };
-      inventoryApi.getInventoryApi.mockReturnValueOnce(stale.promise).mockResolvedValueOnce(recovered);
       const { result } = renderHook(() => useEquipmentQueries());
-      await waitFor(() => expect(inventoryApi.getInventoryApi).toHaveBeenCalledTimes(1));
+      await waitFor(() => expect(result.current.inventory.data.entries).toHaveLength(1));
+      inventoryApi.getInventoryApi.mockReturnValueOnce(stale.promise).mockResolvedValueOnce(recovered);
+      act(() => { void result.current.inventory.reload(); });
 
       await act(async () => { await result.current.equip(21, 501); });
       await act(async () => {

--- a/features/inventory/useEquipmentQueries.ts
+++ b/features/inventory/useEquipmentQueries.ts
@@ -1,0 +1,65 @@
+"use client";
+
+import { useMemo, useRef, useState } from "react";
+
+import type { EquipmentSlotInfo } from "@/shared/api/types";
+import { ApiError } from "@/shared/api/client";
+import { equipGearApi, getEquippedGearApi, unequipGearApi } from "@/lib/api/endpoints/equipment.api";
+import { composeEquipmentSlots } from "./model";
+import { useInventoryEntries, useLatestQuery } from "./useInventoryQueries";
+
+const loadEquipment = () => getEquippedGearApi();
+
+function message(caught: unknown, fallback: string): string {
+  return caught instanceof Error ? caught.message : fallback;
+}
+
+export function useEquipmentQueries() {
+  const equipment = useLatestQuery<EquipmentSlotInfo[]>([], loadEquipment, "Unable to load Equipment.");
+  const inventory = useInventoryEntries();
+  const [pendingKey, setPendingKey] = useState<string | null>(null);
+  const [mutationError, setMutationError] = useState<string | null>(null);
+  const mutationLocked = useRef(false);
+  const slots = useMemo(
+    () => composeEquipmentSlots(equipment.data, inventory.data.entries),
+    [equipment.data, inventory.data.entries],
+  );
+
+  const runMutation = async (key: string, request: () => Promise<unknown>) => {
+    if (mutationLocked.current) return;
+    mutationLocked.current = true;
+    setPendingKey(key);
+    setMutationError(null);
+    let requestError: unknown = null;
+    try {
+      try {
+        await request();
+      } catch (caught) {
+        requestError = caught;
+      }
+      const [nextEquipment, nextInventory] = await Promise.all([equipment.reload(), inventory.reload()]);
+      if (requestError) {
+        setMutationError(requestError instanceof ApiError
+          ? `Equipment request was rejected. Server state was reloaded. ${requestError.message}`
+          : `Request outcome was not confirmed. Server state was reloaded. ${message(requestError, "")}`.trim());
+      } else if (!nextEquipment || !nextInventory) {
+        setMutationError("Equipment changed, but authoritative recovery failed. Retry the failed query.");
+      }
+    } finally {
+      mutationLocked.current = false;
+      setPendingKey(null);
+    }
+  };
+
+  const equip = (slotId: number, itemInstanceId: number) => runMutation(
+    `equip-${slotId}`,
+    () => equipGearApi(slotId, itemInstanceId),
+  );
+
+  const unequip = (slotId: number) => runMutation(
+    `unequip-${slotId}`,
+    () => unequipGearApi(slotId),
+  );
+
+  return { equipment, inventory, slots, pendingKey, mutationError, equip, unequip };
+}

--- a/features/inventory/useEquipmentQueries.ts
+++ b/features/inventory/useEquipmentQueries.ts
@@ -5,7 +5,7 @@ import { useMemo, useRef, useState } from "react";
 import type { EquipmentSlotInfo } from "@/shared/api/types";
 import { ApiError } from "@/shared/api/client";
 import { equipGearApi, getEquippedGearApi, unequipGearApi } from "@/lib/api/endpoints/equipment.api";
-import { composeEquipmentSlots } from "./model";
+import { composeEquipmentSlots, getEquipCompatibility } from "./model";
 import { useInventoryEntries, useLatestQuery } from "./useInventoryQueries";
 
 const loadEquipment = () => getEquippedGearApi();
@@ -51,10 +51,21 @@ export function useEquipmentQueries() {
     }
   };
 
-  const equip = (slotId: number, itemInstanceId: number) => runMutation(
-    `equip-${slotId}`,
-    () => equipGearApi(slotId, itemInstanceId),
-  );
+  const equip = async (slotId: number, itemInstanceId: number) => {
+    if (mutationLocked.current) return;
+    const slot = equipment.data.find((entry) => entry.slotId === slotId);
+    const item = inventory.data.entries.find((entry) => entry.itemInstanceId === itemInstanceId);
+    if (!slot || !item) {
+      setMutationError("The selected Equipment slot or Inventory item is no longer available.");
+      return;
+    }
+    const compatibility = getEquipCompatibility(slot, item);
+    if (compatibility.status !== "VERIFIED") {
+      setMutationError(compatibility.reason);
+      return;
+    }
+    await runMutation(`equip-${slotId}`, () => equipGearApi(slotId, itemInstanceId));
+  };
 
   const unequip = (slotId: number) => runMutation(
     `unequip-${slotId}`,

--- a/features/inventory/useInventoryQueries.ts
+++ b/features/inventory/useInventoryQueries.ts
@@ -5,7 +5,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import type { InventoryEntriesResponse, MailboxEntriesResponse, MailEntry } from "@/shared/api/types";
 import { claimMailApi, deleteMailApi, getInventoryApi, getMailboxApi } from "@/lib/api/endpoints/inventory.api";
 
-type QueryState<T> = {
+export type QueryState<T> = {
   data: T;
   loading: boolean;
   error: string | null;
@@ -16,7 +16,7 @@ function message(caught: unknown, fallback: string): string {
   return caught instanceof Error ? caught.message : fallback;
 }
 
-function useLatestQuery<T>(initial: T, load: () => Promise<T>, fallback: string): QueryState<T> {
+export function useLatestQuery<T>(initial: T, load: () => Promise<T>, fallback: string): QueryState<T> {
   const [data, setData] = useState(initial);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -45,9 +45,17 @@ function useLatestQuery<T>(initial: T, load: () => Promise<T>, fallback: string)
 const loadInventory = () => getInventoryApi();
 const loadMailbox = () => getMailboxApi();
 
+export function useInventoryEntries() {
+  return useLatestQuery<InventoryEntriesResponse>({ entries: [] }, loadInventory, "Unable to load Items.");
+}
+
+function useMailboxEntries() {
+  return useLatestQuery<MailboxEntriesResponse>({ entries: [] }, loadMailbox, "Unable to load Inbox.");
+}
+
 export function useInventoryQueries() {
-  const inventory = useLatestQuery<InventoryEntriesResponse>({ entries: [] }, loadInventory, "Unable to load Items.");
-  const mailbox = useLatestQuery<MailboxEntriesResponse>({ entries: [] }, loadMailbox, "Unable to load Inbox.");
+  const inventory = useInventoryEntries();
+  const mailbox = useMailboxEntries();
   const mutationLocked = useRef(false);
   const [pendingKey, setPendingKey] = useState<string | null>(null);
   const [mutationError, setMutationError] = useState<string | null>(null);

--- a/lib/api/endpoints/equipment.api.test.ts
+++ b/lib/api/endpoints/equipment.api.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { equipGearApi, getEquippedGearApi, unequipGearApi } from "./equipment.api";
+import { equipmentMock } from "../mock/equipment.mock";
+
+const client = vi.hoisted(() => ({
+  apiDelete: vi.fn(),
+  apiGet: vi.fn(),
+  apiPut: vi.fn(),
+}));
+
+vi.mock("@/shared/api/client", () => ({ USE_MOCK: false, ...client }));
+
+describe("Equipment를 실제 backend에 연결할 때", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    equipmentMock.reset();
+  });
+
+  describe("현재 player의 equipment infos를 조회하면", () => {
+    it("result.infos를 exact endpoint에서 꺼내 반환한다", async () => {
+      const infos = [{ slotId: 42, slotCode: "RING_LEFT", slotName: "Left Ring", slotCategory: "RING", slotRole: "LEFT", itemInstanceId: null }];
+      client.apiGet.mockResolvedValue({ infos });
+
+      await expect(getEquippedGearApi()).resolves.toEqual(infos);
+      expect(client.apiGet).toHaveBeenCalledWith("/api/v1/players/equipment");
+    });
+  });
+
+  describe("명시적으로 선택한 slot을 변경하면", () => {
+    it("equip은 실제 slotId path와 itemInstanceId body를 사용한다", async () => {
+      client.apiPut.mockResolvedValue({ slotId: 42, itemInstanceId: 501 });
+
+      await equipGearApi(42, 501);
+
+      expect(client.apiPut).toHaveBeenCalledWith("/api/v1/players/equipment/42", { itemInstanceId: 501 });
+    });
+
+    it("unequip은 itemInstanceId가 아닌 실제 slotId path를 사용한다", async () => {
+      client.apiDelete.mockResolvedValue({ slotId: 42 });
+
+      await unequipGearApi(42);
+
+      expect(client.apiDelete).toHaveBeenCalledWith("/api/v1/players/equipment/42");
+    });
+  });
+
+  describe("mock equipment contract를 사용하면", () => {
+    it("API DTO에는 composed item metadata가 없고 mutation은 itemInstanceId만 바꾼다", () => {
+      const before = equipmentMock.infos().infos[0];
+      equipmentMock.equip(before.slotId, 999);
+      const after = equipmentMock.infos().infos[0];
+
+      expect(Object.keys(before)).toEqual(["slotId", "slotCode", "slotName", "slotCategory", "slotRole", "itemInstanceId"]);
+      expect(after).toEqual({ ...before, itemInstanceId: 999 });
+      expect(after).not.toHaveProperty("itemName");
+      expect(after).not.toHaveProperty("itemRarity");
+      expect(after).not.toHaveProperty("itemAttrs");
+    });
+  });
+});

--- a/lib/api/endpoints/equipment.api.ts
+++ b/lib/api/endpoints/equipment.api.ts
@@ -1,113 +1,22 @@
-import { USE_MOCK, apiGet, apiPut, apiDelete } from "../client";
-import { MOCK_INVENTORY_ITEMS } from "../mock/inventory.mock";
-import type { EquipmentSlotInfo, EquippedResponse, UnequippedResponse } from "@/shared/api/types";
-
-// Mock: Kirito의 장착 슬롯 (slotCode는 백엔드에서 정의)
-const MOCK_EQUIPMENT_SLOTS: EquipmentSlotInfo[] = [
-  {
-    slotId: 1,
-    slotCode: "MAIN_HAND",
-    slotName: "주무기",
-    slotCategory: "Weapon",
-    slotRole: "DAMAGE",
-    itemInstanceId: 1, // Elucidator
-    itemName: "Elucidator",
-    itemRarity: "Legendary",
-    itemAttrs: { atk: 850, crit: 18 },
-  },
-  {
-    slotId: 2,
-    slotCode: "OFF_HAND",
-    slotName: "보조무기",
-    slotCategory: "Weapon",
-    slotRole: "DAMAGE",
-    itemInstanceId: 2, // Dark Repulser
-    itemName: "Dark Repulser",
-    itemRarity: "Legendary",
-    itemAttrs: { atk: 820, magic: 120 },
-  },
-  {
-    slotId: 3,
-    slotCode: "CHEST",
-    slotName: "상체",
-    slotCategory: "Armor",
-    slotRole: "DEFENSE",
-    itemInstanceId: 3, // Black Coat of Midnight
-    itemName: "Black Coat of Midnight",
-    itemRarity: "Epic",
-    itemAttrs: { def: 340, agi: 45 },
-  },
-  {
-    slotId: 4,
-    slotCode: "BOOTS",
-    slotName: "신발",
-    slotCategory: "Boots",
-    slotRole: "MOBILITY",
-    itemInstanceId: 4, // Windrunner Boots
-    itemName: "Windrunner Boots",
-    itemRarity: "Rare",
-    itemAttrs: { def: 120, speed: 25 },
-  },
-  {
-    slotId: 5,
-    slotCode: "ACCESSORY_1",
-    slotName: "악세서리 1",
-    slotCategory: "Accessory",
-    slotRole: "UTILITY",
-    itemInstanceId: null,
-    itemName: undefined,
-    itemRarity: undefined,
-    itemAttrs: undefined,
-  },
-  {
-    slotId: 6,
-    slotCode: "ACCESSORY_2",
-    slotName: "악세서리 2",
-    slotCategory: "Accessory",
-    slotRole: "UTILITY",
-    itemInstanceId: null,
-    itemName: undefined,
-    itemRarity: undefined,
-    itemAttrs: undefined,
-  },
-];
-
-// In-memory mock equip state (changes are not persisted)
-let mockEquipState = [...MOCK_EQUIPMENT_SLOTS];
+import { USE_MOCK, apiDelete, apiGet, apiPut } from "@/shared/api/client";
+import type { EquipmentInfosResponse, EquipmentSlotInfo, EquippedResponse, UnequippedResponse } from "@/shared/api/types";
+import { equipmentMock } from "../mock/equipment.mock";
 
 export async function getEquippedGearApi(): Promise<EquipmentSlotInfo[]> {
-  if (USE_MOCK) return mockEquipState;
-  const res = await apiGet<{ infos: EquipmentSlotInfo[] }>("/api/v1/players/equipment");
+  const res = USE_MOCK
+    ? equipmentMock.infos()
+    : await apiGet<EquipmentInfosResponse>("/api/v1/players/equipment");
   return res.infos;
 }
 
-export async function equipGearApi(slotId: number, itemInstanceId: number): Promise<EquippedResponse> {
-  if (USE_MOCK) {
-    const item = MOCK_INVENTORY_ITEMS.find((i) => i.itemInstanceId === itemInstanceId);
-    mockEquipState = mockEquipState.map((slot) =>
-      slot.slotId === slotId
-        ? {
-            ...slot,
-            itemInstanceId,
-            itemName: item?.itemName,
-            itemRarity: item?.rarity,
-            itemAttrs: item?.instanceAttrs as Record<string, unknown>,
-          }
-        : slot,
-    );
-    return { slotId, itemInstanceId };
-  }
-  return apiPut<EquippedResponse>(`/api/v1/players/equipment/${slotId}`, { itemInstanceId });
+export function equipGearApi(slotId: number, itemInstanceId: number): Promise<EquippedResponse> {
+  return USE_MOCK
+    ? Promise.resolve(equipmentMock.equip(slotId, itemInstanceId))
+    : apiPut<EquippedResponse>(`/api/v1/players/equipment/${slotId}`, { itemInstanceId });
 }
 
-export async function unequipGearApi(slotId: number): Promise<UnequippedResponse> {
-  if (USE_MOCK) {
-    mockEquipState = mockEquipState.map((slot) =>
-      slot.slotId === slotId
-        ? { ...slot, itemInstanceId: null, itemName: undefined, itemRarity: undefined, itemAttrs: undefined }
-        : slot,
-    );
-    return { slotId };
-  }
-  return apiDelete<UnequippedResponse>(`/api/v1/players/equipment/${slotId}`);
+export function unequipGearApi(slotId: number): Promise<UnequippedResponse> {
+  return USE_MOCK
+    ? Promise.resolve(equipmentMock.unequip(slotId))
+    : apiDelete<UnequippedResponse>(`/api/v1/players/equipment/${slotId}`);
 }

--- a/lib/api/mock/equipment.mock.ts
+++ b/lib/api/mock/equipment.mock.ts
@@ -1,0 +1,33 @@
+import type { EquipmentSlotInfo } from "@/shared/api/types";
+
+const INITIAL_EQUIPMENT_SLOTS: EquipmentSlotInfo[] = [
+  { slotId: 1, slotCode: "MAIN_HAND", slotName: "Main Hand", slotCategory: "WEAPON", slotRole: "MAIN", itemInstanceId: 1 },
+  { slotId: 2, slotCode: "OFF_HAND", slotName: "Off Hand", slotCategory: "WEAPON", slotRole: "OFFHAND", itemInstanceId: 2 },
+  { slotId: 3, slotCode: "HEAD", slotName: "Head", slotCategory: "HEAD", slotRole: "SINGLE", itemInstanceId: 14 },
+  { slotId: 4, slotCode: "CHEST", slotName: "Chest", slotCategory: "CHEST", slotRole: "SINGLE", itemInstanceId: 3 },
+  { slotId: 5, slotCode: "HANDS", slotName: "Hands", slotCategory: "HANDS", slotRole: "SINGLE", itemInstanceId: 13 },
+  { slotId: 6, slotCode: "LEGS", slotName: "Legs", slotCategory: "LEGS", slotRole: "SINGLE", itemInstanceId: null },
+  { slotId: 7, slotCode: "FEET", slotName: "Feet", slotCategory: "FEET", slotRole: "SINGLE", itemInstanceId: 4 },
+  { slotId: 8, slotCode: "NECK", slotName: "Neck", slotCategory: "NECK", slotRole: "SINGLE", itemInstanceId: null },
+  { slotId: 9, slotCode: "RING_LEFT", slotName: "Left Ring", slotCategory: "RING", slotRole: "LEFT", itemInstanceId: 18 },
+  { slotId: 10, slotCode: "RING_RIGHT", slotName: "Right Ring", slotCategory: "RING", slotRole: "RIGHT", itemInstanceId: null },
+  { slotId: 11, slotCode: "TRINKET", slotName: "Trinket", slotCategory: "TRINKET", slotRole: "SINGLE", itemInstanceId: null },
+];
+
+const copy = <T,>(value: T): T => structuredClone(value);
+let slots = copy(INITIAL_EQUIPMENT_SLOTS);
+
+export const equipmentMock = {
+  infos: () => ({ infos: copy(slots) }),
+  equip: (slotId: number, itemInstanceId: number) => {
+    if (!slots.some((slot) => slot.slotId === slotId)) throw new Error("Equipment slot not found.");
+    slots = slots.map((slot) => slot.slotId === slotId ? { ...slot, itemInstanceId } : slot);
+    return { slotId, itemInstanceId };
+  },
+  unequip: (slotId: number) => {
+    if (!slots.some((slot) => slot.slotId === slotId)) throw new Error("Equipment slot not found.");
+    slots = slots.map((slot) => slot.slotId === slotId ? { ...slot, itemInstanceId: null } : slot);
+    return { slotId };
+  },
+  reset: () => { slots = copy(INITIAL_EQUIPMENT_SLOTS); },
+};

--- a/lib/api/mock/inventory.mock.ts
+++ b/lib/api/mock/inventory.mock.ts
@@ -1,43 +1,27 @@
 import type { InventoryEntry, MailboxClaimRequest, MailboxDeleteRequest, MailEntry } from "../types";
 
 export const MOCK_INVENTORY_ITEMS: InventoryEntry[] = [
-  { itemInstanceId: 1, slotIndex: 0, itemId: 1001, itemName: "Elucidator", category: "Weapon", type: "Sword", rarity: "Legendary", stackable: false, maxStack: 1, quantity: 1, bound: true, durability: 98, instanceAttrs: { atk: 850, crit: 18 } },
-  { itemInstanceId: 2, slotIndex: 1, itemId: 1002, itemName: "Dark Repulser", category: "Weapon", type: "Sword", rarity: "Legendary", stackable: false, maxStack: 1, quantity: 1, bound: true, durability: 95, instanceAttrs: { atk: 820, magic: 120 } },
-  { itemInstanceId: 3, slotIndex: 2, itemId: 2001, itemName: "Black Coat of Midnight", category: "Armor", type: "Coat", rarity: "Epic", stackable: false, maxStack: 1, quantity: 1, bound: true, durability: 88, instanceAttrs: { def: 340, agi: 45 } },
-  { itemInstanceId: 4, slotIndex: 3, itemId: 2002, itemName: "Windrunner Boots", category: "Boots", type: "Boots", rarity: "Rare", stackable: false, maxStack: 1, quantity: 1, bound: false, durability: 72, instanceAttrs: { def: 120, speed: 25 } },
+  { itemInstanceId: 1, slotIndex: 0, itemId: 1001, itemName: "Elucidator", category: "WEAPON", type: "SWORD", rarity: "LEGENDARY", stackable: false, maxStack: 1, quantity: 1, bound: true, durability: 98, instanceAttrs: { atk: 850, crit: 18 } },
+  { itemInstanceId: 2, slotIndex: 1, itemId: 1002, itemName: "Dark Repulser", category: "WEAPON", type: "SWORD", rarity: "LEGENDARY", stackable: false, maxStack: 1, quantity: 1, bound: true, durability: 95, instanceAttrs: { atk: 820, magic: 120 } },
+  { itemInstanceId: 3, slotIndex: 2, itemId: 2001, itemName: "Black Coat of Midnight", category: "ARMOR", type: "CHEST", rarity: "EPIC", stackable: false, maxStack: 1, quantity: 1, bound: true, durability: 88, instanceAttrs: { def: 340, agi: 45 } },
+  { itemInstanceId: 4, slotIndex: 3, itemId: 2002, itemName: "Windrunner Boots", category: "ARMOR", type: "ETC", rarity: "RARE", stackable: false, maxStack: 1, quantity: 1, bound: false, durability: 72, instanceAttrs: { def: 120, speed: 25 } },
   { itemInstanceId: 5, slotIndex: 4, itemId: 3001, itemName: "HP Potion (M)", category: "Consumable", type: "Potion", rarity: "Common", stackable: true, maxStack: 99, quantity: 42, bound: false, durability: null, instanceAttrs: { heal: 500 } },
   { itemInstanceId: 6, slotIndex: 5, itemId: 3002, itemName: "MP Potion (S)", category: "Consumable", type: "Potion", rarity: "Common", stackable: true, maxStack: 99, quantity: 28, bound: false, durability: null, instanceAttrs: { restore: 200 } },
   { itemInstanceId: 7, slotIndex: 6, itemId: 4001, itemName: "Teleport Crystal", category: "Consumable", type: "Crystal", rarity: "Uncommon", stackable: true, maxStack: 10, quantity: 5, bound: false, durability: null, instanceAttrs: {} },
-  { itemInstanceId: 8, slotIndex: 7, itemId: 1003, itemName: "Pale Edge", category: "Weapon", type: "Sword", rarity: "Rare", stackable: false, maxStack: 1, quantity: 1, bound: false, durability: 100, instanceAttrs: { atk: 620, dex: 30 } },
-  { itemInstanceId: 9, slotIndex: 8, itemId: 1004, itemName: "Wind Fleuret", category: "Weapon", type: "Rapier", rarity: "Rare", stackable: false, maxStack: 1, quantity: 1, bound: false, durability: 85, instanceAttrs: { atk: 540, agi: 55 } },
+  { itemInstanceId: 8, slotIndex: 7, itemId: 1003, itemName: "Pale Edge", category: "WEAPON", type: "SWORD", rarity: "RARE", stackable: false, maxStack: 1, quantity: 1, bound: false, durability: 100, instanceAttrs: { atk: 620, dex: 30 } },
+  { itemInstanceId: 9, slotIndex: 8, itemId: 1004, itemName: "Wind Fleuret", category: "WEAPON", type: "SWORD", rarity: "RARE", stackable: false, maxStack: 1, quantity: 1, bound: false, durability: 85, instanceAttrs: { atk: 540, agi: 55 } },
   { itemInstanceId: 10, slotIndex: 9, itemId: 5001, itemName: "Iron Ore", category: "Material", type: "Ore", rarity: "Common", stackable: true, maxStack: 999, quantity: 156, bound: false, durability: null, instanceAttrs: {} },
   { itemInstanceId: 11, slotIndex: 10, itemId: 5002, itemName: "Mithril Ingot", category: "Material", type: "Ingot", rarity: "Rare", stackable: true, maxStack: 100, quantity: 12, bound: false, durability: null, instanceAttrs: {} },
   { itemInstanceId: 12, slotIndex: 11, itemId: 5003, itemName: "Dragon Scale", category: "Material", type: "Scale", rarity: "Epic", stackable: true, maxStack: 50, quantity: 4, bound: false, durability: null, instanceAttrs: {} },
-  { itemInstanceId: 13, slotIndex: 12, itemId: 2003, itemName: "Shadow Gauntlets", category: "Armor", type: "Gloves", rarity: "Uncommon", stackable: false, maxStack: 1, quantity: 1, bound: false, durability: 65, instanceAttrs: { def: 85, str: 12 } },
-  { itemInstanceId: 14, slotIndex: 13, itemId: 2004, itemName: "Frontliner's Helm", category: "Armor", type: "Helmet", rarity: "Rare", stackable: false, maxStack: 1, quantity: 1, bound: false, durability: 90, instanceAttrs: { def: 180, vit: 20 } },
+  { itemInstanceId: 13, slotIndex: 12, itemId: 2003, itemName: "Shadow Gauntlets", category: "ARMOR", type: "ETC", rarity: "UNCOMMON", stackable: false, maxStack: 1, quantity: 1, bound: false, durability: 65, instanceAttrs: { def: 85, str: 12 } },
+  { itemInstanceId: 14, slotIndex: 13, itemId: 2004, itemName: "Frontliner's Helm", category: "ARMOR", type: "HELMET", rarity: "RARE", stackable: false, maxStack: 1, quantity: 1, bound: false, durability: 90, instanceAttrs: { def: 180, vit: 20 } },
   { itemInstanceId: 15, slotIndex: 14, itemId: 6001, itemName: "Identification Scroll", category: "Misc", type: "Scroll", rarity: "Common", stackable: true, maxStack: 20, quantity: 8, bound: false, durability: null, instanceAttrs: {} },
   { itemInstanceId: 16, slotIndex: 15, itemId: 3003, itemName: "Antidote (S)", category: "Consumable", type: "Potion", rarity: "Common", stackable: true, maxStack: 50, quantity: 15, bound: false, durability: null, instanceAttrs: {} },
-  { itemInstanceId: 17, slotIndex: 16, itemId: 1005, itemName: "Anneal Blade", category: "Weapon", type: "Sword", rarity: "Uncommon", stackable: false, maxStack: 1, quantity: 1, bound: false, durability: 78, instanceAttrs: { atk: 420 } },
-  { itemInstanceId: 18, slotIndex: 17, itemId: 7001, itemName: "Lucky Charm", category: "Accessory", type: "Charm", rarity: "Uncommon", stackable: false, maxStack: 1, quantity: 1, bound: false, durability: null, instanceAttrs: { luc: 15 } },
+  { itemInstanceId: 17, slotIndex: 16, itemId: 1005, itemName: "Anneal Blade", category: "WEAPON", type: "SWORD", rarity: "UNCOMMON", stackable: false, maxStack: 1, quantity: 1, bound: false, durability: 78, instanceAttrs: { atk: 420 } },
+  { itemInstanceId: 18, slotIndex: 17, itemId: 7001, itemName: "Lucky Charm", category: "ACCESSORY", type: "ETC", rarity: "UNCOMMON", stackable: false, maxStack: 1, quantity: 1, bound: false, durability: null, instanceAttrs: { luc: 15 } },
   { itemInstanceId: 19, slotIndex: 18, itemId: 5004, itemName: "Ancient Wood", category: "Material", type: "Wood", rarity: "Rare", stackable: true, maxStack: 100, quantity: 23, bound: false, durability: null, instanceAttrs: {} },
   { itemInstanceId: 20, slotIndex: 19, itemId: 3004, itemName: "Revive Crystal", category: "Consumable", type: "Crystal", rarity: "Epic", stackable: true, maxStack: 3, quantity: 2, bound: false, durability: null, instanceAttrs: {} },
 ];
-
-export const MOCK_GEAR_WEAPONS: InventoryEntry[] = MOCK_INVENTORY_ITEMS.filter(
-  (item) => item.category === "Weapon",
-);
-
-export const MOCK_GEAR_ARMOR: InventoryEntry[] = MOCK_INVENTORY_ITEMS.filter(
-  (item) => item.category === "Armor",
-);
-
-export const MOCK_GEAR_ACCESSORIES: InventoryEntry[] = MOCK_INVENTORY_ITEMS.filter(
-  (item) => item.category === "Accessory",
-);
-
-export const MOCK_GEAR_BOOTS: InventoryEntry[] = MOCK_INVENTORY_ITEMS.filter(
-  (item) => item.category === "Boots",
-);
 
 export const MOCK_MAIL_ITEMS: MailEntry[] = [
   { mailId: 1, slotIndex: 0, itemId: 8001, itemName: "HP Potion (L)", category: "Consumable", type: "Potion", rarity: "Uncommon", stackable: true, maxStack: 99, quantity: 10, bound: false, durability: null, instanceAttrs: { from: "System", message: "Daily login reward!" } },

--- a/shared/api/types/equipment.ts
+++ b/shared/api/types/equipment.ts
@@ -5,9 +5,10 @@ export interface EquipmentSlotInfo {
   slotCategory: string;
   slotRole: string;
   itemInstanceId: number | null;
-  itemName?: string;
-  itemRarity?: string;
-  itemAttrs?: Record<string, unknown>;
+}
+
+export interface EquipmentInfosResponse {
+  infos: EquipmentSlotInfo[];
 }
 
 export interface EquippedResponse {


### PR DESCRIPTION
## Purpose

Replace the remaining mock-driven Gear runtime with the real player equipment contract composed with the real Inventory entries.

## Delivered

- real player equipment query
- exact equipment DTO contract
- Inventory-backed item enrichment by `itemInstanceId`
- real occupied/empty slot rendering
- explicit real slot targeting
- real equip flow
- real unequip flow
- authoritative mutation recovery
- latest-request-wins query safety
- real-contract equipment mocks
- feature-owned Gear state
- removal of mock slot-selection heuristics

## Backend contracts

Connected:

- `GET /api/v1/players/equipment`
- `PUT /api/v1/players/equipment/{slotId}`
- `DELETE /api/v1/players/equipment/{slotId}`
- `GET /api/v1/inventory`

Equipment remains slot authority.
Inventory remains item display authority.

## Corrected contract boundary

The equipment API is no longer modeled as returning:

- itemName
- itemRarity
- itemAttrs

Gear composes those values from Inventory using `itemInstanceId`.

## Product / architecture boundaries

- `slotId` is equipment endpoint identity
- `itemInstanceId` is Inventory item identity
- no arbitrary `slotId=1` fallback
- multi-slot targeting is explicit
- no optimistic final equipment state
- no Gear backend redesign
- no global state library
- Items and Inbox remain unchanged

## Tests

Coverage includes:

- exact equipment API mapping
- Inventory/equipment composition
- empty and occupied slots
- missing enrichment
- explicit target-slot semantics
- equip/unequip recovery
- stale request protection
- mock parity
- Inventory/Journal/Journey/Role/auth regressions

## Validation

- lint
- targeted tests
- full tests
- build

Closes #14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a dedicated inventory gear panel for viewing equipment slots and available items.
  - Added gear-part filtering and compatibility checks to help prevent invalid equipment choices.
  - Added confirmation prompts for equipping and unequipping items.
  - Added loading, empty, and error states with retry options.
  - Equipment and inventory data now refresh after gear changes to reflect authoritative updates.

- **Bug Fixes**
  - Improved handling of occupied slots when item details are unavailable.
  - Prevented stale selections and outdated results after data reloads or failed requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->