### PR TITLE
[LifeLog] Connect real Quick Record write flow

### DIFF
--- a/features/lifelog/JournalShell.test.tsx
+++ b/features/lifelog/JournalShell.test.tsx
@@ -1,13 +1,14 @@
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { JournalPage, RoleDetail } from "@/shared/api/types";
+import type { JournalPage, QuickRecordResult, RoleDetail } from "@/shared/api/types";
 import JournalShell from "./JournalShell";
 import { journalMock, MOCK_JOURNAL_ENTRIES } from "./mock";
 
 const api = vi.hoisted(() => ({
   getJournalDetailApi: vi.fn(),
   listJournalApi: vi.fn(),
+  quickRecordApi: vi.fn(),
 }));
 
 vi.mock("./api", () => api);
@@ -22,6 +23,12 @@ const roles: RoleDetail[] = [
   { id: 2, roleType: "FAMILY", name: "Family Member", description: "Be present", status: "ACTIVE", createdAt: "2026-01-02T00:00:00Z", updatedAt: "2026-01-02T00:00:00Z", version: 0 },
 ];
 const mixedPage = journalMock.page({ page: 0, size: 20 });
+const quickResult: QuickRecordResult = {
+  sourceType: "COLLECTION",
+  sourceId: 999,
+  recordedAt: "2026-08-14T00:00:00Z",
+  replay: false,
+};
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
@@ -38,6 +45,98 @@ describe("LifeLog Journal surface를 사용할 때", () => {
     vi.clearAllMocks();
     api.listJournalApi.mockResolvedValue(mixedPage);
     api.getJournalDetailApi.mockImplementation(async (lifeLogId: number) => journalMock.detail(lifeLogId));
+    api.quickRecordApi.mockResolvedValue(quickResult);
+  });
+
+  describe("Quick Record form을 제출하면", () => {
+    it("Collection payload 하나와 optional top-level metadata만 전송한다", async () => {
+      render(<JournalShell roles={roles} />);
+      fireEvent.click(screen.getByText("Quick Record"));
+
+      const type = screen.getByLabelText("Quick Record type") as HTMLSelectElement;
+      expect(Array.from(type.options, ({ value }) => value)).toEqual(["COLLECTION", "EXERCISE", "MEDIA"]);
+      expect(screen.queryByLabelText(/event/i)).not.toBeInTheDocument();
+      fireEvent.change(screen.getByLabelText("Quick Record subtype"), { target: { value: "PROJECT" } });
+      fireEvent.change(screen.getByLabelText("Quick Record role"), { target: { value: "2" } });
+      fireEvent.change(screen.getByLabelText("Collection category"), { target: { value: "BOOK" } });
+      fireEvent.change(screen.getByLabelText("Collection title"), { target: { value: "The Pragmatic Programmer" } });
+      fireEvent.change(screen.getByLabelText("Quantity"), { target: { value: "1" } });
+      fireEvent.click(screen.getByRole("button", { name: "Save Quick Record" }));
+
+      await waitFor(() => expect(api.quickRecordApi).toHaveBeenCalledOnce());
+      expect(api.quickRecordApi).toHaveBeenCalledWith({
+        type: "COLLECTION",
+        lifeLogSubtype: "PROJECT",
+        primaryRoleId: 2,
+        collection: { category: "BOOK", title: "The Pragmatic Programmer", quantity: 1 },
+      }, expect.stringMatching(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i));
+      expect(screen.queryByLabelText(/rating|player|user/i)).not.toBeInTheDocument();
+    });
+
+    it("Exercise optional zero를 보존하고 비어 있는 optional field는 생략한다", async () => {
+      render(<JournalShell roles={roles} />);
+      fireEvent.click(screen.getByText("Quick Record"));
+      fireEvent.change(screen.getByLabelText("Quick Record type"), { target: { value: "EXERCISE" } });
+      fireEvent.change(screen.getByLabelText("Exercise category"), { target: { value: "RUNNING" } });
+      fireEvent.change(screen.getByLabelText("Duration minutes"), { target: { value: "30" } });
+      fireEvent.change(screen.getByLabelText("Exercised on"), { target: { value: "2026-08-14" } });
+      fireEvent.change(screen.getByLabelText("Distance km"), { target: { value: "0" } });
+      fireEvent.change(screen.getByLabelText("Calories"), { target: { value: "0" } });
+      fireEvent.click(screen.getByRole("button", { name: "Save Quick Record" }));
+
+      await waitFor(() => expect(api.quickRecordApi).toHaveBeenCalledOnce());
+      expect(api.quickRecordApi.mock.calls[0][0]).toEqual({
+        type: "EXERCISE",
+        exercise: {
+          category: "RUNNING",
+          durationMinutes: 30,
+          exercisedOn: "2026-08-14",
+          distanceKm: 0,
+          calories: 0,
+        },
+      });
+    });
+
+    it("Media currentEpisode zero를 보존하고 partial episode payload를 허용한다", async () => {
+      render(<JournalShell roles={roles} />);
+      fireEvent.click(screen.getByText("Quick Record"));
+      fireEvent.change(screen.getByLabelText("Quick Record type"), { target: { value: "MEDIA" } });
+      fireEvent.change(screen.getByLabelText("Media category"), { target: { value: "ANIME" } });
+      fireEvent.change(screen.getByLabelText("Media title"), { target: { value: "Frieren" } });
+      fireEvent.change(screen.getByLabelText("Media status"), { target: { value: "WATCHING" } });
+      fireEvent.change(screen.getByLabelText("Current episode"), { target: { value: "0" } });
+      fireEvent.click(screen.getByRole("button", { name: "Save Quick Record" }));
+
+      await waitFor(() => expect(api.quickRecordApi).toHaveBeenCalledOnce());
+      expect(api.quickRecordApi.mock.calls[0][0]).toEqual({
+        type: "MEDIA",
+        media: { category: "ANIME", title: "Frieren", status: "WATCHING", currentEpisode: 0 },
+      });
+    });
+
+    it("ambiguous failure 뒤 edit 전에는 Retry만 노출하고 edit 후 새 logical Submit을 만든다", async () => {
+      api.quickRecordApi.mockRejectedValueOnce(new Error("Outcome unknown")).mockResolvedValueOnce(quickResult);
+      render(<JournalShell roles={roles} />);
+      fireEvent.click(screen.getByText("Quick Record"));
+      fireEvent.change(screen.getByLabelText("Collection category"), { target: { value: "BOOK" } });
+      fireEvent.change(screen.getByLabelText("Collection title"), { target: { value: "Retry me" } });
+      fireEvent.change(screen.getByLabelText("Quantity"), { target: { value: "1" } });
+      fireEvent.click(screen.getByRole("button", { name: "Save Quick Record" }));
+
+      await screen.findByRole("button", { name: "Retry same record" });
+      expect(screen.queryByRole("button", { name: "Save Quick Record" })).not.toBeInTheDocument();
+      const firstCall = api.quickRecordApi.mock.calls[0];
+      fireEvent.change(screen.getByLabelText("Collection title"), { target: { value: "Edited retry" } });
+
+      expect(screen.queryByRole("button", { name: "Retry same record" })).not.toBeInTheDocument();
+      fireEvent.click(screen.getByRole("button", { name: "Save Quick Record" }));
+      await waitFor(() => expect(api.quickRecordApi).toHaveBeenCalledTimes(2));
+      expect(api.quickRecordApi.mock.calls[1][0]).toEqual({
+        type: "COLLECTION",
+        collection: { category: "BOOK", title: "Edited retry", quantity: 1 },
+      });
+      expect(api.quickRecordApi.mock.calls[1][1]).not.toBe(firstCall[1]);
+    });
   });
 
   describe("mixed physical source 목록을 읽으면", () => {

--- a/features/lifelog/JournalShell.test.tsx
+++ b/features/lifelog/JournalShell.test.tsx
@@ -114,6 +114,22 @@ describe("LifeLog Journal surface를 사용할 때", () => {
       });
     });
 
