### PR TITLE
[Home] Connect first-world Home summary surface

### DIFF
--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -10,16 +10,17 @@ const auth = vi.hoisted(() => ({ state: { isAuthenticated: true, playerId: 7 as 
 const roles = vi.hoisted((): RoleDetail[] => [
   { id: 1, roleType: "PROFESSIONAL", name: "Backend Engineer", description: "Build systems", status: "ACTIVE", createdAt: "2026-01-01T00:00:00Z", updatedAt: "2026-01-01T00:00:00Z", version: 0 },
 ]);
+const roleHook = vi.hoisted(() => ({ useRoles: vi.fn(() => ({ roles, isLoading: false, error: null, refresh: vi.fn() })) }));
 
 vi.mock("next/navigation", () => ({ useRouter: () => router }));
 vi.mock("@/features/auth/AuthContext", () => ({ useAuth: () => auth.state }));
-vi.mock("@/features/role/useRoles", () => ({ useRoles: () => ({ roles, isLoading: false, error: null, refresh: vi.fn() }) }));
+vi.mock("@/features/role/useRoles", () => roleHook);
 vi.mock("@/context/ToastContext", () => ({ useToast: () => ({ showToast: vi.fn() }) }));
 vi.mock("@/shared/hooks/usePanScroll", () => ({ usePanScroll: vi.fn() }));
 vi.mock("@/widgets/left-context/LeftContext", () => ({ default: () => null }));
 vi.mock("@/widgets/orb-nav/OrbNav", () => ({
-  default: ({ items, onSelect }: { items: Array<{ id: MainNavId; label: string }>; onSelect: (id: MainNavId) => void }) => (
-    <nav>{items.map((item) => <button key={item.id} type="button" onClick={() => onSelect(item.id)}>{item.label}</button>)}</nav>
+  default: ({ items, selectedId, onSelect }: { items: Array<{ id: MainNavId; label: string }>; selectedId: MainNavId | null; onSelect: (id: MainNavId) => void }) => (
+    <nav>{items.map((item) => <button key={item.id} type="button" aria-pressed={selectedId === item.id} onClick={() => onSelect(item.id)}>{item.label}</button>)}</nav>
   ),
 }));
 vi.mock("@/widgets/right-panels/RightPanels", () => ({
@@ -34,8 +35,25 @@ vi.mock("@/widgets/right-panels/RightPanels", () => ({
 vi.mock("@/features/lifelog/JournalShell", () => ({ default: ({ roles: roleOptions }: { roles: RoleDetail[] }) => <div data-testid="journal-shell">Journal · {roleOptions.map(({ name }) => name).join(", ")}</div> }));
 vi.mock("@/features/inventory/InventoryShell", () => ({ default: ({ surface }: { surface: string }) => <div data-testid="inventory-shell">Inventory · {surface}</div> }));
 vi.mock("@/features/inventory/GearShell", () => ({ default: () => <div data-testid="gear-shell">Gear Shell</div> }));
-vi.mock("@/features/role/RoleShell", () => ({ default: () => <div data-testid="role-shell">Role Shell</div> }));
-vi.mock("@/features/quests/JourneyShell", () => ({ default: () => <div data-testid="journey-shell">Journey Shell</div> }));
+vi.mock("@/features/home/HomeShell", () => ({
+  default: ({ onOpenJournal, onOpenAchievements, onOpenCurrentQuests, onOpenRoutes, onOpenRole }: {
+    onOpenJournal: () => void;
+    onOpenAchievements: () => void;
+    onOpenCurrentQuests: () => void;
+    onOpenRoutes: () => void;
+    onOpenRole: (roleId: number) => void;
+  }) => (
+    <div data-testid="home-shell">
+      <button type="button" onClick={onOpenJournal}>Home Journal</button>
+      <button type="button" onClick={onOpenAchievements}>Home Achievement</button>
+      <button type="button" onClick={onOpenCurrentQuests}>Home Quest</button>
+      <button type="button" onClick={onOpenRoutes}>Home Route</button>
+      <button type="button" onClick={() => onOpenRole(1)}>Home Role</button>
+    </div>
+  ),
+}));
+vi.mock("@/features/role/RoleShell", () => ({ default: ({ selectedRoleId }: { selectedRoleId: number | null }) => <div data-testid="role-shell">Role Shell · {selectedRoleId}</div> }));
+vi.mock("@/features/quests/JourneyShell", () => ({ default: ({ initialSurface }: { initialSurface?: string }) => <div data-testid="journey-shell">Journey Shell · {initialSurface}</div> }));
 vi.mock("@/shared/ui/ParticleBackground", () => ({ default: () => null }));
 vi.mock("@/shared/ui/AmbientOverlay", () => ({ default: () => null }));
 vi.mock("@/shared/ui/SaoAlert", () => ({ default: () => null }));
@@ -46,6 +64,60 @@ describe("Home shell에서 feature surface를 routing할 때", () => {
     vi.clearAllMocks();
     auth.state = { isAuthenticated: true, playerId: 7, isLoading: false, logout: vi.fn() };
     vi.stubGlobal("requestAnimationFrame", () => 1);
+  });
+
+  describe("인증된 player가 처음 진입하면", () => {
+    it("Home을 표시하고 Home Orb나 active Orb를 만들지 않으며 Role API도 기다리게 한다", () => {
+      render(<Home />);
+
+      expect(screen.getByTestId("home-shell")).toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: /^Home$/ })).not.toBeInTheDocument();
+      expect(screen.getAllByRole("button", { pressed: false })).toHaveLength(8);
+      expect(roleHook.useRoles).toHaveBeenCalledWith(false);
+    });
+  });
+
+  describe("main Orb를 선택하면", () => {
+    it("feature를 열고 active Orb를 다시 누르면 Home으로 돌아간다", () => {
+      render(<Home />);
+
+      fireEvent.click(screen.getByRole("button", { name: "Player" }));
+      expect(screen.queryByTestId("home-shell")).not.toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Player" })).toHaveAttribute("aria-pressed", "true");
+
+      fireEvent.click(screen.getByRole("button", { name: "Player" }));
+      expect(screen.getByTestId("home-shell")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Player" })).toHaveAttribute("aria-pressed", "false");
+    });
+  });
+
+  describe("Home card에서 canonical surface를 열면", () => {
+    it("Journal, Quest, Route, Achievement, Role state만 orchestration한다", () => {
+      const { unmount } = render(<Home />);
+      fireEvent.click(screen.getByRole("button", { name: "Home Journal" }));
+      expect(screen.getByTestId("journal-shell")).toBeInTheDocument();
+      unmount();
+
+      const quest = render(<Home />);
+      fireEvent.click(screen.getByRole("button", { name: "Home Quest" }));
+      expect(screen.getByTestId("journey-shell")).toHaveTextContent("current");
+      quest.unmount();
+
+      const route = render(<Home />);
+      fireEvent.click(screen.getByRole("button", { name: "Home Route" }));
+      expect(screen.getByTestId("journey-shell")).toHaveTextContent("routes");
+      route.unmount();
+
+      const achievement = render(<Home />);
+      fireEvent.click(screen.getByRole("button", { name: "Home Achievement" }));
+      expect(screen.getByRole("button", { name: "Achievement" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Combat" })).toBeInTheDocument();
+      achievement.unmount();
+
+      render(<Home />);
+      fireEvent.click(screen.getByRole("button", { name: "Home Role" }));
+      expect(screen.getByTestId("role-shell")).toHaveTextContent("Role Shell · 1");
+    });
   });
 
   describe("인증된 player가 Journal을 선택하면", () => {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -16,6 +16,7 @@ import RoleShell from "@/features/role/RoleShell";
 import JournalShell from "@/features/lifelog/JournalShell";
 import InventoryShell from "@/features/inventory/InventoryShell";
 import GearShell from "@/features/inventory/GearShell";
+import HomeShell from "@/features/home/HomeShell";
 import { useRoles } from "@/features/role/useRoles";
 import { usePanScroll } from "@/shared/hooks/usePanScroll";
 import { MOCK_CHARACTER_SHEET } from "@/features/player/mock";
@@ -34,6 +35,7 @@ import type {
   PanelDataItem,
   PlayerSubId,
   PanelStackItem,
+  QuestsSubId,
   SocialContextData,
 } from "@/entities/nav";
 import {
@@ -478,7 +480,6 @@ export default function Home() {
   const router = useRouter();
   const { isAuthenticated, playerId, isLoading, logout } = useAuth();
   const playerInfo = MOCK_CHARACTER_SHEET.player;
-  const roleState = useRoles(Boolean(playerId));
 
   const viewportRef = useRef<HTMLDivElement>(null);
   const formOpenCountRef = useRef(0);
@@ -493,7 +494,8 @@ export default function Home() {
     else if (!playerId) router.replace("/linkstart");
   }, [isAuthenticated, isLoading, playerId, router]);
 
-  const [selectedMain, setSelectedMain] = useState<MainNavId>("player");
+  const [selectedMain, setSelectedMain] = useState<MainNavId | null>(null);
+  const roleState = useRoles(Boolean(playerId && (selectedMain === "player" || selectedMain === "role" || selectedMain === "lifelog")));
   const [selectedRoleId, setSelectedRoleId] = useState<number | null>(null);
   const [selectedSubByMain, setSelectedSubByMain] = useState<Record<MainNavId, string | null>>({
     ...DEFAULT_SUB_SELECTIONS,
@@ -574,8 +576,8 @@ export default function Home() {
   };
 
   const { panelStack: basePanelStack, socialContext } = useMemo(
-    () =>
-      buildPanels(
+    () => selectedMain
+      ? buildPanels(
         selectedMain,
         selectedSubByMain,
         selectedMarketShopSectionId,
@@ -584,7 +586,8 @@ export default function Home() {
         selectedLifelogCategoryBySub,
         editingItemId,
         Boolean(activeFormPanel),
-      ),
+      )
+      : { panelStack: [], socialContext: null },
     [
       selectedMain,
       selectedSubByMain,
@@ -622,12 +625,7 @@ export default function Home() {
   const getSurfaceZIndex = (surfaceId: string, groupBaseZ: number, layerBaseZ = 0) =>
     groupBaseZ + layerBaseZ + (surfaceFocusState.lastFocusBySurface[surfaceId] ?? 0);
 
-  const handleMainSelect = (nextMain: MainNavId) => {
-    if (nextMain === selectedMain) {
-      return;
-    }
-
-    setSelectedMain(nextMain);
+  const clearFeatureState = () => {
     setSelectedSubByMain({ ...DEFAULT_SUB_SELECTIONS });
     setSelectedMarketShopSectionId(null);
     setSelectedDetailByKey(createDefaultDetailSelections());
@@ -636,6 +634,18 @@ export default function Home() {
     setActiveFormPanel(null);
     setActiveSpecialPanel(null);
     setEditingItemId(null);
+  };
+
+  const handleMainSelect = (nextMain: MainNavId) => {
+    if (nextMain === selectedMain) {
+      setSelectedMain(null);
+      clearFeatureState();
+      setPendingAction(null);
+      return;
+    }
+
+    setSelectedMain(nextMain);
+    clearFeatureState();
   };
 
   const handleRoleSelect = (roleId: number) => {
@@ -734,6 +744,7 @@ export default function Home() {
     submitLabel?: string,
     prefillValues?: Record<string, string>,
   ) => {
+    if (!selectedMain) return;
     setActiveFormPanel({
       id: `form-${formKey}-${++formOpenCountRef.current}`,
       kind: "form",
@@ -812,6 +823,7 @@ export default function Home() {
 
   // Called from long press action buttons
   const handlePanelItemAction = (_panelIndex: number, itemId: string, actionType: string) => {
+    if (!selectedMain) return;
     const sub = selectedSubByMain[selectedMain];
 
     if (actionType === "edit") {
@@ -1023,6 +1035,7 @@ export default function Home() {
   // Double-click/tap on a category menu item → open create form (clears category so list hides)
   // Double-click/tap on a list item → open edit form
   const handlePanelItemDoubleClick = (panelIndex: number, itemId: string) => {
+    if (!selectedMain) return;
     const panel = panelStack[panelIndex];
 
     // Category panel double-click → create form
@@ -1207,7 +1220,27 @@ export default function Home() {
         </div>
 
         <div className="scrollbar-hide min-w-0 flex-1 overflow-x-auto" style={{ minWidth: UI_CONSTS.layout.rightMinWidth }}>
-          {selectedMain === "role" ? (
+          {selectedMain === null ? (
+            <HomeShell
+              onOpenJournal={() => {
+                handleMainSelect("lifelog");
+                setSelectedSubByMain({ ...DEFAULT_SUB_SELECTIONS, lifelog: "journal" });
+              }}
+              onOpenAchievements={() => {
+                handleMainSelect("player");
+                setSelectedSubByMain({ ...DEFAULT_SUB_SELECTIONS, player: "achievement" });
+              }}
+              onOpenCurrentQuests={() => {
+                handleMainSelect("quests");
+                setSelectedSubByMain({ ...DEFAULT_SUB_SELECTIONS, quests: "current" });
+              }}
+              onOpenRoutes={() => {
+                handleMainSelect("quests");
+                setSelectedSubByMain({ ...DEFAULT_SUB_SELECTIONS, quests: "routes" });
+              }}
+              onOpenRole={handleRoleSelect}
+            />
+          ) : selectedMain === "role" ? (
             <div className="flex w-fit items-center gap-3">
               <RoleShell
                 roles={roleState.roles}
@@ -1228,7 +1261,7 @@ export default function Home() {
               ) : null}
             </div>
           ) : selectedMain === "quests" ? (
-            <JourneyShell />
+            <JourneyShell initialSurface={(selectedSubByMain.quests as QuestsSubId | null) ?? "current"} />
           ) : selectedMain === "inventory" && selectedSubByMain.inventory ? (
             <div className="flex w-fit items-center gap-3">
               <RightPanels

--- a/entities/nav/config.test.ts
+++ b/entities/nav/config.test.ts
@@ -3,6 +3,12 @@ import { describe, expect, it } from "vitest";
 import { DEFAULT_SUB_SELECTIONS, MAIN_NAV_ITEMS, SUBMENUS_BY_MAIN } from "./config";
 
 describe("primary Orb navigation을 구성할 때", () => {
+  describe("Home을 default world surface로 사용하면", () => {
+    it("Home Orb를 추가하지 않는다", () => {
+      expect(MAIN_NAV_ITEMS.some(({ id }) => (id as string) === "home")).toBe(false);
+    });
+  });
+
   describe("Journey 정책을 적용하면", () => {
     it("Quest Orb를 Current/Catalog/Routes로 구성하고 Party/Guild Quest를 노출하지 않는다", () => {
       expect(MAIN_NAV_ITEMS.find(({ id }) => id === "quests")).toEqual({ id: "quests", label: "Journey", slotLabel: "QU" });

--- a/features/home/HomeShell.test.tsx
+++ b/features/home/HomeShell.test.tsx
@@ -1,0 +1,99 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { HomeSummary } from "./model";
+import { MOCK_HOME_SUMMARY } from "./mock";
+import HomeShell from "./HomeShell";
+
+const query = vi.hoisted(() => ({
+  state: { data: null as HomeSummary | null, loading: false, error: null as string | null, reload: vi.fn() },
+}));
+
+vi.mock("./useHomeQuery", () => ({ useHomeQuery: () => query.state }));
+
+const callbacks = {
+  onOpenJournal: vi.fn(),
+  onOpenAchievements: vi.fn(),
+  onOpenCurrentQuests: vi.fn(),
+  onOpenRoutes: vi.fn(),
+  onOpenRole: vi.fn(),
+};
+
+describe("Home world summary를 표시할 때", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    query.state = { data: structuredClone(MOCK_HOME_SUMMARY), loading: false, error: null, reload: vi.fn() };
+  });
+
+  describe("populated summary가 있으면", () => {
+    it("QUICK, Achievement, GOAL_REACHED, multiple Routes, server Role share와 unassigned를 그대로 표시한다", () => {
+      render(<HomeShell {...callbacks} />);
+
+      expect(screen.getByText("Distributed Systems Notes").closest("button")).toHaveTextContent("COLLECTION · QUICK");
+      expect(screen.getByText("First World Trace")).toBeInTheDocument();
+      expect(screen.getByText(/GOAL_REACHED · 25 \/ 25/)).toBeInTheDocument();
+      expect(screen.getByText("Begin with Records")).toBeInTheDocument();
+      expect(screen.getByText("Build a Recovery Rhythm")).toBeInTheDocument();
+      expect(screen.getByText("5 records · 62.5%")).toBeInTheDocument();
+      expect(screen.getByText("Assigned 8 · Unassigned 2 · Total 10")).toBeInTheDocument();
+    });
+
+    it("nullable metadata를 가짜 값 없이 생략하고 nullable Role name에는 실제 ID를 쓴다", () => {
+      render(<HomeShell {...callbacks} />);
+
+      expect(screen.getByText("Role #32")).toBeInTheDocument();
+      expect(screen.getByTestId("home-shell")).not.toHaveTextContent(/null|undefined|not recorded/i);
+      expect(screen.getByText("Build a Recovery Rhythm").closest("button")).not.toHaveTextContent("Current Step");
+    });
+
+    it("cards를 canonical feature callback에만 연결한다", () => {
+      render(<HomeShell {...callbacks} />);
+
+      fireEvent.click(screen.getByRole("button", { name: /Distributed Systems Notes/ }));
+      fireEvent.click(screen.getByRole("button", { name: /First World Trace/ }));
+      fireEvent.click(screen.getByRole("button", { name: /Focus for 25 Minutes/ }));
+      fireEvent.click(screen.getByRole("button", { name: /Begin with Records/ }));
+      fireEvent.click(screen.getByRole("button", { name: /Developer/ }));
+
+      expect(callbacks.onOpenJournal).toHaveBeenCalledOnce();
+      expect(callbacks.onOpenAchievements).toHaveBeenCalledOnce();
+      expect(callbacks.onOpenCurrentQuests).toHaveBeenCalledOnce();
+      expect(callbacks.onOpenRoutes).toHaveBeenCalledOnce();
+      expect(callbacks.onOpenRole).toHaveBeenCalledWith(31);
+    });
+  });
+
+  describe("summary sections가 비어 있으면", () => {
+    it("Home을 유지하고 section별 empty와 zero Role state를 표시한다", () => {
+      query.state.data = {
+        ...structuredClone(MOCK_HOME_SUMMARY),
+        recentJournal: [],
+        recentAchievements: [],
+        journey: { currentQuests: [], selectedRoutes: [] },
+        roleActivity30d: { ...MOCK_HOME_SUMMARY.roleActivity30d, totalRecords: 0, assignedRecords: 0, unassignedRecords: 0, roles: [] },
+      };
+      render(<HomeShell {...callbacks} />);
+
+      expect(screen.getByText("No recent Journal entries.")).toBeInTheDocument();
+      expect(screen.getByText("No recent Achievements.")).toBeInTheDocument();
+      expect(screen.getByText("No current Quests.")).toBeInTheDocument();
+      expect(screen.getByText("No selected Routes.")).toBeInTheDocument();
+      expect(screen.getByText("No assigned Role activity.")).toBeInTheDocument();
+      expect(screen.queryByText(/%/)).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Home request state가 바뀌면", () => {
+    it("initial loading과 Home-level error/retry를 표시한다", () => {
+      query.state = { data: null, loading: true, error: null, reload: vi.fn() };
+      const { rerender } = render(<HomeShell {...callbacks} />);
+      expect(screen.getByText("Loading Home...")).toBeInTheDocument();
+
+      query.state = { data: null, loading: false, error: "Home unavailable", reload: vi.fn() };
+      rerender(<HomeShell {...callbacks} />);
+      expect(screen.getByRole("alert")).toHaveTextContent("Home unavailable");
+      fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+      expect(query.state.reload).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/features/home/HomeShell.test.tsx
+++ b/features/home/HomeShell.test.tsx
@@ -30,6 +30,8 @@ describe("Home world summary를 표시할 때", () => {
       render(<HomeShell {...callbacks} />);
 
       expect(screen.getByText("Distributed Systems Notes").closest("button")).toHaveTextContent("COLLECTION · QUICK");
+      expect(screen.getByRole("button", { name: /RUNNING/ })).toHaveTextContent("2026-08-12");
+      expect(screen.getByRole("button", { name: /Designing Data-Intensive Applications/ })).toHaveTextContent("250/616");
       expect(screen.getByText("First World Trace")).toBeInTheDocument();
       expect(screen.getByText(/GOAL_REACHED · 25 \/ 25/)).toBeInTheDocument();
       expect(screen.getByText("Begin with Records")).toBeInTheDocument();
@@ -60,6 +62,101 @@ describe("Home world summary를 표시할 때", () => {
       expect(callbacks.onOpenCurrentQuests).toHaveBeenCalledOnce();
       expect(callbacks.onOpenRoutes).toHaveBeenCalledOnce();
       expect(callbacks.onOpenRole).toHaveBeenCalledWith(31);
+    });
+  });
+
+  describe("Journal preview의 optional field가 null이면", () => {
+    it("Exercise date를 생략하고 실제 metric zero는 표시한다", () => {
+      query.state.data = {
+        ...structuredClone(MOCK_HOME_SUMMARY),
+        recentJournal: [{
+          lifeLogId: 701,
+          sourceType: "EXERCISE",
+          subtype: null,
+          entryMode: "QUICK",
+          primaryRoleId: null,
+          roleEventId: null,
+          recordedAt: "2026-08-13T00:00:00Z",
+          preview: {
+            category: "STRETCHING",
+            durationMinutes: 0,
+            distanceKm: 0,
+            calories: 0,
+            exercisedOn: null,
+            memo: null,
+          },
+        }],
+      };
+      render(<HomeShell {...callbacks} />);
+
+      const exercise = screen.getByRole("button", { name: /STRETCHING/ });
+      expect(exercise).toHaveTextContent("0 min · 0 km · 0 kcal");
+      expect(exercise).not.toHaveTextContent(/null|undefined|not recorded/i);
+    });
+
+    it("Media optional metadata가 모두 null이면 title/category만 표시한다", () => {
+      query.state.data = {
+        ...structuredClone(MOCK_HOME_SUMMARY),
+        recentJournal: [{
+          lifeLogId: 702,
+          sourceType: "MEDIA",
+          subtype: null,
+          entryMode: null,
+          primaryRoleId: null,
+          roleEventId: null,
+          recordedAt: "2026-08-13T00:00:00Z",
+          preview: {
+            category: "BOOK",
+            title: "Sparse Media",
+            currentEpisode: null,
+            totalEpisode: null,
+            status: null,
+            rating: null,
+          },
+        }],
+      };
+      render(<HomeShell {...callbacks} />);
+
+      const media = screen.getByRole("button", { name: /Sparse Media/ });
+      expect(media).toHaveTextContent("Sparse Media");
+      expect(media).toHaveTextContent("BOOK");
+      expect(media).not.toHaveTextContent(/null|undefined|not recorded|\//i);
+    });
+
+    it("Media episode의 current 또는 total만 있으면 알려진 값만 표시하고 zero도 보존한다", () => {
+      query.state.data = {
+        ...structuredClone(MOCK_HOME_SUMMARY),
+        recentJournal: [
+          {
+            lifeLogId: 703,
+            sourceType: "MEDIA",
+            subtype: null,
+            entryMode: null,
+            primaryRoleId: null,
+            roleEventId: null,
+            recordedAt: "2026-08-13T00:00:00Z",
+            preview: { category: "ANIME", title: "Current Only", currentEpisode: 0, totalEpisode: null, status: null, rating: null },
+          },
+          {
+            lifeLogId: 704,
+            sourceType: "MEDIA",
+            subtype: null,
+            entryMode: null,
+            primaryRoleId: null,
+            roleEventId: null,
+            recordedAt: "2026-08-13T00:00:00Z",
+            preview: { category: "SERIES", title: "Total Only", currentEpisode: null, totalEpisode: 12, status: null, rating: null },
+          },
+        ],
+      };
+      render(<HomeShell {...callbacks} />);
+
+      const current = screen.getByRole("button", { name: /Current Only/ });
+      const total = screen.getByRole("button", { name: /Total Only/ });
+      expect(current).toHaveTextContent("Episode 0");
+      expect(total).toHaveTextContent("Total 12");
+      expect(current).not.toHaveTextContent("/");
+      expect(total).not.toHaveTextContent("/");
     });
   });
 

--- a/features/home/HomeShell.tsx
+++ b/features/home/HomeShell.tsx
@@ -62,8 +62,9 @@ function journalPreview(entry: HomeJournalEntry) {
       };
     case "EXERCISE":
       return {
-        title: `${entry.preview.category} · ${entry.preview.exercisedOn}`,
+        title: entry.preview.category,
         detail: [
+          entry.preview.exercisedOn,
           entry.preview.durationMinutes === null ? null : `${entry.preview.durationMinutes} min`,
           entry.preview.distanceKm === null ? null : `${entry.preview.distanceKm} km`,
           entry.preview.calories === null ? null : `${entry.preview.calories} kcal`,
@@ -71,12 +72,19 @@ function journalPreview(entry: HomeJournalEntry) {
         ],
       };
     case "MEDIA":
+      const episode = entry.preview.currentEpisode !== null && entry.preview.totalEpisode !== null
+        ? `${entry.preview.currentEpisode}/${entry.preview.totalEpisode}`
+        : entry.preview.currentEpisode !== null
+          ? `Episode ${entry.preview.currentEpisode}`
+          : entry.preview.totalEpisode !== null
+            ? `Total ${entry.preview.totalEpisode}`
+            : null;
       return {
         title: entry.preview.title,
         detail: [
           entry.preview.category,
           entry.preview.status,
-          `${entry.preview.currentEpisode}/${entry.preview.totalEpisode}`,
+          episode,
           entry.preview.rating === null ? null : `Rating ${entry.preview.rating}`,
         ],
       };

--- a/features/home/HomeShell.tsx
+++ b/features/home/HomeShell.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+import type { ReactNode } from "react";
+
+import { SAO } from "@/shared/design/tokens";
+import type { HomeJournalEntry } from "./model";
+import { useHomeQuery } from "./useHomeQuery";
+
+type HomeShellProps = {
+  onOpenJournal: () => void;
+  onOpenAchievements: () => void;
+  onOpenCurrentQuests: () => void;
+  onOpenRoutes: () => void;
+  onOpenRole: (roleId: number) => void;
+};
+
+const buttonStyle = {
+  border: `1px solid ${SAO.color.border.panel}`,
+  background: SAO.color.bg.inset,
+  color: SAO.color.text.primary,
+  borderRadius: SAO.radius.panel,
+} as const;
+
+const retryStyle = {
+  ...buttonStyle,
+  padding: "7px 12px",
+  color: SAO.color.text.secondary,
+  fontSize: "0.72rem",
+} as const;
+
+function WorldSection({ title, actionLabel, onOpen, children }: {
+  title: string;
+  actionLabel: string;
+  onOpen?: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <section className="min-w-0 space-y-3 rounded-md border p-4" style={{ background: SAO.color.bg.panel, borderColor: SAO.color.border.panel }}>
+      <div className="flex items-center justify-between gap-3">
+        <h2 className="text-sm font-semibold tracking-[0.12em]" style={{ color: SAO.color.text.primary }}>{title}</h2>
+        {onOpen ? <button type="button" style={retryStyle} onClick={onOpen}>{actionLabel}</button> : null}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function Empty({ children }: { children: ReactNode }) {
+  return <p className="text-sm" style={{ color: SAO.color.text.label }}>{children}</p>;
+}
+
+function Meta({ children }: { children: ReactNode }) {
+  return <p className="text-xs" style={{ color: SAO.color.text.label }}>{children}</p>;
+}
+
+function journalPreview(entry: HomeJournalEntry) {
+  switch (entry.sourceType) {
+    case "COLLECTION":
+      return {
+        title: entry.preview.title,
+        detail: [entry.preview.category, entry.preview.quantity === null ? null : `Quantity ${entry.preview.quantity}`],
+      };
+    case "EXERCISE":
+      return {
+        title: `${entry.preview.category} · ${entry.preview.exercisedOn}`,
+        detail: [
+          entry.preview.durationMinutes === null ? null : `${entry.preview.durationMinutes} min`,
+          entry.preview.distanceKm === null ? null : `${entry.preview.distanceKm} km`,
+          entry.preview.calories === null ? null : `${entry.preview.calories} kcal`,
+          entry.preview.memo,
+        ],
+      };
+    case "MEDIA":
+      return {
+        title: entry.preview.title,
+        detail: [
+          entry.preview.category,
+          entry.preview.status,
+          `${entry.preview.currentEpisode}/${entry.preview.totalEpisode}`,
+          entry.preview.rating === null ? null : `Rating ${entry.preview.rating}`,
+        ],
+      };
+  }
+}
+
+function HomeError({ message, retry }: { message: string; retry: () => void }) {
+  return (
+    <div className="flex items-center justify-between gap-4 rounded-md border p-4" style={{ background: SAO.color.bg.panel, borderColor: SAO.color.action.red }}>
+      <p role="alert" className="text-sm" style={{ color: SAO.color.action.red }}>{message}</p>
+      <button type="button" style={retryStyle} onClick={retry}>Retry</button>
+    </div>
+  );
+}
+
+export default function HomeShell({
+  onOpenJournal,
+  onOpenAchievements,
+  onOpenCurrentQuests,
+  onOpenRoutes,
+  onOpenRole,
+}: HomeShellProps) {
+  const home = useHomeQuery();
+  const data = home.data;
+  const percent = new Intl.NumberFormat("en-US", { style: "percent", maximumFractionDigits: 1 });
+
+  if (home.loading && !data) return <div data-testid="home-shell"><Empty>Loading Home...</Empty></div>;
+  if (home.error && !data) return <div data-testid="home-shell"><HomeError message={home.error} retry={() => void home.reload()} /></div>;
+  if (!data) return null;
+
+  return (
+    <div className="w-[min(980px,calc(100vw-180px))] min-w-[720px] space-y-4" data-testid="home-shell">
+      <header className="rounded-md border px-5 py-4" style={{ background: SAO.color.bg.panel, borderColor: SAO.color.border.gold }}>
+        <p className="text-xs tracking-[0.18em]" style={{ color: SAO.color.text.label }}>AUTHENTICATED WORLD</p>
+        <h1 className="mt-1 text-xl font-semibold" style={{ color: SAO.color.text.primary }}>Home</h1>
+        <Meta>Generated <time dateTime={data.generatedAt}>{data.generatedAt}</time>{home.loading ? " · Refreshing" : ""}</Meta>
+      </header>
+
+      {home.error ? <HomeError message={home.error} retry={() => void home.reload()} /> : null}
+
+      <div className="grid grid-cols-2 gap-4">
+        <WorldSection title="Recent Journal" actionLabel="Open Journal" onOpen={onOpenJournal}>
+          {data.recentJournal.length === 0 ? <Empty>No recent Journal entries.</Empty> : (
+            <div className="space-y-2">
+              {data.recentJournal.map((entry) => {
+                const preview = journalPreview(entry);
+                const metadata = [
+                  entry.sourceType,
+                  entry.entryMode === "QUICK" ? "QUICK" : entry.entryMode,
+                  entry.subtype,
+                  entry.primaryRoleId === null ? null : `Role #${entry.primaryRoleId}`,
+                  entry.roleEventId === null ? null : `Event #${entry.roleEventId}`,
+                ].filter((value): value is string => value !== null);
+                return (
+                  <button key={entry.lifeLogId} type="button" className="block w-full p-3 text-left" style={buttonStyle} onClick={onOpenJournal}>
+                    <p className="text-sm font-semibold">{preview.title}</p>
+                    <Meta>{preview.detail.filter((value): value is string => value !== null).join(" · ")}</Meta>
+                    <Meta>{metadata.join(" · ")}</Meta>
+                    <Meta><time dateTime={entry.recordedAt}>{entry.recordedAt}</time></Meta>
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </WorldSection>
+
+        <WorldSection title="Recent Achievements" actionLabel="Open Achievements" onOpen={onOpenAchievements}>
+          {data.recentAchievements.length === 0 ? <Empty>No recent Achievements.</Empty> : (
+            <div className="space-y-2">
+              {data.recentAchievements.map((achievement) => (
+                <button key={achievement.achievementId} type="button" className="block w-full p-3 text-left" style={buttonStyle} onClick={onOpenAchievements}>
+                  <p className="text-sm font-semibold">{achievement.name}</p>
+                  <Meta>{achievement.category}</Meta>
+                  <p className="line-clamp-2 text-xs" style={{ color: SAO.color.text.secondary }}>{achievement.descMd}</p>
+                  <Meta><time dateTime={achievement.acquiredAt}>{achievement.acquiredAt}</time></Meta>
+                </button>
+              ))}
+            </div>
+          )}
+        </WorldSection>
+
+        <section className="min-w-0 space-y-4 rounded-md border p-4" style={{ background: SAO.color.bg.panel, borderColor: SAO.color.border.panel }}>
+          <h2 className="text-sm font-semibold tracking-[0.12em]" style={{ color: SAO.color.text.primary }}>Current Journey</h2>
+          <div className="space-y-2">
+            <div className="flex items-center justify-between gap-3">
+              <h3 className="text-xs font-semibold" style={{ color: SAO.color.text.secondary }}>Current Quests</h3>
+              <button type="button" style={retryStyle} onClick={onOpenCurrentQuests}>Open Quests</button>
+            </div>
+            {data.journey.currentQuests.length === 0 ? <Empty>No current Quests.</Empty> : data.journey.currentQuests.map((quest) => (
+              <button key={quest.acceptanceId} type="button" className="block w-full p-3 text-left" style={buttonStyle} onClick={onOpenCurrentQuests}>
+                <p className="text-sm font-semibold">{quest.title}</p>
+                <Meta>{quest.status} · {quest.progressValue} / {quest.targetValue}</Meta>
+                <Meta>Accepted <time dateTime={quest.acceptedAt}>{quest.acceptedAt}</time></Meta>
+                {quest.goalReachedAt ? <Meta>Goal reached <time dateTime={quest.goalReachedAt}>{quest.goalReachedAt}</time></Meta> : null}
+              </button>
+            ))}
+          </div>
+          <div className="space-y-2">
+            <div className="flex items-center justify-between gap-3">
+              <h3 className="text-xs font-semibold" style={{ color: SAO.color.text.secondary }}>Selected Routes</h3>
+              <button type="button" style={retryStyle} onClick={onOpenRoutes}>Open Routes</button>
+            </div>
+            {data.journey.selectedRoutes.length === 0 ? <Empty>No selected Routes.</Empty> : data.journey.selectedRoutes.map((route) => (
+              <button key={route.routeId} type="button" className="block w-full p-3 text-left" style={buttonStyle} onClick={onOpenRoutes}>
+                <p className="text-sm font-semibold">{route.title}</p>
+                <Meta>{route.status}{route.currentStepId === null ? "" : ` · Current Step #${route.currentStepId}`}</Meta>
+                <Meta>Selected <time dateTime={route.selectedAt}>{route.selectedAt}</time></Meta>
+                {route.completedAt ? <Meta>Completed <time dateTime={route.completedAt}>{route.completedAt}</time></Meta> : null}
+              </button>
+            ))}
+          </div>
+        </section>
+
+        <WorldSection
+          title="Role Activity — 30 Days"
+          actionLabel="Open Roles"
+          onOpen={data.roleActivity30d.roles[0] ? () => onOpenRole(data.roleActivity30d.roles[0].roleId) : undefined}
+        >
+          <Meta><time dateTime={data.roleActivity30d.windowStart}>{data.roleActivity30d.windowStart}</time> — <time dateTime={data.roleActivity30d.windowEnd}>{data.roleActivity30d.windowEnd}</time></Meta>
+          <Meta>Assigned {data.roleActivity30d.assignedRecords} · Unassigned {data.roleActivity30d.unassignedRecords} · Total {data.roleActivity30d.totalRecords}</Meta>
+          {data.roleActivity30d.assignedRecords === 0 ? <Empty>No assigned Role activity.</Empty> : (
+            <div className="space-y-2">
+              {data.roleActivity30d.roles.map((role) => (
+                <button key={role.roleId} type="button" className="block w-full p-3 text-left" style={buttonStyle} onClick={() => onOpenRole(role.roleId)}>
+                  <p className="text-sm font-semibold">{role.roleName ?? `Role #${role.roleId}`}</p>
+                  <Meta>{role.recordCount} records · {percent.format(role.share)}</Meta>
+                </button>
+              ))}
+            </div>
+          )}
+        </WorldSection>
+      </div>
+    </div>
+  );
+}

--- a/features/home/api.test.ts
+++ b/features/home/api.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getHomeApi } from "./api";
+import { MOCK_HOME_SUMMARY } from "./mock";
+
+const client = vi.hoisted(() => ({ apiGet: vi.fn() }));
+
+vi.mock("@/shared/api/client", () => ({ USE_MOCK: false, ...client }));
+
+describe("Home world summary를 backend에서 읽을 때", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    client.apiGet.mockResolvedValue(MOCK_HOME_SUMMARY);
+  });
+
+  describe("authenticated Home을 요청하면", () => {
+    it("identity나 query 없이 정확히 GET /api/v1/home result를 사용한다", async () => {
+      const result = await getHomeApi();
+
+      expect(client.apiGet).toHaveBeenCalledOnce();
+      expect(client.apiGet).toHaveBeenCalledWith("/api/v1/home");
+      expect(client.apiGet.mock.calls[0][0]).not.toMatch(/[?]|playerId|userId/);
+      expect(result).toBe(MOCK_HOME_SUMMARY);
+    });
+
+    it("composed Home result shape를 그대로 반환한다", async () => {
+      const result = await getHomeApi();
+
+      expect(result).toEqual(expect.objectContaining({
+        generatedAt: expect.any(String),
+        recentJournal: expect.any(Array),
+        recentAchievements: expect.any(Array),
+        journey: expect.objectContaining({ currentQuests: expect.any(Array), selectedRoutes: expect.any(Array) }),
+        roleActivity30d: expect.objectContaining({ roles: expect.any(Array) }),
+      }));
+    });
+  });
+
+  describe("Home mock contract를 사용하면", () => {
+    it("backend casing과 nullable metadata를 지키고 page/detail 전용 field를 추가하지 않는다", () => {
+      const quick = MOCK_HOME_SUMMARY.recentJournal.find(({ entryMode }) => entryMode === "QUICK")!;
+
+      expect(quick).toEqual(expect.objectContaining({ sourceType: "COLLECTION", subtype: null, roleEventId: null }));
+      expect(quick).not.toHaveProperty("sourceId");
+      expect(MOCK_HOME_SUMMARY.journey.currentQuests.map(({ status }) => status)).toEqual(["GOAL_REACHED", "IN_PROGRESS"]);
+      expect(MOCK_HOME_SUMMARY.journey.selectedRoutes).toHaveLength(2);
+      expect(MOCK_HOME_SUMMARY.roleActivity30d).toEqual(expect.objectContaining({ assignedRecords: 8, unassignedRecords: 2, totalRecords: 10 }));
+      expect(MOCK_HOME_SUMMARY.roleActivity30d.roles.some(({ roleName }) => roleName === null)).toBe(true);
+    });
+  });
+});

--- a/features/home/api.ts
+++ b/features/home/api.ts
@@ -1,0 +1,7 @@
+import { USE_MOCK, apiGet } from "@/shared/api/client";
+import { homeMock } from "./mock";
+import type { HomeSummary } from "./model";
+
+export function getHomeApi(): Promise<HomeSummary> {
+  return USE_MOCK ? Promise.resolve(homeMock()) : apiGet<HomeSummary>("/api/v1/home");
+}

--- a/features/home/mock.ts
+++ b/features/home/mock.ts
@@ -1,0 +1,120 @@
+import type { HomeSummary } from "./model";
+
+export const MOCK_HOME_SUMMARY = {
+  generatedAt: "2026-08-12T09:30:00Z",
+  recentJournal: [
+    {
+      lifeLogId: 301,
+      sourceType: "COLLECTION",
+      subtype: null,
+      entryMode: "QUICK",
+      primaryRoleId: null,
+      roleEventId: null,
+      recordedAt: "2026-08-12T09:20:00Z",
+      preview: { category: "BOOK", title: "Distributed Systems Notes", quantity: 1 },
+    },
+    {
+      lifeLogId: 302,
+      sourceType: "EXERCISE",
+      subtype: "ACTIVITY",
+      entryMode: "FULL",
+      primaryRoleId: 31,
+      roleEventId: 901,
+      recordedAt: "2026-08-12T08:10:00Z",
+      preview: {
+        category: "RUNNING",
+        durationMinutes: 30,
+        distanceKm: 5.2,
+        calories: null,
+        exercisedOn: "2026-08-12",
+        memo: null,
+      },
+    },
+    {
+      lifeLogId: 303,
+      sourceType: "MEDIA",
+      subtype: "REFLECTION",
+      entryMode: "FULL",
+      primaryRoleId: null,
+      roleEventId: null,
+      recordedAt: "2026-08-11T20:00:00Z",
+      preview: {
+        category: "BOOK",
+        title: "Designing Data-Intensive Applications",
+        currentEpisode: 250,
+        totalEpisode: 616,
+        status: "READING",
+        rating: 4.8,
+      },
+    },
+  ],
+  recentAchievements: [
+    {
+      achievementId: 601,
+      code: "HOME_FIRST",
+      name: "First World Trace",
+      category: "STORY",
+      descMd: "Recorded the first trace in your world.",
+      acquiredAt: "2026-08-12T09:25:00Z",
+    },
+  ],
+  journey: {
+    currentQuests: [
+      {
+        acceptanceId: 401,
+        questCode: "Q_FOCUS_25",
+        title: "Focus for 25 Minutes",
+        status: "GOAL_REACHED",
+        progressValue: 25,
+        targetValue: 25,
+        acceptedAt: "2026-08-12T07:00:00Z",
+        goalReachedAt: "2026-08-12T07:25:00Z",
+      },
+      {
+        acceptanceId: 402,
+        questCode: "Q_RECORD_THREE",
+        title: "Connect Three Traces",
+        status: "IN_PROGRESS",
+        progressValue: 1,
+        targetValue: 3,
+        acceptedAt: "2026-08-11T07:00:00Z",
+        goalReachedAt: null,
+      },
+    ],
+    selectedRoutes: [
+      {
+        routeId: 501,
+        routeCode: "ROUTE_RECORD",
+        title: "Begin with Records",
+        status: "IN_PROGRESS",
+        currentStepId: 11,
+        selectedAt: "2026-08-10T01:00:00Z",
+        completedAt: null,
+      },
+      {
+        routeId: 502,
+        routeCode: "ROUTE_RECOVERY",
+        title: "Build a Recovery Rhythm",
+        status: "IN_PROGRESS",
+        currentStepId: null,
+        selectedAt: "2026-08-09T01:00:00Z",
+        completedAt: null,
+      },
+    ],
+  },
+  roleActivity30d: {
+    windowStart: "2026-07-14T09:30:00Z",
+    windowEnd: "2026-08-12T09:30:00Z",
+    totalRecords: 10,
+    assignedRecords: 8,
+    unassignedRecords: 2,
+    roles: [
+      { roleId: 31, roleName: "Developer", recordCount: 5, share: 0.625 },
+      { roleId: 32, roleName: null, recordCount: 3, share: 0.375 },
+    ],
+  },
+} satisfies HomeSummary;
+
+export function homeMock(): HomeSummary {
+  return structuredClone(MOCK_HOME_SUMMARY);
+}

--- a/features/home/model.ts
+++ b/features/home/model.ts
@@ -28,15 +28,15 @@ export type HomeJournalEntry =
       durationMinutes: number | null;
       distanceKm: number | null;
       calories: number | null;
-      exercisedOn: string;
+      exercisedOn: string | null;
       memo: string | null;
     }>
   | HomeJournalBase<"MEDIA", {
       category: string;
       title: string;
-      currentEpisode: number;
-      totalEpisode: number;
-      status: string;
+      currentEpisode: number | null;
+      totalEpisode: number | null;
+      status: string | null;
       rating: number | null;
     }>;
 

--- a/features/home/model.ts
+++ b/features/home/model.ts
@@ -1,0 +1,88 @@
+import type {
+  JournalEntryMode,
+  JournalSourceType,
+  JournalSubtype,
+  QuestRouteStatus,
+  QuestStatus,
+} from "@/shared/api/types";
+
+type HomeJournalBase<T extends JournalSourceType, P> = {
+  lifeLogId: number;
+  sourceType: T;
+  subtype: JournalSubtype | null;
+  entryMode: JournalEntryMode | null;
+  primaryRoleId: number | null;
+  roleEventId: number | null;
+  recordedAt: string;
+  preview: P;
+};
+
+export type HomeJournalEntry =
+  | HomeJournalBase<"COLLECTION", {
+      category: string;
+      title: string;
+      quantity: number | null;
+    }>
+  | HomeJournalBase<"EXERCISE", {
+      category: string;
+      durationMinutes: number | null;
+      distanceKm: number | null;
+      calories: number | null;
+      exercisedOn: string;
+      memo: string | null;
+    }>
+  | HomeJournalBase<"MEDIA", {
+      category: string;
+      title: string;
+      currentEpisode: number;
+      totalEpisode: number;
+      status: string;
+      rating: number | null;
+    }>;
+
+export type HomeSummary = {
+  generatedAt: string;
+  recentJournal: HomeJournalEntry[];
+  recentAchievements: Array<{
+    achievementId: number;
+    code: string;
+    name: string;
+    category: string;
+    descMd: string;
+    acquiredAt: string;
+  }>;
+  journey: {
+    currentQuests: Array<{
+      acceptanceId: number;
+      questCode: string;
+      title: string;
+      status: QuestStatus;
+      progressValue: number;
+      targetValue: number;
+      acceptedAt: string;
+      goalReachedAt: string | null;
+    }>;
+    selectedRoutes: Array<{
+      routeId: number;
+      routeCode: string;
+      title: string;
+      status: QuestRouteStatus;
+      currentStepId: number | null;
+      selectedAt: string;
+      completedAt: string | null;
+    }>;
+  };
+  roleActivity30d: {
+    windowStart: string;
+    windowEnd: string;
+    totalRecords: number;
+    assignedRecords: number;
+    unassignedRecords: number;
+    roles: Array<{
+      roleId: number;
+      roleName: string | null;
+      recordCount: number;
+      share: number;
+    }>;
+  };
+};

--- a/features/home/useHomeQuery.test.tsx
+++ b/features/home/useHomeQuery.test.tsx
@@ -1,0 +1,109 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { HomeSummary } from "./model";
+import { MOCK_HOME_SUMMARY } from "./mock";
+import { useHomeQuery } from "./useHomeQuery";
+
+const api = vi.hoisted(() => ({ getHomeApi: vi.fn() }));
+
+vi.mock("./api", () => api);
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+}
+
+describe("Home server query state를 관리할 때", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api.getHomeApi.mockResolvedValue(structuredClone(MOCK_HOME_SUMMARY));
+  });
+
+  describe("처음 mount하면", () => {
+    it("Home request 하나만 보내고 loading 뒤 result를 보존한다", async () => {
+      const request = deferred<HomeSummary>();
+      api.getHomeApi.mockReturnValue(request.promise);
+      const { result } = renderHook(() => useHomeQuery());
+
+      await waitFor(() => expect(result.current.loading).toBe(true));
+      expect(result.current.data).toBeNull();
+      expect(api.getHomeApi).toHaveBeenCalledOnce();
+
+      await act(async () => {
+        request.resolve(structuredClone(MOCK_HOME_SUMMARY));
+        await request.promise;
+      });
+      expect(result.current.data).toEqual(MOCK_HOME_SUMMARY);
+      expect(result.current.loading).toBe(false);
+    });
+  });
+
+  describe("request가 실패하면", () => {
+    it("error를 표시하고 retry 성공 시 같은 query state를 복구한다", async () => {
+      api.getHomeApi.mockRejectedValueOnce(new Error("Home unavailable"));
+      const { result } = renderHook(() => useHomeQuery());
+
+      await waitFor(() => expect(result.current.error).toBe("Home unavailable"));
+      await act(async () => { await result.current.reload(); });
+
+      expect(api.getHomeApi).toHaveBeenCalledTimes(2);
+      expect(result.current.data).toEqual(MOCK_HOME_SUMMARY);
+      expect(result.current.error).toBeNull();
+    });
+  });
+
+  describe("겹친 request가 역순으로 끝나면", () => {
+    it("stale success가 최신 Home success를 덮어쓰지 않는다", async () => {
+      const stale = deferred<HomeSummary>();
+      const latest = deferred<HomeSummary>();
+      const latestSummary = { ...structuredClone(MOCK_HOME_SUMMARY), generatedAt: "2026-08-12T10:00:00Z" };
+      api.getHomeApi.mockReturnValueOnce(stale.promise).mockReturnValueOnce(latest.promise);
+      const { result } = renderHook(() => useHomeQuery());
+      await waitFor(() => expect(api.getHomeApi).toHaveBeenCalledOnce());
+
+      act(() => { void result.current.reload(); });
+      await act(async () => {
+        latest.resolve(latestSummary);
+        await latest.promise;
+      });
+      expect(result.current.data?.generatedAt).toBe(latestSummary.generatedAt);
+
+      await act(async () => {
+        stale.resolve(structuredClone(MOCK_HOME_SUMMARY));
+        await stale.promise;
+      });
+      expect(result.current.data?.generatedAt).toBe(latestSummary.generatedAt);
+      expect(result.current.loading).toBe(false);
+    });
+
+    it("stale error가 최신 Home data/loading/error를 바꾸지 않는다", async () => {
+      const stale = deferred<HomeSummary>();
+      const latest = deferred<HomeSummary>();
+      api.getHomeApi.mockReturnValueOnce(stale.promise).mockReturnValueOnce(latest.promise);
+      const { result } = renderHook(() => useHomeQuery());
+      await waitFor(() => expect(api.getHomeApi).toHaveBeenCalledOnce());
+
+      act(() => { void result.current.reload(); });
+      await act(async () => {
+        stale.reject(new Error("stale Home failure"));
+        await stale.promise.catch(() => undefined);
+      });
+      expect(result.current.loading).toBe(true);
+      expect(result.current.error).toBeNull();
+
+      await act(async () => {
+        latest.resolve(structuredClone(MOCK_HOME_SUMMARY));
+        await latest.promise;
+      });
+      expect(result.current.data).toEqual(MOCK_HOME_SUMMARY);
+      expect(result.current.loading).toBe(false);
+      expect(result.current.error).toBeNull();
+    });
+  });
+});

--- a/features/home/useHomeQuery.ts
+++ b/features/home/useHomeQuery.ts
@@ -1,0 +1,35 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { getHomeApi } from "./api";
+import type { HomeSummary } from "./model";
+
+export function useHomeQuery() {
+  const [data, setData] = useState<HomeSummary | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const requestId = useRef(0);
+
+  const reload = useCallback(async () => {
+    const currentRequestId = ++requestId.current;
+    setLoading(true);
+    setError(null);
+    try {
+      const next = await getHomeApi();
+      if (currentRequestId === requestId.current) setData(next);
+      return next;
+    } catch (caught) {
+      if (currentRequestId === requestId.current) {
+        setError(caught instanceof Error ? caught.message : "Unable to load Home.");
+      }
+      return undefined;
+    } finally {
+      if (currentRequestId === requestId.current) setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { void reload(); }, [reload]);
+
+  return { data, loading, error, reload };
+}

--- a/features/quests/JourneyShell.test.tsx
+++ b/features/quests/JourneyShell.test.tsx
@@ -106,6 +106,16 @@ describe("Journey에서 Quest와 QuestRoute를 볼 때", () => {
     api.advanceQuestRouteApi.mockResolvedValue(advancedRoute);
   });
 
+  describe("canonical Home callback이 initial surface를 지정하면", () => {
+    it("Routes에서 바로 시작한다", async () => {
+      render(<JourneyShell initialSurface="routes" />);
+
+      expect(await screen.findByText(unselectedRoute.title)).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /Routes/ })).toBeInTheDocument();
+      expect(screen.queryByText("No active Quest Routes.")).not.toBeInTheDocument();
+    });
+  });
+
   describe("Current Quest의 상태와 next action을 확인하면", () => {
     it("IN_PROGRESS/GOAL_REACHED/COMPLETED/CANCELED를 구분하고 Party/Guild surface나 reward claim을 노출하지 않는다", async () => {
       render(<JourneyShell />);

--- a/features/quests/JourneyShell.tsx
+++ b/features/quests/JourneyShell.tsx
@@ -69,9 +69,9 @@ type RouteDetailState = {
   error: string | null;
 };
 
-export default function JourneyShell() {
+export default function JourneyShell({ initialSurface = "current" }: { initialSurface?: QuestsSubId }) {
   const queries = useJourneyQueries(true);
-  const [surface, setSurface] = useState<QuestsSubId>("current");
+  const [surface, setSurface] = useState<QuestsSubId>(initialSurface);
   const [selectedAcceptanceId, setSelectedAcceptanceId] = useState<number | null>(null);
   const [selectedCatalogCode, setSelectedCatalogCode] = useState<string | null>(null);
   const [selectedRouteId, setSelectedRouteId] = useState<number | null>(null);

--- a/features/role/RoleShell.test.tsx
+++ b/features/role/RoleShell.test.tsx
@@ -110,6 +110,16 @@ describe("실제 Role shell을 사용할 때", () => {
     });
   });
 
+  describe("다른 surface에서 Role identity를 preselect하면", () => {
+    it("Role 목록이 loading되는 동안 선택 ID를 지우지 않는다", () => {
+      const onSelectRole = vi.fn();
+
+      render(<RoleShell roles={[]} selectedRoleId={2} isLoading error={null} onSelectRole={onSelectRole} onRefresh={vi.fn()} />);
+
+      expect(onSelectRole).not.toHaveBeenCalledWith(null);
+    });
+  });
+
   describe("Relations surface에서 Person과 관계를 관리하면", () => {
     it("Person을 별도 identity로 생성·선택하고 Relation을 create/update/archive한다", async () => {
       render(<Harness />);

--- a/features/role/RoleShell.tsx
+++ b/features/role/RoleShell.tsx
@@ -445,7 +445,6 @@ export default function RoleShell({
 
   useEffect(() => {
     if (roles.length > 0 && !selectedRole) onSelectRole(roles[0].id);
-    if (roles.length === 0 && selectedRoleId !== null) onSelectRole(null);
   }, [onSelectRole, roles, selectedRole, selectedRoleId]);
 
   useEffect(() => {

--- a/widgets/orb-nav/OrbNav.tsx
+++ b/widgets/orb-nav/OrbNav.tsx
@@ -17,7 +17,7 @@ type OrbItem = {
 
 type OrbNavProps = {
   items: OrbItem[];
-  selectedId: MainNavId;
+  selectedId: MainNavId | null;
   onSelect: (id: MainNavId) => void;
   zIndex?: number;
   onFocus?: () => void;


### PR DESCRIPTION
## Purpose

Connect the authenticated player's default LifeAsGame world surface to the canonical backend Home projection.

## Delivered

- default Home/world state with no Home Orb
- real `GET /api/v1/home` integration
- recent Journal summary
- recent Achievement summary
- current Quest summary
- selected QuestRoute summary
- 30-day Role activity distribution
- Home loading/error/retry/empty states
- latest-request-wins query protection
- navigation into canonical feature surfaces
- real-contract Home mocks

## Product boundaries

- Home is a read-only summary/launch surface
- no Home persistence
- no client-side summary recomposition
- no single active Route assumption
- no Role score/radar/streak
- no Home mutations

## Navigation

- initial authenticated state shows Home
- selecting a main Orb opens that feature
- selecting the active Orb again returns Home
- no Home Orb was added

## Backend contract

Connected:

`GET /api/v1/home`

No player/user identity parameter.

## Tests

Coverage includes:

- exact Home API
- mock parity
- loading/error/retry
- stale request protection
- populated/empty summary
- QUICK semantics
- GOAL_REACHED semantics
- multiple Routes
- Role distribution
- default Home and Orb toggle navigation
- feature regressions

## Validation

- lint
- targeted tests
- full tests
- build

Closes #16

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Home dashboard with recent journal activity, achievements, quests, routes, and role activity.
  * Added shortcuts from Home to key app sections.
  * Enabled deselecting the active navigation item to return to Home.
  * Routes can now open directly from the quests experience.

* **Bug Fixes**
  * Preserved selected roles while role data is loading.
  * Improved Home loading, error, retry, and stale-request handling.
  * Preserved zero-value and optional Home summary details when displayed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->