+    it("Media episode input을 비워 두면 request에서도 둘 다 생략한다", async () => {
+      render(<JournalShell roles={roles} />);
+      fireEvent.click(screen.getByText("Quick Record"));
+      fireEvent.change(screen.getByLabelText("Quick Record type"), { target: { value: "MEDIA" } });
+      fireEvent.change(screen.getByLabelText("Media category"), { target: { value: "ANIME" } });
+      fireEvent.change(screen.getByLabelText("Media title"), { target: { value: "Frieren" } });
+      fireEvent.change(screen.getByLabelText("Media status"), { target: { value: "WATCHING" } });
+      fireEvent.click(screen.getByRole("button", { name: "Save Quick Record" }));
+
+      await waitFor(() => expect(api.quickRecordApi).toHaveBeenCalledOnce());
+      expect(api.quickRecordApi.mock.calls[0][0]).toEqual({
+        type: "MEDIA",
+        media: { category: "ANIME", title: "Frieren", status: "WATCHING" },
+      });
+    });
+
     it("ambiguous failure 뒤 edit 전에는 Retry만 노출하고 edit 후 새 logical Submit을 만든다", async () => {
       api.quickRecordApi.mockRejectedValueOnce(new Error("Outcome unknown")).mockResolvedValueOnce(quickResult);
       render(<JournalShell roles={roles} />);

--- a/features/lifelog/JournalShell.tsx
+++ b/features/lifelog/JournalShell.tsx
@@ -1,6 +1,20 @@
 "use client";
 
-import type { JournalDetail, JournalEntry, JournalSubtype, RoleDetail } from "@/shared/api/types";
+import { useRef, useState } from "react";
+
+import type {
+  JournalDetail,
+  JournalEntry,
+  JournalSubtype,
+  QuickRecordCollectionCategory,
+  QuickRecordExerciseCategory,
+  QuickRecordMediaCategory,
+  QuickRecordMediaStatus,
+  QuickRecordRequest,
+  QuickRecordResult,
+  QuickRecordType,
+  RoleDetail,
+} from "@/shared/api/types";
 import { INPUT_STYLE, SAO } from "@/shared/design/tokens";
 import PanelCard from "@/shared/ui/PanelCard";
 import { PanelFrame } from "@/widgets/right-panels/ui/PanelFrame";
@@ -27,6 +41,193 @@ const secondaryButton = {
   fontSize: "0.68rem",
   letterSpacing: "0.08em",
 } as const;
+
+const COLLECTION_CATEGORIES = ["FIGURE", "CARD", "BOOK", "GAME", "STAMP", "COIN", "OTHER"] as const;
+const EXERCISE_CATEGORIES = ["RUNNING", "WALKING", "CYCLING", "SWIMMING", "GYM", "YOGA", "OTHER"] as const;
+const MEDIA_CATEGORIES = ["ANIME", "MOVIE", "SERIES", "BOOK", "WEBTOON", "GAME", "MUSIC"] as const;
+const MEDIA_STATUSES = ["PLANNED", "WATCHING", "COMPLETED", "DROPPED", "ON_HOLD"] as const;
+
+function text(form: FormData, key: string) {
+  return String(form.get(key) ?? "").trim();
+}
+
+function optionalNumber(form: FormData, key: string) {
+  const raw = text(form, key);
+  return raw === "" ? undefined : Number(raw);
+}
+
+function QuickRecordForm({
+  roles,
+  rolesLoading,
+  rolesError,
+  pending,
+  error,
+  result,
+  refreshError,
+  canRetry,
+  onSubmit,
+  onRetry,
+  onEdit,
+}: {
+  roles: RoleDetail[];
+  rolesLoading: boolean;
+  rolesError: string | null;
+  pending: boolean;
+  error: string | null;
+  result: QuickRecordResult | null;
+  refreshError: string | null;
+  canRetry: boolean;
+  onSubmit: (body: QuickRecordRequest) => Promise<QuickRecordResult | undefined>;
+  onRetry: () => Promise<QuickRecordResult | undefined>;
+  onEdit: () => void;
+}) {
+  const [type, setType] = useState<QuickRecordType>("COLLECTION");
+  const formRef = useRef<HTMLFormElement>(null);
+
+  const resetAfter = (saved: QuickRecordResult | undefined) => {
+    if (!saved) return;
+    formRef.current?.reset();
+    setType("COLLECTION");
+  };
+
+  const submit = async (event: React.SubmitEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const form = new FormData(event.currentTarget);
+    const lifeLogSubtype = text(form, "lifeLogSubtype") as JournalSubtype | "";
+    const primaryRoleId = optionalNumber(form, "primaryRoleId");
+    const metadata = {
+      ...(lifeLogSubtype ? { lifeLogSubtype } : {}),
+      ...(primaryRoleId === undefined ? {} : { primaryRoleId }),
+    };
+
+    let body: QuickRecordRequest;
+    if (type === "COLLECTION") {
+      body = {
+        ...metadata,
+        type,
+        collection: {
+          category: text(form, "collectionCategory") as QuickRecordCollectionCategory,
+          title: text(form, "collectionTitle"),
+          quantity: Number(text(form, "quantity")),
+        },
+      };
+    } else if (type === "EXERCISE") {
+      const distanceKm = optionalNumber(form, "distanceKm");
+      const calories = optionalNumber(form, "calories");
+      const memo = text(form, "memo");
+      body = {
+        ...metadata,
+        type,
+        exercise: {
+          category: text(form, "exerciseCategory") as QuickRecordExerciseCategory,
+          durationMinutes: Number(text(form, "durationMinutes")),
+          exercisedOn: text(form, "exercisedOn"),
+          ...(distanceKm === undefined ? {} : { distanceKm }),
+          ...(calories === undefined ? {} : { calories }),
+          ...(memo ? { memo } : {}),
+        },
+      };
+    } else {
+      const currentEpisode = optionalNumber(form, "currentEpisode");
+      const totalEpisode = optionalNumber(form, "totalEpisode");
+      body = {
+        ...metadata,
+        type,
+        media: {
+          category: text(form, "mediaCategory") as QuickRecordMediaCategory,
+          title: text(form, "mediaTitle"),
+          status: text(form, "mediaStatus") as QuickRecordMediaStatus,
+          ...(currentEpisode === undefined ? {} : { currentEpisode }),
+          ...(totalEpisode === undefined ? {} : { totalEpisode }),
+        },
+      };
+    }
+
+    resetAfter(await onSubmit(body));
+  };
+
+  const select = (name: string, label: string, values: readonly string[]) => (
+    <label className="block text-xs" style={{ color: SAO.color.text.label }}>
+      {label}
+      <select name={name} required defaultValue="" style={INPUT_STYLE} disabled={pending}>
+        <option value="" disabled>Select...</option>
+        {values.map((value) => <option key={value} value={value}>{value.replaceAll("_", " ")}</option>)}
+      </select>
+    </label>
+  );
+
+  return (
+    <form ref={formRef} className="space-y-2" onSubmit={submit} onChangeCapture={onEdit}>
+      <label className="block text-xs" style={{ color: SAO.color.text.label }}>
+        Quick Record type
+        <select
+          name="type"
+          aria-label="Quick Record type"
+          value={type}
+          style={INPUT_STYLE}
+          disabled={pending}
+          onChange={(event) => setType(event.target.value as QuickRecordType)}
+        >
+          <option value="COLLECTION">Collection</option>
+          <option value="EXERCISE">Exercise</option>
+          <option value="MEDIA">Media</option>
+        </select>
+      </label>
+
+      <label className="block text-xs" style={{ color: SAO.color.text.label }}>
+        Quick Record subtype
+        <select name="lifeLogSubtype" aria-label="Quick Record subtype" defaultValue="" style={INPUT_STYLE} disabled={pending}>
+          <option value="">None</option>
+          {JOURNAL_SUBTYPES.map((subtype) => <option key={subtype} value={subtype}>{subtype.replaceAll("_", " ")}</option>)}
+        </select>
+      </label>
+
+      <label className="block text-xs" style={{ color: SAO.color.text.label }}>
+        Quick Record role
+        <select name="primaryRoleId" aria-label="Quick Record role" defaultValue="" style={INPUT_STYLE} disabled={pending || rolesLoading}>
+          <option value="">No Role</option>
+          {roles.map((role) => <option key={role.id} value={role.id}>{role.name}</option>)}
+        </select>
+      </label>
+      {rolesLoading ? <InfoCard>Loading Roles...</InfoCard> : null}
+      {rolesError ? <p role="alert" className="text-xs" style={{ color: SAO.color.action.red }}>Role selection unavailable: {rolesError}</p> : null}
+
+      {type === "COLLECTION" ? (
+        <>
+          {select("collectionCategory", "Collection category", COLLECTION_CATEGORIES)}
+          <label className="block text-xs" style={{ color: SAO.color.text.label }}>Collection title<input name="collectionTitle" required style={INPUT_STYLE} disabled={pending} /></label>
+          <label className="block text-xs" style={{ color: SAO.color.text.label }}>Quantity<input name="quantity" type="number" min={1} required style={INPUT_STYLE} disabled={pending} /></label>
+        </>
+      ) : type === "EXERCISE" ? (
+        <>
+          {select("exerciseCategory", "Exercise category", EXERCISE_CATEGORIES)}
+          <label className="block text-xs" style={{ color: SAO.color.text.label }}>Duration minutes<input name="durationMinutes" type="number" min={1} required style={INPUT_STYLE} disabled={pending} /></label>
+          <label className="block text-xs" style={{ color: SAO.color.text.label }}>Exercised on<input name="exercisedOn" type="date" required style={INPUT_STYLE} disabled={pending} /></label>
+          <label className="block text-xs" style={{ color: SAO.color.text.label }}>Distance km<input name="distanceKm" type="number" min={0} step="any" style={INPUT_STYLE} disabled={pending} /></label>
+          <label className="block text-xs" style={{ color: SAO.color.text.label }}>Calories<input name="calories" type="number" min={0} style={INPUT_STYLE} disabled={pending} /></label>
+          <label className="block text-xs" style={{ color: SAO.color.text.label }}>Memo<textarea name="memo" rows={2} style={{ ...INPUT_STYLE, resize: "vertical" }} disabled={pending} /></label>
+        </>
+      ) : (
+        <>
+          {select("mediaCategory", "Media category", MEDIA_CATEGORIES)}
+          <label className="block text-xs" style={{ color: SAO.color.text.label }}>Media title<input name="mediaTitle" required style={INPUT_STYLE} disabled={pending} /></label>
+          {select("mediaStatus", "Media status", MEDIA_STATUSES)}
+          <label className="block text-xs" style={{ color: SAO.color.text.label }}>Current episode<input name="currentEpisode" type="number" min={0} style={INPUT_STYLE} disabled={pending} /></label>
+          <label className="block text-xs" style={{ color: SAO.color.text.label }}>Total episodes<input name="totalEpisode" type="number" min={1} style={INPUT_STYLE} disabled={pending} /></label>
+        </>
+      )}
+
+      {error ? <p role="alert" className="text-xs" style={{ color: SAO.color.action.red }}>{error}</p> : null}
+      {result ? <p role="status" className="text-xs" style={{ color: SAO.color.text.gold }}>{result.replay ? "Quick Record replay confirmed." : "Quick Record saved."}</p> : null}
+      {refreshError ? <p role="alert" className="text-xs" style={{ color: SAO.color.action.red }}>{refreshError}</p> : null}
+      <div className="flex gap-2">
+        {canRetry
+          ? <button type="button" disabled={pending} style={{ ...secondaryButton, flex: 1 }} onClick={() => void onRetry().then(resetAfter)}>Retry same record</button>
+          : <button type="submit" disabled={pending} style={{ ...secondaryButton, flex: 1 }}>{pending ? "Saving..." : "Save Quick Record"}</button>}
+      </div>
+    </form>
+  );
+}
 
 function ErrorState({ text, retry }: { text: string; retry: () => void }) {
   return (
@@ -127,6 +328,24 @@ export default function JournalShell({ roles, rolesLoading = false, rolesError =
     <div className="relative flex min-w-0 w-fit flex-row flex-nowrap items-center gap-3" data-testid="journal-shell">
       <PanelFrame title="Journal Filters" depth={2}>
         <div className="space-y-3 px-3">
+          <details>
+            <summary className="cursor-pointer text-xs" style={{ color: SAO.color.text.gold }}>Quick Record</summary>
+            <div className="mt-3">
+              <QuickRecordForm
+                roles={roles}
+                rolesLoading={rolesLoading}
+                rolesError={rolesError}
+                pending={journal.quickRecord.pending}
+                error={journal.quickRecord.error}
+                result={journal.quickRecord.result}
+                refreshError={journal.quickRecord.refreshError}
+                canRetry={journal.quickRecord.canRetry}
+                onSubmit={journal.quickRecord.submit}
+                onRetry={journal.quickRecord.retry}
+                onEdit={journal.quickRecord.invalidateRetry}
+              />
+            </div>
+          </details>
           <label className="block text-xs" style={{ color: SAO.color.text.label }}>
             Role
             <select aria-label="Role filter" value={journal.params.primaryRoleId ?? ""} style={INPUT_STYLE} onChange={(event) => journal.changeRoleFilter(event.target.value ? Number(event.target.value) : undefined)}>

--- a/features/lifelog/api.test.ts
+++ b/features/lifelog/api.test.ts
@@ -1,10 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { JournalPage, JournalSubtype } from "@/shared/api/types";
-import { getJournalDetailApi, listJournalApi } from "./api";
-import { journalMock, MOCK_JOURNAL_ENTRIES } from "./mock";
+import type { JournalPage, JournalSubtype, QuickRecordRequest } from "@/shared/api/types";
+import { getJournalDetailApi, listJournalApi, quickRecordApi } from "./api";
+import { journalMock, MOCK_JOURNAL_ENTRIES, resetJournalMock } from "./mock";
 
-const client = vi.hoisted(() => ({ apiGet: vi.fn() }));
+const client = vi.hoisted(() => ({ apiGet: vi.fn(), apiPost: vi.fn() }));
 
 vi.mock("@/shared/api/client", () => ({ USE_MOCK: false, ...client }));
 
@@ -13,7 +13,9 @@ const emptyPage: JournalPage = { content: [], page: 0, size: 20, totalElements: 
 describe("Journal을 실제 backend에서 읽을 때", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    resetJournalMock();
     client.apiGet.mockResolvedValue(emptyPage);
+    client.apiPost.mockResolvedValue({ sourceType: "COLLECTION", sourceId: 31, recordedAt: "2026-08-14T00:00:00Z", replay: false });
   });
 
   describe("목록 filter와 server page를 요청하면", () => {
@@ -42,6 +44,30 @@ describe("Journal을 실제 backend에서 읽을 때", () => {
     });
   });
 
+  describe("Quick Record를 저장하면", () => {
+    it("self endpoint에 exact payload와 Idempotency-Key만 전달한다", async () => {
+      const body: QuickRecordRequest = {
+        type: "COLLECTION",
+        lifeLogSubtype: "MEMORY",
+        primaryRoleId: 31,
+        collection: { category: "BOOK", title: "Private title", quantity: 1 },
+      };
+
+      await quickRecordApi(body, "quick-key-31");
+
+      expect(client.apiPost).toHaveBeenCalledWith("/api/v1/lifelogs/quick-record", body, {
+        headers: { "Idempotency-Key": "quick-key-31" },
+      });
+      expect(body).not.toHaveProperty("playerId");
+      expect(body).not.toHaveProperty("userId");
+      expect(body.collection).not.toHaveProperty("lifeLogSubtype");
+      expect(body.collection).not.toHaveProperty("primaryRoleId");
+      expect(body.collection).not.toHaveProperty("roleEventId");
+      expect(body).not.toHaveProperty("reflectionScope");
+      expect(body).not.toHaveProperty("roleEventId");
+    });
+  });
+
   describe("mock mode contract를 사용하면", () => {
     it("세 physical source와 QUICK entryMode, nullable legacy metadata만 제공한다", () => {
       const sourceTypes = MOCK_JOURNAL_ENTRIES.map(({ sourceType }) => sourceType as string);
@@ -62,6 +88,27 @@ describe("Journal을 실제 backend에서 읽을 때", () => {
       expect(firstPage).toEqual(expect.objectContaining({ page: 0, size: 2, totalElements: 4, totalPages: 2 }));
       expect(rolePage.content.map(({ lifeLogId }) => lifeLogId)).toEqual([102]);
       expect(journalMock.detail(103)).toEqual(expect.objectContaining({ lifeLogId: 103, sourceType: "EXERCISE", entryMode: "QUICK" }));
+    });
+
+    it("같은 key/payload는 같은 Source를 replay하고 Journal authority에 한 번만 기록한다", () => {
+      const body: QuickRecordRequest = {
+        type: "EXERCISE",
+        lifeLogSubtype: "ACTIVITY",
+        exercise: { category: "RUNNING", durationMinutes: 1, exercisedOn: "2026-08-14", distanceKm: 0, calories: 0 },
+      };
+
+      const first = journalMock.quickRecord(body, "same-key");
+      const replay = journalMock.quickRecord(body, "same-key");
+      const page = journalMock.page({ page: 0, size: 20 });
+      const matches = page.content.filter((entry) => entry.sourceType === first.sourceType && entry.sourceId === first.sourceId);
+
+      expect(first.replay).toBe(false);
+      expect(replay).toEqual({ ...first, replay: true });
+      expect(matches).toHaveLength(1);
+      expect(matches[0].entryMode).toBe("QUICK");
+      expect(matches[0].lifeLogId).not.toBe(first.sourceId);
+      expect(matches[0].preview).toEqual(expect.objectContaining({ distanceKm: 0, calories: 0 }));
+      expect(journalMock.detail(matches[0].lifeLogId)).toEqual(expect.objectContaining({ sourceId: first.sourceId }));
     });
   });
 });

--- a/features/lifelog/api.test.ts
+++ b/features/lifelog/api.test.ts
@@ -66,6 +66,21 @@ describe("Journal을 실제 backend에서 읽을 때", () => {
       expect(body).not.toHaveProperty("reflectionScope");
       expect(body).not.toHaveProperty("roleEventId");
     });
+
+    it("Media progress를 생략한 request를 invent하지 않고 그대로 전달한다", async () => {
+      const body: QuickRecordRequest = {
+        type: "MEDIA",
+        media: { category: "ANIME", title: "Frieren", status: "WATCHING" },
+      };
+
+      await quickRecordApi(body, "media-key");
+
+      expect(client.apiPost).toHaveBeenCalledWith("/api/v1/lifelogs/quick-record", body, {
+        headers: { "Idempotency-Key": "media-key" },
+      });
+      expect(body.media).not.toHaveProperty("currentEpisode");
+      expect(body.media).not.toHaveProperty("totalEpisode");
+    });
   });
 
   describe("mock mode contract를 사용하면", () => {
@@ -109,6 +124,55 @@ describe("Journal을 실제 backend에서 읽을 때", () => {
       expect(matches[0].lifeLogId).not.toBe(first.sourceId);
       expect(matches[0].preview).toEqual(expect.objectContaining({ distanceKm: 0, calories: 0 }));
       expect(journalMock.detail(matches[0].lifeLogId)).toEqual(expect.objectContaining({ sourceId: first.sourceId }));
+    });
+
+    describe("Media progress를 canonical Journal state로 materialize하면", () => {
+      it.each([
+        ["둘 다 생략", undefined, undefined, 0, 1],
+        ["current zero만 제공", 0, undefined, 0, 1],
+        ["current 5만 제공", 5, undefined, 5, 5],
+        ["total 12만 제공", undefined, 12, 0, 12],
+        ["둘 다 제공", 5, 12, 5, 12],
+      ])("%s이면 preview/detail에 normalized pair를 함께 사용한다", (_case, currentEpisode, totalEpisode, current, total) => {
+        const body: QuickRecordRequest = {
+          type: "MEDIA",
+          media: {
+            category: "ANIME",
+            title: "Progress case",
+            status: "WATCHING",
+            ...(currentEpisode === undefined ? {} : { currentEpisode }),
+            ...(totalEpisode === undefined ? {} : { totalEpisode }),
+          },
+        };
+
+        const result = journalMock.quickRecord(body, `progress-${_case}`);
+        const entry = journalMock.page({ page: 0, size: 20 }).content.find(({ sourceType, sourceId }) =>
+          sourceType === result.sourceType && sourceId === result.sourceId
+        );
+        if (!entry || entry.sourceType !== "MEDIA") throw new Error("Media Journal entry not found.");
+        const detail = journalMock.detail(entry.lifeLogId);
+        if (detail.sourceType !== "MEDIA") throw new Error("Media Journal detail not found.");
+
+        expect(entry.preview).toEqual(expect.objectContaining({ currentEpisode: current, totalEpisode: total }));
+        expect(detail.source).toEqual(expect.objectContaining({ currentEpisode: current, totalEpisode: total }));
+      });
+
+      it("same-key replay는 normalized row를 중복 생성하지 않는다", () => {
+        const body: QuickRecordRequest = {
+          type: "MEDIA",
+          media: { category: "ANIME", title: "Replay", status: "WATCHING", currentEpisode: 5 },
+        };
+
+        const first = journalMock.quickRecord(body, "media-replay");
+        const replay = journalMock.quickRecord(body, "media-replay");
+        const matches = journalMock.page({ page: 0, size: 20 }).content.filter(({ sourceType, sourceId }) =>
+          sourceType === first.sourceType && sourceId === first.sourceId
+        );
+
+        expect(replay).toEqual({ ...first, replay: true });
+        expect(matches).toHaveLength(1);
+        expect(matches[0].preview).toEqual(expect.objectContaining({ currentEpisode: 5, totalEpisode: 5 }));
+      });
     });
   });
 });

--- a/features/lifelog/api.ts
+++ b/features/lifelog/api.ts
@@ -1,5 +1,5 @@
-import { USE_MOCK, apiGet } from "@/shared/api/client";
-import type { JournalDetail, JournalListParams, JournalPage } from "@/shared/api/types";
+import { USE_MOCK, apiGet, apiPost } from "@/shared/api/client";
+import type { JournalDetail, JournalListParams, JournalPage, QuickRecordRequest, QuickRecordResult } from "@/shared/api/types";
 import { journalMock } from "./mock";
 
 export function listJournalApi(params: JournalListParams): Promise<JournalPage> {
@@ -16,4 +16,12 @@ export function getJournalDetailApi(lifeLogId: number): Promise<JournalDetail> {
   return USE_MOCK
     ? Promise.resolve(journalMock.detail(lifeLogId))
     : apiGet<JournalDetail>(`/api/v1/lifelogs/${lifeLogId}`);
+}
+
+export function quickRecordApi(body: QuickRecordRequest, idempotencyKey: string): Promise<QuickRecordResult> {
+  return USE_MOCK
+    ? Promise.resolve().then(() => journalMock.quickRecord(body, idempotencyKey))
+    : apiPost<QuickRecordResult>("/api/v1/lifelogs/quick-record", body, {
+        headers: { "Idempotency-Key": idempotencyKey },
+      });
 }

--- a/features/lifelog/mock.ts
+++ b/features/lifelog/mock.ts
@@ -137,6 +137,11 @@ function copy<T>(value: T): T {
   return structuredClone(value);
 }
 
+function normalizeMediaProgress(currentEpisode?: number, totalEpisode?: number) {
+  const current = currentEpisode ?? 0;
+  return { currentEpisode: current, totalEpisode: totalEpisode ?? Math.max(1, current) };
+}
+
 export function resetJournalMock(): void {
   journalEntries = structuredClone([...MOCK_JOURNAL_ENTRIES]);
   journalDetails = structuredClone(MOCK_JOURNAL_DETAILS);
@@ -199,8 +204,7 @@ function recordQuick(body: QuickRecordRequest, idempotencyKey: string): QuickRec
       category: body.media.category,
       title: body.media.title,
       originalTitle: null,
-      currentEpisode: body.media.currentEpisode ?? 0,
-      totalEpisode: body.media.totalEpisode ?? 1,
+      ...normalizeMediaProgress(body.media.currentEpisode, body.media.totalEpisode),
       status: body.media.status,
       tags: [],
     };

--- a/features/lifelog/mock.ts
+++ b/features/lifelog/mock.ts
@@ -1,4 +1,11 @@
-import type { JournalDetail, JournalEntry, JournalListParams, JournalPage } from "@/shared/api/types";
+import type {
+  JournalDetail,
+  JournalEntry,
+  JournalListParams,
+  JournalPage,
+  QuickRecordRequest,
+  QuickRecordResult,
+} from "@/shared/api/types";
 
 export const MOCK_JOURNAL_ENTRIES = [
   {
@@ -122,13 +129,107 @@ export const MOCK_JOURNAL_DETAILS = [
   },
 ] satisfies JournalDetail[];
 
+let journalEntries: JournalEntry[] = structuredClone([...MOCK_JOURNAL_ENTRIES]);
+let journalDetails: JournalDetail[] = structuredClone(MOCK_JOURNAL_DETAILS);
+const quickRecordReceipts = new Map<string, { payload: string; result: QuickRecordResult }>();
+
 function copy<T>(value: T): T {
   return structuredClone(value);
 }
 
+export function resetJournalMock(): void {
+  journalEntries = structuredClone([...MOCK_JOURNAL_ENTRIES]);
+  journalDetails = structuredClone(MOCK_JOURNAL_DETAILS);
+  quickRecordReceipts.clear();
+}
+
+function recordQuick(body: QuickRecordRequest, idempotencyKey: string): QuickRecordResult {
+  const payload = JSON.stringify(body);
+  const receipt = quickRecordReceipts.get(idempotencyKey);
+  if (receipt) {
+    if (receipt.payload !== payload) throw new Error("Idempotency key payload conflict.");
+    return copy({ ...receipt.result, replay: true });
+  }
+
+  const lifeLogId = Math.max(0, ...journalEntries.map((entry) => entry.lifeLogId)) + 1;
+  const sourceId = Math.max(0, ...journalEntries.map((entry) => entry.sourceId)) + 1;
+  const recordedAt = new Date().toISOString();
+  const metadata = {
+    lifeLogId,
+    sourceId,
+    subtype: body.lifeLogSubtype ?? null,
+    entryMode: "QUICK" as const,
+    reflectionScope: null,
+    periodKey: null,
+    primaryRoleId: body.primaryRoleId ?? null,
+    roleEventId: null,
+    recordedAt,
+  };
+
+  let entry: JournalEntry;
+  let detail: JournalDetail;
+  if (body.type === "COLLECTION") {
+    entry = { ...metadata, sourceType: "COLLECTION", preview: { ...body.collection } };
+    detail = {
+      ...metadata,
+      sourceType: "COLLECTION",
+      source: {
+        ...body.collection,
+        originalTitle: null,
+        conditionNote: null,
+        acquiredFrom: null,
+        tags: [],
+        createdAt: recordedAt,
+        updatedAt: recordedAt,
+      },
+    };
+  } else if (body.type === "EXERCISE") {
+    const source = {
+      category: body.exercise.category,
+      durationMinutes: body.exercise.durationMinutes,
+      distanceKm: body.exercise.distanceKm ?? null,
+      calories: body.exercise.calories ?? null,
+      exercisedOn: body.exercise.exercisedOn,
+      memo: body.exercise.memo ?? null,
+    };
+    entry = { ...metadata, sourceType: "EXERCISE", preview: source };
+    detail = { ...metadata, sourceType: "EXERCISE", source: { ...source, createdAt: recordedAt, updatedAt: recordedAt } };
+  } else {
+    const source = {
+      category: body.media.category,
+      title: body.media.title,
+      originalTitle: null,
+      currentEpisode: body.media.currentEpisode ?? 0,
+      totalEpisode: body.media.totalEpisode ?? 1,
+      status: body.media.status,
+      tags: [],
+    };
+    entry = { ...metadata, sourceType: "MEDIA", preview: { ...source, rating: null } };
+    detail = {
+      ...metadata,
+      sourceType: "MEDIA",
+      source: {
+        ...source,
+        rating: null,
+        rewatchCount: 0,
+        startedOn: null,
+        finishedOn: null,
+        createdAt: recordedAt,
+        updatedAt: recordedAt,
+      },
+    };
+  }
+
+  journalEntries.unshift(entry);
+  journalDetails.unshift(detail);
+  const result = { sourceType: body.type, sourceId, recordedAt, replay: false } satisfies QuickRecordResult;
+  quickRecordReceipts.set(idempotencyKey, { payload, result });
+  return copy(result);
+}
+
 export const journalMock = {
   page: ({ primaryRoleId, subtype, page, size }: JournalListParams): JournalPage => {
-    const filtered = MOCK_JOURNAL_ENTRIES.filter((entry) =>
+    const filtered = journalEntries.filter((entry) =>
       (primaryRoleId === undefined || entry.primaryRoleId === primaryRoleId)
       && (subtype === undefined || entry.subtype === subtype)
     );
@@ -141,8 +242,9 @@ export const journalMock = {
     });
   },
   detail: (lifeLogId: number): JournalDetail => {
-    const detail = MOCK_JOURNAL_DETAILS.find((entry) => entry.lifeLogId === lifeLogId);
+    const detail = journalDetails.find((entry) => entry.lifeLogId === lifeLogId);
     if (!detail) throw new Error("Journal entry not found.");
     return copy(detail);
   },
+  quickRecord: recordQuick,
 };

--- a/features/lifelog/useJournalQueries.test.tsx
+++ b/features/lifelog/useJournalQueries.test.tsx
@@ -1,13 +1,14 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { JournalDetail, JournalPage } from "@/shared/api/types";
+import type { JournalDetail, JournalPage, QuickRecordRequest, QuickRecordResult } from "@/shared/api/types";
 import { journalMock } from "./mock";
 import { useJournalQueries } from "./useJournalQueries";
 
 const api = vi.hoisted(() => ({
   getJournalDetailApi: vi.fn(),
   listJournalApi: vi.fn(),
+  quickRecordApi: vi.fn(),
 }));
 
 vi.mock("./api", () => api);
@@ -23,12 +24,25 @@ function deferred<T>() {
 }
 
 const page = journalMock.page({ page: 0, size: 20 });
+const quickBody: QuickRecordRequest = {
+  type: "COLLECTION",
+  collection: { category: "BOOK", title: "Quick book", quantity: 1 },
+};
+const quickResult: QuickRecordResult = {
+  sourceType: "COLLECTION",
+  sourceId: 999,
+  recordedAt: "2026-08-14T00:00:00Z",
+  replay: false,
+};
+const quickEntry = { ...page.content[0], lifeLogId: 777, sourceId: 999, entryMode: "QUICK" as const };
+const pageWithQuick = { ...page, content: [quickEntry, ...page.content], totalElements: page.totalElements + 1 };
 
 describe("Journal server query state를 관리할 때", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     api.listJournalApi.mockResolvedValue(page);
     api.getJournalDetailApi.mockImplementation(async (lifeLogId: number) => journalMock.detail(lifeLogId));
+    api.quickRecordApi.mockResolvedValue(quickResult);
   });
 
   describe("filter 또는 page를 변경하면", () => {
@@ -155,6 +169,118 @@ describe("Journal server query state를 관리할 때", () => {
       expect(result.current.detail.data?.lifeLogId).toBe(103);
       expect(result.current.detail.loading).toBe(false);
       expect(result.current.detail.error).toBeNull();
+    });
+  });
+
+  describe("Quick Record logical submission을 수행하면", () => {
+    it("failed Retry에 exact payload/key를 재사용하고 reload 결과의 canonical lifeLogId를 선택한다", async () => {
+      api.quickRecordApi.mockRejectedValueOnce(new Error("response lost")).mockResolvedValueOnce({ ...quickResult, replay: true });
+      api.listJournalApi.mockResolvedValueOnce(page).mockResolvedValueOnce(pageWithQuick);
+      api.getJournalDetailApi.mockImplementation(async (lifeLogId: number) => ({ ...journalMock.detail(104), lifeLogId, sourceId: 999 }));
+      const { result } = renderHook(() => useJournalQueries());
+      await waitFor(() => expect(result.current.list.data).toEqual(page));
+
+      await act(async () => { await result.current.quickRecord.submit(quickBody); });
+      const [failedBody, failedKey] = api.quickRecordApi.mock.calls[0];
+      expect(result.current.quickRecord.canRetry).toBe(true);
+
+      await act(async () => { await result.current.quickRecord.retry(); });
+
+      expect(api.quickRecordApi).toHaveBeenNthCalledWith(2, failedBody, failedKey);
+      expect(result.current.quickRecord.result?.replay).toBe(true);
+      expect(result.current.selectedLifeLogId).toBe(777);
+      expect(api.getJournalDetailApi).toHaveBeenCalledWith(777);
+      expect(api.getJournalDetailApi).not.toHaveBeenCalledWith(999);
+    });
+
+    it("failure 뒤 edit는 retained Retry를 버리고 다음 Submit에 새 key를 만든다", async () => {
+      api.quickRecordApi.mockRejectedValueOnce(new Error("ambiguous")).mockResolvedValueOnce(quickResult);
+      const { result } = renderHook(() => useJournalQueries());
+      await waitFor(() => expect(result.current.list.data).toEqual(page));
+
+      await act(async () => { await result.current.quickRecord.submit(quickBody); });
+      const firstKey = api.quickRecordApi.mock.calls[0][1];
+      act(() => result.current.quickRecord.invalidateRetry());
+      expect(result.current.quickRecord.canRetry).toBe(false);
+
+      const edited = { ...quickBody, collection: { ...quickBody.collection, title: "Edited book" } } as QuickRecordRequest;
+      await act(async () => { await result.current.quickRecord.submit(edited); });
+
+      expect(api.quickRecordApi.mock.calls[1][1]).not.toBe(firstKey);
+      expect(api.quickRecordApi.mock.calls[1][0]).toEqual(edited);
+    });
+
+    it("pending duplicate를 무시하고 authoritative reload 전에는 list를 optimistic 변경하지 않는다", async () => {
+      const request = deferred<QuickRecordResult>();
+      api.quickRecordApi.mockReturnValue(request.promise);
+      api.listJournalApi.mockResolvedValueOnce(page).mockResolvedValueOnce(pageWithQuick);
+      const { result } = renderHook(() => useJournalQueries());
+      await waitFor(() => expect(result.current.list.data).toEqual(page));
+
+      act(() => {
+        void result.current.quickRecord.submit(quickBody);
+        void result.current.quickRecord.submit(quickBody);
+      });
+      expect(api.quickRecordApi).toHaveBeenCalledOnce();
+      expect(result.current.list.data).toEqual(page);
+
+      await act(async () => {
+        request.resolve(quickResult);
+        await request.promise;
+      });
+      await waitFor(() => expect(result.current.list.data).toEqual(pageWithQuick));
+    });
+
+    it("current filter가 새 Source를 숨기면 filter를 보존하고 selection을 만들지 않는다", async () => {
+      const filtered = journalMock.page({ primaryRoleId: 2, page: 0, size: 20 });
+      api.listJournalApi.mockImplementation(async (params) => params.primaryRoleId === 2 ? filtered : page);
+      const { result } = renderHook(() => useJournalQueries());
+      await waitFor(() => expect(result.current.list.data).toEqual(page));
+      act(() => result.current.changeRoleFilter(2));
+      await waitFor(() => expect(result.current.params.primaryRoleId).toBe(2));
+
+      await act(async () => { await result.current.quickRecord.submit(quickBody); });
+
+      expect(result.current.params).toEqual({ page: 0, size: 20, primaryRoleId: 2 });
+      expect(result.current.selectedLifeLogId).toBeNull();
+      expect(api.getJournalDetailApi).not.toHaveBeenCalled();
+    });
+
+    it("pending 중 filter가 바뀌어도 post-save reload는 최신 filter를 사용한다", async () => {
+      const request = deferred<QuickRecordResult>();
+      const filtered = journalMock.page({ primaryRoleId: 2, page: 0, size: 20 });
+      api.quickRecordApi.mockReturnValue(request.promise);
+      api.listJournalApi.mockImplementation(async (params) => params.primaryRoleId === 2 ? filtered : page);
+      const { result } = renderHook(() => useJournalQueries());
+      await waitFor(() => expect(result.current.list.data).toEqual(page));
+
+      act(() => void result.current.quickRecord.submit(quickBody));
+      act(() => result.current.changeRoleFilter(2));
+      await waitFor(() => expect(api.listJournalApi).toHaveBeenCalledTimes(2));
+      await act(async () => {
+        request.resolve(quickResult);
+        await request.promise;
+      });
+
+      await waitFor(() => expect(api.listJournalApi).toHaveBeenCalledTimes(3));
+      expect(api.listJournalApi).toHaveBeenLastCalledWith({ page: 0, size: 20, primaryRoleId: 2 });
+      expect(result.current.params.primaryRoleId).toBe(2);
+      expect(result.current.selectedLifeLogId).toBeNull();
+    });
+
+    it("Journal reload 실패는 recording success를 유지하고 별도 refresh error를 남긴다", async () => {
+      api.listJournalApi.mockResolvedValueOnce(page).mockRejectedValueOnce(new Error("Journal refresh unavailable"));
+      const { result } = renderHook(() => useJournalQueries());
+      await waitFor(() => expect(result.current.list.data).toEqual(page));
+
+      let saved: QuickRecordResult | undefined;
+      await act(async () => { saved = await result.current.quickRecord.submit(quickBody); });
+
+      expect(saved).toEqual(quickResult);
+      expect(result.current.quickRecord.result).toEqual(quickResult);
+      expect(result.current.quickRecord.error).toBeNull();
+      expect(result.current.quickRecord.refreshError).toContain("Quick Record succeeded");
+      expect(result.current.list.error).toBe("Journal refresh unavailable");
     });
   });
 });

--- a/features/lifelog/useJournalQueries.ts
+++ b/features/lifelog/useJournalQueries.ts
@@ -2,8 +2,8 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import type { JournalDetail, JournalListParams, JournalPage, JournalSubtype } from "@/shared/api/types";
-import { getJournalDetailApi, listJournalApi } from "./api";
+import type { JournalDetail, JournalListParams, JournalPage, JournalSubtype, QuickRecordRequest, QuickRecordResult } from "@/shared/api/types";
+import { getJournalDetailApi, listJournalApi, quickRecordApi } from "./api";
 
 const INITIAL_PARAMS: JournalListParams = { page: 0, size: 20 };
 const EMPTY_PAGE: JournalPage = { content: [], page: 0, size: 20, totalElements: 0, totalPages: 0 };
@@ -12,6 +12,14 @@ type DetailState = {
   data: JournalDetail | null;
   loading: boolean;
   error: string | null;
+};
+
+type QuickRecordState = {
+  pending: boolean;
+  error: string | null;
+  result: QuickRecordResult | null;
+  refreshError: string | null;
+  canRetry: boolean;
 };
 
 function message(caught: unknown, fallback: string): string {
@@ -25,9 +33,19 @@ export function useJournalQueries() {
   const [listError, setListError] = useState<string | null>(null);
   const [selectedLifeLogId, setSelectedLifeLogId] = useState<number | null>(null);
   const [detail, setDetail] = useState<DetailState>({ data: null, loading: false, error: null });
+  const paramsRef = useRef<JournalListParams>(INITIAL_PARAMS);
   const listRequestId = useRef(0);
   const detailRequestId = useRef(0);
   const selectedLifeLogIdRef = useRef<number | null>(null);
+  const quickRecordLocked = useRef(false);
+  const failedQuickRecord = useRef<{ body: QuickRecordRequest; key: string } | null>(null);
+  const [quickRecord, setQuickRecord] = useState<QuickRecordState>({
+    pending: false,
+    error: null,
+    result: null,
+    refreshError: null,
+    canRetry: false,
+  });
 
   const clearSelection = useCallback(() => {
     selectedLifeLogIdRef.current = null;
@@ -41,8 +59,8 @@ export function useJournalQueries() {
     setListLoading(true);
     setListError(null);
     try {
-      const next = await listJournalApi(params);
-      if (requestId !== listRequestId.current) return next;
+      const next = await listJournalApi(paramsRef.current);
+      if (requestId !== listRequestId.current) return undefined;
       setPageData(next);
       const selectedId = selectedLifeLogIdRef.current;
       if (selectedId !== null && !next.content.some(({ lifeLogId }) => lifeLogId === selectedId)) clearSelection();
@@ -53,7 +71,7 @@ export function useJournalQueries() {
     } finally {
       if (requestId === listRequestId.current) setListLoading(false);
     }
-  }, [clearSelection, params]);
+  }, [clearSelection]);
 
   const loadDetail = useCallback(async (lifeLogId: number, preserve = false) => {
     const requestId = ++detailRequestId.current;
@@ -76,7 +94,7 @@ export function useJournalQueries() {
 
   useEffect(() => {
     void reloadList();
-  }, [reloadList]);
+  }, [params, reloadList]);
 
   const selectEntry = useCallback((lifeLogId: number) => {
     selectedLifeLogIdRef.current = lifeLogId;
@@ -84,19 +102,78 @@ export function useJournalQueries() {
     void loadDetail(lifeLogId);
   }, [loadDetail]);
 
+  const runQuickRecord = useCallback(async (body: QuickRecordRequest, key: string) => {
+    if (quickRecordLocked.current) return undefined;
+    quickRecordLocked.current = true;
+    setQuickRecord({ pending: true, error: null, result: null, refreshError: null, canRetry: false });
+    try {
+      const result = await quickRecordApi(body, key);
+      failedQuickRecord.current = null;
+      setQuickRecord({ pending: true, error: null, result, refreshError: null, canRetry: false });
+
+      const nextPage = await reloadList();
+      if (!nextPage) {
+        setQuickRecord((current) => ({
+          ...current,
+          refreshError: "Quick Record succeeded, but Journal refresh failed. Retry the Journal list.",
+        }));
+      } else {
+        const matching = nextPage.content.find((entry) =>
+          entry.sourceType === result.sourceType && entry.sourceId === result.sourceId
+        );
+        if (matching) selectEntry(matching.lifeLogId);
+      }
+      return result;
+    } catch (caught) {
+      failedQuickRecord.current = { body, key };
+      setQuickRecord({
+        pending: false,
+        error: message(caught, "Unable to save Quick Record."),
+        result: null,
+        refreshError: null,
+        canRetry: true,
+      });
+      return undefined;
+    } finally {
+      quickRecordLocked.current = false;
+      setQuickRecord((current) => ({ ...current, pending: false }));
+    }
+  }, [reloadList, selectEntry]);
+
+  const submitQuickRecord = useCallback((body: QuickRecordRequest) => {
+    const failed = failedQuickRecord.current;
+    return failed
+      ? runQuickRecord(failed.body, failed.key)
+      : runQuickRecord(structuredClone(body), globalThis.crypto.randomUUID());
+  }, [runQuickRecord]);
+
+  const retryQuickRecord = useCallback(() => {
+    const failed = failedQuickRecord.current;
+    return failed ? runQuickRecord(failed.body, failed.key) : Promise.resolve(undefined);
+  }, [runQuickRecord]);
+
+  const invalidateQuickRecordRetry = () => {
+    if (!failedQuickRecord.current) return;
+    failedQuickRecord.current = null;
+    setQuickRecord((current) => ({ ...current, error: null, canRetry: false }));
+  };
+
   const changeRoleFilter = (primaryRoleId?: number) => {
     listRequestId.current += 1;
-    setParams((current) => ({ ...current, primaryRoleId, page: 0 }));
+    paramsRef.current = { ...paramsRef.current, primaryRoleId, page: 0 };
+    setParams(paramsRef.current);
   };
 
   const changeSubtypeFilter = (subtype?: JournalSubtype) => {
     listRequestId.current += 1;
-    setParams((current) => ({ ...current, subtype, page: 0 }));
+    paramsRef.current = { ...paramsRef.current, subtype, page: 0 };
+    setParams(paramsRef.current);
   };
 
   const changePage = (page: number) => {
     listRequestId.current += 1;
-    setParams((current) => ({ ...current, page }));
+    paramsRef.current = { ...paramsRef.current, page };
+    setParams(paramsRef.current);
   };
 
   const retryDetail = () => {
@@ -107,6 +184,12 @@ export function useJournalQueries() {
     params,
     list: { data: pageData, loading: listLoading, error: listError, reload: reloadList },
     detail: { ...detail, retry: retryDetail },
+    quickRecord: {
+      ...quickRecord,
+      submit: submitQuickRecord,
+      retry: retryQuickRecord,
+      invalidateRetry: invalidateQuickRecordRetry,
+    },
     selectedLifeLogId,
     selectEntry,
     changeRoleFilter,

--- a/shared/api/client.test.ts
+++ b/shared/api/client.test.ts
@@ -99,6 +99,18 @@ describe("backend API에 요청할 때", () => {
       const headers = new Headers(fetchMock.mock.calls[0][1]?.headers);
       expect(headers.has("Authorization")).toBe(false);
     });
+
+    it("caller header를 추가하되 Authorization은 client authority로 유지한다", async () => {
+      tokenStorage.write(oldSession);
+      fetchMock.mockResolvedValueOnce(response("ok"));
+
+      await apiPost("/protected", {}, { headers: { "Idempotency-Key": "quick-key", Authorization: "Bearer caller" } });
+
+      const headers = new Headers(fetchMock.mock.calls[0][1]?.headers);
+      expect(headers.get("Idempotency-Key")).toBe("quick-key");
+      expect(headers.get("Authorization")).toBe("Bearer old-access");
+      expect(headers.get("Content-Type")).toBe("application/json");
+    });
   });
 
   describe("인증 요청이 401이면", () => {
@@ -114,6 +126,22 @@ describe("backend API에 요청할 때", () => {
       expect(fetchMock).toHaveBeenCalledTimes(3);
       expect(fetchMock.mock.calls[1][0]).toContain("/api/v1/auth/refresh");
       expect(new Headers(fetchMock.mock.calls[2][1]?.headers).get("Authorization")).toBe("Bearer new-access");
+    });
+
+    it("refresh retry에도 caller Idempotency-Key를 그대로 보존한다", async () => {
+      tokenStorage.write(oldSession);
+      fetchMock
+        .mockResolvedValueOnce(response(null, 401, { isSuccess: false }))
+        .mockResolvedValueOnce(response(newSession))
+        .mockResolvedValueOnce(response({ sourceId: 31 }));
+
+      await apiPost("/api/v1/lifelogs/quick-record", { type: "COLLECTION" }, { headers: { "Idempotency-Key": "stable-key" } });
+
+      const first = new Headers(fetchMock.mock.calls[0][1]?.headers);
+      const retried = new Headers(fetchMock.mock.calls[2][1]?.headers);
+      expect(first.get("Idempotency-Key")).toBe("stable-key");
+      expect(retried.get("Idempotency-Key")).toBe("stable-key");
+      expect(retried.get("Authorization")).toBe("Bearer new-access");
     });
 
     it("재시도도 401이면 refresh를 반복하지 않는다", async () => {

--- a/shared/api/client.ts
+++ b/shared/api/client.ts
@@ -17,6 +17,7 @@ export class ApiError extends Error {
 
 type RequestOptions = {
   auth?: boolean;
+  headers?: HeadersInit;
   rawResponse?: boolean;
   retry?: boolean;
   token?: string;
@@ -94,9 +95,11 @@ async function apiRequest<T>(
   options: RequestOptions = {},
 ): Promise<T> {
   const auth = options.auth !== false;
-  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  const headers = new Headers(options.headers);
+  headers.set("Content-Type", "application/json");
+  headers.delete("Authorization");
   const accessToken = options.token ?? (auth ? tokenStorage.read()?.accessToken : undefined);
-  if (auth && accessToken) headers.Authorization = `Bearer ${accessToken}`;
+  if (auth && accessToken) headers.set("Authorization", `Bearer ${accessToken}`);
 
   const response = await fetch(`${BASE_URL}${path}`, {
     method,

--- a/shared/api/types/lifelog.ts
+++ b/shared/api/types/lifelog.ts
@@ -111,3 +111,53 @@ export interface JournalListParams {
   page: number;
   size: number;
 }
+
+export type QuickRecordType = JournalSourceType;
+export type QuickRecordCollectionCategory = "FIGURE" | "CARD" | "BOOK" | "GAME" | "STAMP" | "COIN" | "OTHER";
+export type QuickRecordExerciseCategory = "RUNNING" | "WALKING" | "CYCLING" | "SWIMMING" | "GYM" | "YOGA" | "OTHER";
+export type QuickRecordMediaCategory = "ANIME" | "MOVIE" | "SERIES" | "BOOK" | "WEBTOON" | "GAME" | "MUSIC";
+export type QuickRecordMediaStatus = "PLANNED" | "WATCHING" | "COMPLETED" | "DROPPED" | "ON_HOLD";
+
+type QuickRecordMetadata = {
+  lifeLogSubtype?: JournalSubtype;
+  primaryRoleId?: number;
+};
+
+export type QuickRecordRequest = QuickRecordMetadata & (
+  | {
+      type: "COLLECTION";
+      collection: {
+        category: QuickRecordCollectionCategory;
+        title: string;
+        quantity: number;
+      };
+    }
+  | {
+      type: "EXERCISE";
+      exercise: {
+        category: QuickRecordExerciseCategory;
+        durationMinutes: number;
+        exercisedOn: string;
+        distanceKm?: number;
+        calories?: number;
+        memo?: string;
+      };
+    }
+  | {
+      type: "MEDIA";
+      media: {
+        category: QuickRecordMediaCategory;
+        title: string;
+        status: QuickRecordMediaStatus;
+        currentEpisode?: number;
+        totalEpisode?: number;
+      };
+    }
+);
+
+export type QuickRecordResult = {
+  sourceType: QuickRecordType;
+  sourceId: number;
+  recordedAt: string;
+  replay: boolean;
+};


### PR DESCRIPTION
## Purpose

Connect the canonical Journal surface to the backend's real idempotent Quick Record write boundary.

Closes #18

## Delivered

- real `POST /api/v1/lifelogs/quick-record`
- required `Idempotency-Key` support
- COLLECTION / EXERCISE / MEDIA compact Quick Record forms
- optional Journal subtype
- optional real Role context
- duplicate-submit protection
- same-key retry for one logical submission
- authoritative Journal reload after success/replay
- mock idempotent replay/read-loop parity
- shared API client caller-header support

## Contract boundaries

- Quick is an entry mode, not a physical source type
- exactly one physical source payload is submitted
- LifeLog metadata stays at the Quick Record top level
- no nested LifeLog metadata
- no player/user identity parameter
- no raw RoleEvent ID input
- `sourceId` is never treated as `lifeLogId`
- no optimistic Journal insertion

## Recovery

- pending duplicate submissions are blocked
- retry of the same failed logical submit reuses its Idempotency-Key
- editing the form starts a new logical submission
- successful recording remains successful even if subsequent Journal refresh fails
- Journal is reloaded from authoritative state

## Structural integrity

Touched LifeLog/shared API boundaries were audited for semantic state, identity, DTO, mock, and responsibility mismatches.
Only local findings necessary for this flow were changed.

## Validation

- targeted LifeLog/API client tests
- lint
- full tests
- build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a collapsible Quick Record form to create collection, exercise, and media journal entries.
  * Supports optional metadata, category-specific fields, submission status, and retrying failed or ambiguous submissions.
  * Newly created entries appear in the journal and can be selected automatically.

* **Bug Fixes**
  * Prevented duplicate submissions and preserved zero-value fields.
  * Improved request retry behavior while retaining authentication and idempotency information.
  * Preserved journal filters and pagination during refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->