### PR TITLE
[LifeLog] Connect real Collection CRUD surface

### DIFF
--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -33,6 +33,7 @@ vi.mock("@/widgets/right-panels/RightPanels", () => ({
   ),
 }));
 vi.mock("@/features/lifelog/JournalShell", () => ({ default: ({ roles: roleOptions }: { roles: RoleDetail[] }) => <div data-testid="journal-shell">Journal · {roleOptions.map(({ name }) => name).join(", ")}</div> }));
+vi.mock("@/features/lifelog/CollectionShell", () => ({ default: () => <div data-testid="collection-shell">Collection Shell</div> }));
 vi.mock("@/features/inventory/InventoryShell", () => ({ default: ({ surface }: { surface: string }) => <div data-testid="inventory-shell">Inventory · {surface}</div> }));
 vi.mock("@/features/inventory/GearShell", () => ({ default: () => <div data-testid="gear-shell">Gear Shell</div> }));
 vi.mock("@/features/home/HomeShell", () => ({
@@ -134,7 +135,7 @@ describe("Home shell에서 feature surface를 routing할 때", () => {
 
       fireEvent.click(screen.getByRole("button", { name: "Collection" }));
       expect(screen.queryByTestId("journal-shell")).not.toBeInTheDocument();
-      expect(screen.getByRole("button", { name: "Figure" })).toBeInTheDocument();
+      expect(screen.getByTestId("collection-shell")).toBeInTheDocument();
     });
 
     it("Role과 Journey feature shell routing을 그대로 유지한다", () => {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -14,6 +14,7 @@ import { useAuth } from "@/features/auth/AuthContext";
 import JourneyShell from "@/features/quests/JourneyShell";
 import RoleShell from "@/features/role/RoleShell";
 import JournalShell from "@/features/lifelog/JournalShell";
+import CollectionShell from "@/features/lifelog/CollectionShell";
 import InventoryShell from "@/features/inventory/InventoryShell";
 import GearShell from "@/features/inventory/GearShell";
 import HomeShell from "@/features/home/HomeShell";
@@ -45,7 +46,6 @@ import {
   PLAYER_LISTS,
 } from "@/features/player/model";
 import {
-  COLLECTION_FORM_FIELDS,
   EXERCISE_FORM_FIELDS,
   LIFELOG_CATEGORY_ITEMS,
   LIFELOG_LISTS,
@@ -258,7 +258,7 @@ function buildPanels(
 
   if (selectedMain === "lifelog") {
     const sub = selectedMainSub as LifelogSubId;
-    if (sub === "journal") return { panelStack, socialContext: null };
+    if (sub === "journal" || sub === "collection") return { panelStack, socialContext: null };
     const subLabel = mainItems.find((item) => item.id === sub)?.label ?? "Lifelog";
     const categoryItems = LIFELOG_CATEGORY_ITEMS[sub] ?? [];
     const selectedCategory = selectedLifelogCategoryBySub[sub] ?? null;
@@ -808,8 +808,6 @@ export default function Home() {
 
     if (route === "lifelog-list" && sub === "exercise") {
       openForm("exercise-create", "Log Exercise", EXERCISE_FORM_FIELDS, "기록하기");
-    } else if (route === "lifelog-list" && sub === "collection") {
-      openForm("collection-create", "Add Collection", COLLECTION_FORM_FIELDS, "추가하기");
     } else if (route === "lifelog-list" && sub === "media") {
       openForm("media-create", "Log Media", MEDIA_FORM_FIELDS, "기록하기");
     } else if (route === "social-list" && sub === "party") {
@@ -829,7 +827,6 @@ export default function Home() {
     if (actionType === "edit") {
       const allLists = [
         ...LIFELOG_LISTS.exercise,
-        ...LIFELOG_LISTS.collection,
         ...LIFELOG_LISTS.media,
       ];
       const item = allLists.find((i) => i.id === itemId);
@@ -837,8 +834,6 @@ export default function Home() {
       if (selectedMain === "lifelog" && sub === "exercise") {
         openForm("exercise-edit", "Edit Exercise", EXERCISE_FORM_FIELDS, "수정하기",
           item ? { category: item.detailRows[0]?.split(": ")[1] ?? "" } : undefined);
-      } else if (selectedMain === "lifelog" && sub === "collection") {
-        openForm("collection-edit", "Edit Collection", COLLECTION_FORM_FIELDS, "수정하기");
       } else if (selectedMain === "lifelog" && sub === "media") {
         openForm("media-edit", "Edit Media", MEDIA_FORM_FIELDS, "수정하기");
       }
@@ -1026,7 +1021,7 @@ export default function Home() {
     if (formKey.startsWith("credential") || formKey.startsWith("hobby")) {
       const sub = selectedSubByMain.player as PlayerSubId;
       setSelectedPlayerCategoryBySub((prev) => ({ ...prev, [sub]: value || null }));
-    } else if (formKey.startsWith("exercise") || formKey.startsWith("collection") || formKey.startsWith("media")) {
+    } else if (formKey.startsWith("exercise") || formKey.startsWith("media")) {
       const sub = selectedSubByMain.lifelog as LifelogSubId;
       setSelectedLifelogCategoryBySub((prev) => ({ ...prev, [sub]: value || null }));
     }
@@ -1061,8 +1056,6 @@ export default function Home() {
       setEditingItemId(null);
       if (sub === "exercise") {
         openForm("exercise-create", "Log Exercise", EXERCISE_FORM_FIELDS, "기록하기", { category: itemId });
-      } else if (sub === "collection") {
-        openForm("collection-create", "Add Collection", COLLECTION_FORM_FIELDS, "추가하기", { category: itemId });
       } else if (sub === "media") {
         openForm("media-create", "Log Media", MEDIA_FORM_FIELDS, "기록하기", { type: itemId });
       }
@@ -1088,8 +1081,6 @@ export default function Home() {
       setEditingItemId(itemId);
       if (sub === "exercise") {
         openForm("exercise-edit", "Edit Exercise", EXERCISE_FORM_FIELDS, "수정하기");
-      } else if (sub === "collection") {
-        openForm("collection-edit", "Edit Collection", COLLECTION_FORM_FIELDS, "수정하기");
       } else if (sub === "media") {
         openForm("media-edit", "Edit Media", MEDIA_FORM_FIELDS, "수정하기");
       }
@@ -1283,6 +1274,16 @@ export default function Home() {
                 onPanelItemSelect={handlePanelItemSelect}
               />
               <JournalShell roles={roleState.roles} rolesLoading={roleState.isLoading} rolesError={roleState.error} />
+            </div>
+          ) : selectedMain === "lifelog" && selectedSubByMain.lifelog === "collection" ? (
+            <div className="flex w-fit items-center gap-3">
+              <RightPanels
+                selectedMain="lifelog"
+                panelStack={panelStack.slice(0, 1)}
+                panelStackKey="lifelog-collection-menu"
+                onPanelItemSelect={handlePanelItemSelect}
+              />
+              <CollectionShell />
             </div>
           ) : (
             <RightPanels

--- a/features/lifelog/CollectionShell.test.tsx
+++ b/features/lifelog/CollectionShell.test.tsx
@@ -1,0 +1,97 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { COLLECTION_CATEGORIES } from "@/shared/api/types";
+import type { CollectionInfo } from "@/shared/api/types";
+import CollectionShell from "./CollectionShell";
+
+const api = vi.hoisted(() => ({
+  createCollectionApi: vi.fn(),
+  deleteCollectionApi: vi.fn(),
+  getCollectionApi: vi.fn(),
+  searchCollectionsApi: vi.fn(),
+  updateCollectionApi: vi.fn(),
+}));
+
+vi.mock("./api", () => api);
+vi.mock("@/shared/ui/PanelCard", () => ({
+  default: ({ label, onClick }: { label: string; onClick: () => void }) => <button type="button" data-testid="collection-entry" onClick={onClick}>{label}</button>,
+}));
+
+const item: CollectionInfo = {
+  id: 31,
+  playerId: 7,
+  category: "BOOK",
+  title: "Architecture Notes",
+  originalTitle: null,
+  quantity: 1,
+  conditionNote: "Annotated",
+  acquiredFrom: "Local bookstore",
+  tags: ["architecture"],
+  createdAt: "2026-08-12T09:00:00Z",
+  updatedAt: "2026-08-12T09:00:00Z",
+};
+
+describe("Collection source surface를 사용할 때", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api.searchCollectionsApi.mockResolvedValue([item]);
+    api.getCollectionApi.mockResolvedValue(item);
+    api.createCollectionApi.mockResolvedValue({ id: 99 });
+    api.updateCollectionApi.mockResolvedValue({ ...item, quantity: 2, conditionNote: "Used", acquiredFrom: "Gift" });
+    api.deleteCollectionApi.mockResolvedValue({ id: item.id });
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+  });
+
+  describe("canonical create/update controls를 제출하면", () => {
+    it("exact categories와 backend-supported fields만 전송한다", async () => {
+      render(<CollectionShell />);
+      await screen.findByTestId("collection-entry");
+
+      const filter = screen.getByLabelText("Category filter") as HTMLSelectElement;
+      expect(Array.from(filter.options, ({ value }) => value).slice(1)).toEqual([...COLLECTION_CATEGORIES]);
+      fireEvent.click(screen.getByText("Add Collection"));
+      expect(screen.queryByLabelText(/rarity|acquired date|item name/i)).not.toBeInTheDocument();
+      expect(screen.getByLabelText("Create category")).toBeRequired();
+      expect(screen.getByLabelText("Title")).toBeRequired();
+      expect(screen.getByLabelText("Quantity")).toBeRequired();
+      fireEvent.change(screen.getByLabelText("Create category"), { target: { value: "CARD" } });
+      fireEvent.change(screen.getByLabelText("Title"), { target: { value: "Rare card" } });
+      fireEvent.change(screen.getByLabelText("Original title"), { target: { value: "Original" } });
+      fireEvent.change(screen.getByLabelText("Quantity"), { target: { value: "1" } });
+      fireEvent.change(screen.getByLabelText("Condition note"), { target: { value: "Sleeved" } });
+      fireEvent.change(screen.getByLabelText("Acquired from"), { target: { value: "Trade" } });
+      fireEvent.change(screen.getByLabelText("Tags, comma separated"), { target: { value: "rare, card" } });
+      fireEvent.click(screen.getByRole("button", { name: "Create Collection" }));
+
+      await waitFor(() => expect(api.createCollectionApi).toHaveBeenCalledWith({
+        category: "CARD",
+        title: "Rare card",
+        originalTitle: "Original",
+        quantity: 1,
+        conditionNote: "Sleeved",
+        acquiredFrom: "Trade",
+        tags: ["rare", "card"],
+      }));
+
+      fireEvent.click(screen.getByTestId("collection-entry"));
+      await screen.findByText("Collection source #31");
+      fireEvent.change(screen.getByLabelText("Update quantity"), { target: { value: "2" } });
+      fireEvent.change(screen.getByLabelText("Update condition note"), { target: { value: "Used" } });
+      fireEvent.change(screen.getByLabelText("Update acquired from"), { target: { value: "Gift" } });
+      fireEvent.click(screen.getByRole("button", { name: "Update Collection" }));
+
+      await waitFor(() => expect(api.updateCollectionApi).toHaveBeenCalledWith(31, {
+        quantity: 2,
+        conditionNote: "Used",
+        acquiredFrom: "Gift",
+      }));
+      expect(api.updateCollectionApi.mock.calls[0][1]).not.toEqual(expect.objectContaining({
+        title: expect.anything(),
+        category: expect.anything(),
+        originalTitle: expect.anything(),
+        tags: expect.anything(),
+      }));
+    });
+  });
+});

--- a/features/lifelog/CollectionShell.tsx
+++ b/features/lifelog/CollectionShell.tsx
@@ -1,0 +1,210 @@
+"use client";
+
+import { useState } from "react";
+
+import {
+  COLLECTION_CATEGORIES,
+  type CollectionCategory,
+  type CollectionCreateRequest,
+  type CollectionInfo,
+} from "@/shared/api/types";
+import { INPUT_STYLE, SAO } from "@/shared/design/tokens";
+import PanelCard from "@/shared/ui/PanelCard";
+import { PanelFrame } from "@/widgets/right-panels/ui/PanelFrame";
+import { GoldRow, InfoCard } from "@/widgets/right-panels/ui/Rows";
+import { useCollectionQueries } from "./useCollectionQueries";
+
+const buttonStyle = {
+  border: `1px solid ${SAO.color.border.panel}`,
+  background: SAO.color.bg.inset,
+  color: SAO.color.text.secondary,
+  borderRadius: SAO.radius.panel,
+  padding: "7px 10px",
+  fontSize: "0.68rem",
+  letterSpacing: "0.08em",
+} as const;
+
+function text(form: FormData, key: string): string {
+  return String(form.get(key) ?? "").trim();
+}
+
+function optional(form: FormData, key: string): string | undefined {
+  return text(form, key) || undefined;
+}
+
+function ErrorState({ message, retry }: { message: string; retry: () => void }) {
+  return (
+    <div className="space-y-2 px-3">
+      <p role="alert" className="text-xs" style={{ color: SAO.color.action.red }}>{message}</p>
+      <button type="button" style={buttonStyle} onClick={retry}>Retry</button>
+    </div>
+  );
+}
+
+function CategorySelect({ name, label, optional: allowEmpty = false, disabled = false }: { name: string; label: string; optional?: boolean; disabled?: boolean }) {
+  return (
+    <label className="block text-xs" style={{ color: SAO.color.text.label }}>
+      {label}
+      <select name={name} aria-label={label} defaultValue="" required={!allowEmpty} disabled={disabled} style={INPUT_STYLE}>
+        <option value="">{allowEmpty ? "All Categories" : "Select..."}</option>
+        {COLLECTION_CATEGORIES.map((category) => <option key={category} value={category}>{category}</option>)}
+      </select>
+    </label>
+  );
+}
+
+function CreateForm({ pending, create }: { pending: boolean; create: (body: CollectionCreateRequest) => Promise<boolean> }) {
+  const submit = async (event: React.SubmitEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const element = event.currentTarget;
+    const form = new FormData(element);
+    const originalTitle = optional(form, "originalTitle");
+    const conditionNote = optional(form, "conditionNote");
+    const acquiredFrom = optional(form, "acquiredFrom");
+    const tags = text(form, "tags").split(",").map((tag) => tag.trim()).filter(Boolean);
+    const saved = await create({
+      category: text(form, "category") as CollectionCategory,
+      title: text(form, "title"),
+      quantity: Number(text(form, "quantity")),
+      ...(originalTitle ? { originalTitle } : {}),
+      ...(conditionNote ? { conditionNote } : {}),
+      ...(acquiredFrom ? { acquiredFrom } : {}),
+      ...(tags.length > 0 ? { tags } : {}),
+    });
+    if (saved) element.reset();
+  };
+
+  return (
+    <form className="mt-3 space-y-2" onSubmit={submit}>
+      <CategorySelect name="category" label="Create category" disabled={pending} />
+      <label className="block text-xs" style={{ color: SAO.color.text.label }}>Title<input name="title" required disabled={pending} style={INPUT_STYLE} /></label>
+      <label className="block text-xs" style={{ color: SAO.color.text.label }}>Original title<input name="originalTitle" disabled={pending} style={INPUT_STYLE} /></label>
+      <label className="block text-xs" style={{ color: SAO.color.text.label }}>Quantity<input name="quantity" type="number" min={1} required disabled={pending} style={INPUT_STYLE} /></label>
+      <label className="block text-xs" style={{ color: SAO.color.text.label }}>Condition note<input name="conditionNote" disabled={pending} style={INPUT_STYLE} /></label>
+      <label className="block text-xs" style={{ color: SAO.color.text.label }}>Acquired from<input name="acquiredFrom" disabled={pending} style={INPUT_STYLE} /></label>
+      <label className="block text-xs" style={{ color: SAO.color.text.label }}>Tags, comma separated<input name="tags" disabled={pending} style={INPUT_STYLE} /></label>
+      <button type="submit" disabled={pending} style={buttonStyle}>{pending ? "Saving..." : "Create Collection"}</button>
+    </form>
+  );
+}
+
+function CollectionDetail({
+  item,
+  pending,
+  update,
+  remove,
+}: {
+  item: CollectionInfo;
+  pending: boolean;
+  update: (body: { quantity: number; conditionNote: string; acquiredFrom: string }) => Promise<boolean>;
+  remove: () => Promise<boolean>;
+}) {
+  const submit = (event: React.SubmitEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const form = new FormData(event.currentTarget);
+    void update({
+      quantity: Number(text(form, "quantity")),
+      conditionNote: text(form, "conditionNote"),
+      acquiredFrom: text(form, "acquiredFrom"),
+    });
+  };
+
+  return (
+    <div className="space-y-3 px-3">
+      <InfoCard>{item.title}</InfoCard>
+      <GoldRow>Collection source #{item.id}</GoldRow>
+      <GoldRow>Category: {item.category}</GoldRow>
+      <GoldRow>Original title: {item.originalTitle ?? "Not recorded"}</GoldRow>
+      <GoldRow>Tags: {item.tags.length > 0 ? item.tags.join(", ") : "Not recorded"}</GoldRow>
+      <GoldRow>Created: {item.createdAt}</GoldRow>
+      <GoldRow>Updated: {item.updatedAt}</GoldRow>
+      <form key={`${item.id}-${item.updatedAt}`} className="space-y-2" onSubmit={submit}>
+        <label className="block text-xs" style={{ color: SAO.color.text.label }}>Update quantity<input name="quantity" type="number" min={1} required defaultValue={item.quantity ?? 1} disabled={pending} style={INPUT_STYLE} /></label>
+        <label className="block text-xs" style={{ color: SAO.color.text.label }}>Update condition note<input name="conditionNote" defaultValue={item.conditionNote ?? ""} disabled={pending} style={INPUT_STYLE} /></label>
+        <label className="block text-xs" style={{ color: SAO.color.text.label }}>Update acquired from<input name="acquiredFrom" defaultValue={item.acquiredFrom ?? ""} disabled={pending} style={INPUT_STYLE} /></label>
+        <div className="flex gap-2">
+          <button type="submit" disabled={pending} style={{ ...buttonStyle, flex: 1 }}>{pending ? "Working..." : "Update Collection"}</button>
+          <button type="button" disabled={pending} style={buttonStyle} onClick={() => {
+            if (window.confirm(`Delete ${item.title}?`)) void remove();
+          }}>Delete</button>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+export default function CollectionShell() {
+  const collections = useCollectionQueries();
+  const [category, setCategory] = useState<CollectionCategory | "">("");
+  const [titleLike, setTitleLike] = useState("");
+  const pending = collections.pendingMutation !== null;
+  const nextDisabled = collections.list.loading || collections.list.items.length < collections.params.size;
+
+  return (
+    <div className="relative flex min-w-0 w-fit flex-row flex-nowrap items-center gap-3" data-testid="collection-shell">
+      <PanelFrame title="Collection Search" depth={2}>
+        <div className="space-y-3 px-3">
+          <form className="space-y-2" onSubmit={(event) => {
+            event.preventDefault();
+            collections.search(category || undefined, titleLike);
+          }}>
+            <label className="block text-xs" style={{ color: SAO.color.text.label }}>
+              Category filter
+              <select aria-label="Category filter" value={category} onChange={(event) => setCategory(event.target.value as CollectionCategory | "")} style={INPUT_STYLE}>
+                <option value="">All Categories</option>
+                {COLLECTION_CATEGORIES.map((value) => <option key={value} value={value}>{value}</option>)}
+              </select>
+            </label>
+            <label className="block text-xs" style={{ color: SAO.color.text.label }}>Title search<input aria-label="Title search" value={titleLike} onChange={(event) => setTitleLike(event.target.value)} style={INPUT_STYLE} /></label>
+            <button type="submit" style={buttonStyle}>Search</button>
+          </form>
+          <details>
+            <summary className="cursor-pointer text-xs" style={{ color: SAO.color.text.gold }}>Add Collection</summary>
+            <CreateForm pending={pending} create={collections.create} />
+          </details>
+        </div>
+      </PanelFrame>
+
+      <PanelFrame title="Collections" depth={1}>
+        <div className="space-y-3">
+          {collections.list.loading && collections.list.items.length === 0 ? <InfoCard>Loading Collections...</InfoCard> : null}
+          {collections.list.error ? <ErrorState message={collections.list.error} retry={() => void collections.list.reload()} /> : null}
+          {!collections.list.loading && !collections.list.error && collections.list.items.length === 0 ? <InfoCard>No Collections.</InfoCard> : null}
+          {collections.mutationError ? <p role="alert" className="px-3 text-xs" style={{ color: SAO.color.action.red }}>{collections.mutationError}</p> : null}
+          <div className="space-y-2">
+            {collections.list.items.map((item, index) => (
+              <PanelCard
+                key={item.id}
+                label={item.title}
+                slotLabel={`x${item.quantity}`}
+                subtitle={`${item.category} · ${item.conditionNote ?? "No condition note"}`}
+                selected={collections.selectedId === item.id}
+                index={index}
+                onClick={() => collections.select(item.id)}
+              />
+            ))}
+          </div>
+          <div className="flex items-center justify-between gap-2 px-3">
+            <button type="button" disabled={collections.list.loading || collections.params.page === 0} style={buttonStyle} onClick={() => collections.changePage(collections.params.page - 1)}>Previous</button>
+            <span className="text-xs" style={{ color: SAO.color.text.label }}>Page {collections.params.page + 1}</span>
+            <button type="button" disabled={nextDisabled} style={buttonStyle} onClick={() => collections.changePage(collections.params.page + 1)}>Next</button>
+          </div>
+        </div>
+      </PanelFrame>
+
+      <PanelFrame title="Collection Detail" depth={0}>
+        {!collections.selectedId ? <InfoCard>Select a Collection.</InfoCard> : null}
+        {collections.detail.loading && !collections.detail.data ? <InfoCard>Loading Collection...</InfoCard> : null}
+        {collections.detail.error ? <ErrorState message={collections.detail.error} retry={() => void collections.detail.retry()} /> : null}
+        {collections.detail.data ? (
+          <CollectionDetail
+            item={collections.detail.data}
+            pending={pending}
+            update={(body) => collections.update(collections.detail.data!.id, body)}
+            remove={() => collections.remove(collections.detail.data!.id)}
+          />
+        ) : null}
+      </PanelFrame>
+    </div>
+  );
+}

--- a/features/lifelog/JournalShell.tsx
+++ b/features/lifelog/JournalShell.tsx
@@ -2,6 +2,7 @@
 
 import { useRef, useState } from "react";
 
+import { COLLECTION_CATEGORIES } from "@/shared/api/types";
 import type {
   JournalDetail,
   JournalEntry,
@@ -42,7 +43,6 @@ const secondaryButton = {
   letterSpacing: "0.08em",
 } as const;
 
-const COLLECTION_CATEGORIES = ["FIGURE", "CARD", "BOOK", "GAME", "STAMP", "COIN", "OTHER"] as const;
 const EXERCISE_CATEGORIES = ["RUNNING", "WALKING", "CYCLING", "SWIMMING", "GYM", "YOGA", "OTHER"] as const;
 const MEDIA_CATEGORIES = ["ANIME", "MOVIE", "SERIES", "BOOK", "WEBTOON", "GAME", "MUSIC"] as const;
 const MEDIA_STATUSES = ["PLANNED", "WATCHING", "COMPLETED", "DROPPED", "ON_HOLD"] as const;

--- a/features/lifelog/api.test.ts
+++ b/features/lifelog/api.test.ts
@@ -1,14 +1,107 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { JournalPage, JournalSubtype, QuickRecordRequest } from "@/shared/api/types";
-import { getJournalDetailApi, listJournalApi, quickRecordApi } from "./api";
-import { journalMock, MOCK_JOURNAL_ENTRIES, resetJournalMock } from "./mock";
+import { COLLECTION_CATEGORIES } from "@/shared/api/types";
+import type { CollectionCreateRequest, CollectionInfo, CollectionUpdateRequest, JournalPage, JournalSubtype, QuickRecordRequest } from "@/shared/api/types";
+import {
+  createCollectionApi,
+  deleteCollectionApi,
+  getCollectionApi,
+  getJournalDetailApi,
+  listJournalApi,
+  quickRecordApi,
+  recentCollectionsApi,
+  searchCollectionsApi,
+  updateCollectionApi,
+} from "./api";
+import { collectionMock, journalMock, MOCK_JOURNAL_ENTRIES, resetJournalMock } from "./mock";
 
-const client = vi.hoisted(() => ({ apiGet: vi.fn(), apiPost: vi.fn() }));
+const client = vi.hoisted(() => ({
+  apiDelete: vi.fn(),
+  apiGet: vi.fn(),
+  apiGetRaw: vi.fn(),
+  apiPost: vi.fn(),
+  apiPostRaw: vi.fn(),
+}));
 
 vi.mock("@/shared/api/client", () => ({ USE_MOCK: false, ...client }));
 
 const emptyPage: JournalPage = { content: [], page: 0, size: 20, totalElements: 0, totalPages: 0 };
+const collection: CollectionInfo = {
+  id: 31,
+  playerId: 7,
+  category: "BOOK",
+  title: "Architecture Notes",
+  originalTitle: null,
+  quantity: 1,
+  conditionNote: "Annotated",
+  acquiredFrom: "Local bookstore",
+  tags: ["architecture"],
+  createdAt: "2026-08-12T09:00:00Z",
+  updatedAt: "2026-08-12T09:00:00Z",
+};
+
+describe("Collection source API를 호출할 때", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetJournalMock();
+  });
+
+  describe("backend의 mixed response contract를 따르면", () => {
+    it("recent/search/create/update는 raw, get/delete는 envelope client를 exact endpoint로 사용한다", async () => {
+      client.apiGetRaw.mockResolvedValue([collection]);
+      client.apiGet.mockResolvedValue(collection);
+      client.apiPostRaw.mockResolvedValueOnce({ id: 31 }).mockResolvedValueOnce(collection);
+      client.apiDelete.mockResolvedValue({ id: 31 });
+      const create: CollectionCreateRequest = { category: "BOOK", title: "Architecture Notes", quantity: 1 };
+      const update: CollectionUpdateRequest = { quantity: 2, conditionNote: "Used", acquiredFrom: "Gift" };
+
+      await recentCollectionsApi(12);
+      const search = await searchCollectionsApi({ category: "BOOK", titleLike: "A/B ?", page: 2, size: 20 });
+      await getCollectionApi(31);
+      await createCollectionApi(create);
+      await updateCollectionApi(31, update);
+      await deleteCollectionApi(31);
+
+      expect(client.apiGetRaw).toHaveBeenNthCalledWith(1, "/api/v1/players/collections/recent?limit=12");
+      expect(client.apiGetRaw).toHaveBeenNthCalledWith(2, "/api/v1/players/collections/search?category=BOOK&titleLike=A%2FB+%3F&page=2&size=20");
+      expect(client.apiGet).toHaveBeenCalledWith("/api/v1/players/collections/31");
+      expect(client.apiPostRaw).toHaveBeenNthCalledWith(1, "/api/v1/players/collections", create);
+      expect(client.apiPostRaw).toHaveBeenNthCalledWith(2, "/api/v1/players/collections/31", update);
+      expect(client.apiDelete).toHaveBeenCalledWith("/api/v1/players/collections/31");
+      expect(search).toEqual([collection]);
+      expect(search).not.toHaveProperty("totalElements");
+      expect(search).not.toHaveProperty("totalPages");
+    });
+  });
+
+  describe("source request semantics를 유지하면", () => {
+    it("canonical categories와 exact create/update fields만 허용하고 caller identity를 보내지 않는다", () => {
+      const create: CollectionCreateRequest = { category: "CARD", title: "Rare card", quantity: 1 };
+      const update: CollectionUpdateRequest = { quantity: 2, conditionNote: "Sleeved", acquiredFrom: "Trade" };
+
+      expect(COLLECTION_CATEGORIES).toEqual(["FIGURE", "CARD", "BOOK", "GAME", "STAMP", "COIN", "OTHER"]);
+      expect(create).toEqual({ category: "CARD", title: "Rare card", quantity: 1 });
+      expect(update).toEqual({ quantity: 2, conditionNote: "Sleeved", acquiredFrom: "Trade" });
+      expect(create).not.toHaveProperty("playerId");
+      expect(create).not.toHaveProperty("userId");
+      for (const unsupported of ["title", "category", "originalTitle", "tags"]) expect(update).not.toHaveProperty(unsupported);
+    });
+
+    it("mock recent/search/get/create/update/delete가 한 source authority를 사용하고 Journal을 조작하지 않는다", () => {
+      const journalIds = journalMock.page({ page: 0, size: 20 }).content.map(({ lifeLogId }) => lifeLogId);
+      expect(collectionMock.recent(1).map(({ id }) => id)).toEqual([204]);
+      expect(collectionMock.search({ category: "BOOK", titleLike: "architecture", page: 0, size: 1 }).map(({ id }) => id)).toEqual([204]);
+
+      const created = collectionMock.create({ category: "CARD", title: "New card", quantity: 1 });
+      expect(collectionMock.get(created.id)).toEqual(expect.objectContaining({ title: "New card", category: "CARD", quantity: 1 }));
+      const updated = collectionMock.update(created.id, { quantity: 2, conditionNote: "Sleeved", acquiredFrom: "Trade" });
+      expect(updated).toEqual(expect.objectContaining({ title: "New card", category: "CARD", quantity: 2, conditionNote: "Sleeved", acquiredFrom: "Trade" }));
+      expect(collectionMock.delete(created.id)).toEqual({ id: created.id });
+      expect(() => collectionMock.get(created.id)).toThrow("Collection not found.");
+      expect(journalMock.page({ page: 0, size: 20 }).content.map(({ lifeLogId }) => lifeLogId)).toEqual(journalIds);
+    });
+  });
+});
 
 describe("Journal을 실제 backend에서 읽을 때", () => {
   beforeEach(() => {

--- a/features/lifelog/api.ts
+++ b/features/lifelog/api.ts
@@ -1,6 +1,61 @@
-import { USE_MOCK, apiGet, apiPost } from "@/shared/api/client";
-import type { JournalDetail, JournalListParams, JournalPage, QuickRecordRequest, QuickRecordResult } from "@/shared/api/types";
-import { journalMock } from "./mock";
+import { USE_MOCK, apiDelete, apiGet, apiGetRaw, apiPost, apiPostRaw } from "@/shared/api/client";
+import type {
+  CollectionCreateRequest,
+  CollectionCreated,
+  CollectionDeleted,
+  CollectionInfo,
+  CollectionSearchParams,
+  CollectionUpdateRequest,
+  JournalDetail,
+  JournalListParams,
+  JournalPage,
+  QuickRecordRequest,
+  QuickRecordResult,
+} from "@/shared/api/types";
+import { collectionMock, journalMock } from "./mock";
+
+const COLLECTION_PATH = "/api/v1/players/collections";
+
+export function recentCollectionsApi(limit: number): Promise<CollectionInfo[]> {
+  return USE_MOCK
+    ? Promise.resolve(collectionMock.recent(limit))
+    : apiGetRaw<CollectionInfo[]>(`${COLLECTION_PATH}/recent?limit=${limit}`);
+}
+
+export function searchCollectionsApi(params: CollectionSearchParams): Promise<CollectionInfo[]> {
+  const query = new URLSearchParams();
+  if (params.category) query.set("category", params.category);
+  if (params.titleLike) query.set("titleLike", params.titleLike);
+  query.set("page", String(params.page));
+  query.set("size", String(params.size));
+  return USE_MOCK
+    ? Promise.resolve(collectionMock.search(params))
+    : apiGetRaw<CollectionInfo[]>(`${COLLECTION_PATH}/search?${query}`);
+}
+
+export function getCollectionApi(collectionId: number): Promise<CollectionInfo> {
+  return USE_MOCK
+    ? Promise.resolve().then(() => collectionMock.get(collectionId))
+    : apiGet<CollectionInfo>(`${COLLECTION_PATH}/${collectionId}`);
+}
+
+export function createCollectionApi(body: CollectionCreateRequest): Promise<CollectionCreated> {
+  return USE_MOCK
+    ? Promise.resolve().then(() => collectionMock.create(body))
+    : apiPostRaw<CollectionCreated>(COLLECTION_PATH, body);
+}
+
+export function updateCollectionApi(collectionId: number, body: CollectionUpdateRequest): Promise<CollectionInfo> {
+  return USE_MOCK
+    ? Promise.resolve().then(() => collectionMock.update(collectionId, body))
+    : apiPostRaw<CollectionInfo>(`${COLLECTION_PATH}/${collectionId}`, body);
+}
+
+export function deleteCollectionApi(collectionId: number): Promise<CollectionDeleted> {
+  return USE_MOCK
+    ? Promise.resolve().then(() => collectionMock.delete(collectionId))
+    : apiDelete<CollectionDeleted>(`${COLLECTION_PATH}/${collectionId}`);
+}
 
 export function listJournalApi(params: JournalListParams): Promise<JournalPage> {
   if (USE_MOCK) return Promise.resolve(journalMock.page(params));

--- a/features/lifelog/data.ts
+++ b/features/lifelog/data.ts
@@ -1,14 +1,3 @@
-export const COLLECTION_DATA = [
-  { title: "Kirito 1/7 Scale Figure",         cat: "Figure",       qty: 1,  cond: "Mint in box",  from: "Good Smile" },
-  { title: "Asuna ALO Ver. Figure",            cat: "Figure",       qty: 1,  cond: "Mint",         from: "Kotobukiya" },
-  { title: "SAO Progressive Manga",            cat: "Manga",        qty: 8,  cond: "Like new",     from: "Kyobo" },
-  { title: "SAO Light Novel JP Complete",      cat: "Light Novel",  qty: 27, cond: "JP edition",   from: "Amazon JP" },
-  { title: "SAO Artbook Vol. 1",               cat: "Artbook",      qty: 1,  cond: "Like new",     from: "Comiket" },
-  { title: "Elucidator Replica Sword",         cat: "Merchandise",  qty: 1,  cond: "Display",      from: "Animax Shop" },
-  { title: "SAO Complete Series Bluray",       cat: "Bluray",       qty: 1,  cond: "Sealed",       from: "Aniplex" },
-  { title: "SAO Enamel Pin Set",               cat: "Merchandise",  qty: 12, cond: "Complete set", from: "CR Shop" },
-];
-
 export const MEDIA_DATA = [
   { title: "Sword Art Online",                  cat: "Anime",  cur: 25,  total: 25,  status: "COMPLETED",    rating: 9.5 },
   { title: "Attack on Titan",                   cat: "Anime",  cur: 87,  total: 87,  status: "COMPLETED",    rating: 9.8 },

--- a/features/lifelog/forms.ts
+++ b/features/lifelog/forms.ts
@@ -19,28 +19,6 @@ export const EXERCISE_FORM_FIELDS: FormFieldSpec[] = [
   { key: "notes",         label: "Notes",            type: "textarea", placeholder: "Session notes..." },
 ];
 
-export const COLLECTION_FORM_FIELDS: FormFieldSpec[] = [
-  { key: "name",      label: "Item Name",  type: "text",   placeholder: "e.g. Kirito 1/7 Figure", required: true },
-  { key: "category",  label: "Category",   type: "select", required: true, options: [
-    { value: "FIGURE", label: "Figure" }, { value: "BOOK",  label: "Book" },
-    { value: "GAME",   label: "Game" },   { value: "ART",   label: "Art" },
-    { value: "MUSIC",  label: "Music" },  { value: "OTHER", label: "Other" },
-  ]},
-  { key: "rarity",    label: "Rarity",     type: "select", required: true, options: [
-    { value: "COMMON",    label: "Common" },    { value: "UNCOMMON",  label: "Uncommon" },
-    { value: "RARE",      label: "Rare" },      { value: "EPIC",      label: "Epic" },
-    { value: "LEGENDARY", label: "Legendary" },
-  ]},
-  { key: "condition", label: "Condition",  type: "select", required: true, options: [
-    { value: "MINT",      label: "Mint" },      { value: "EXCELLENT", label: "Excellent" },
-    { value: "GOOD",      label: "Good" },      { value: "FAIR",      label: "Fair" },
-    { value: "POOR",      label: "Poor" },
-  ]},
-  { key: "acquiredAt",label: "Acquired Date", type: "date", required: true },
-  { key: "source",    label: "Source",         type: "text",     placeholder: "e.g. Amazon JP" },
-  { key: "notes",     label: "Notes",          type: "textarea", placeholder: "Notes..." },
-];
-
 export const MEDIA_FORM_FIELDS: FormFieldSpec[] = [
   { key: "type",          label: "Type",    type: "select", required: true, options: [
     { value: "ANIME",  label: "Anime" },  { value: "BOOK",   label: "Book" },

--- a/features/lifelog/mock.ts
+++ b/features/lifelog/mock.ts
@@ -1,4 +1,8 @@
 import type {
+  CollectionCreateRequest,
+  CollectionInfo,
+  CollectionSearchParams,
+  CollectionUpdateRequest,
   JournalDetail,
   JournalEntry,
   JournalListParams,
@@ -129,8 +133,38 @@ export const MOCK_JOURNAL_DETAILS = [
   },
 ] satisfies JournalDetail[];
 
+export const MOCK_COLLECTION_SOURCES = [
+  {
+    id: 204,
+    playerId: 6,
+    category: "BOOK",
+    title: "Architecture Notes",
+    originalTitle: null,
+    quantity: 1,
+    conditionNote: "Annotated",
+    acquiredFrom: "Local bookstore",
+    tags: ["architecture", "journal"],
+    createdAt: "2026-08-12T09:00:00Z",
+    updatedAt: "2026-08-12T09:00:00Z",
+  },
+  {
+    id: 201,
+    playerId: 6,
+    category: "FIGURE",
+    title: "Legacy Collection",
+    originalTitle: null,
+    quantity: 1,
+    conditionNote: null,
+    acquiredFrom: null,
+    tags: [],
+    createdAt: "2026-08-10T10:00:00Z",
+    updatedAt: "2026-08-10T10:00:00Z",
+  },
+] satisfies CollectionInfo[];
+
 let journalEntries: JournalEntry[] = structuredClone([...MOCK_JOURNAL_ENTRIES]);
 let journalDetails: JournalDetail[] = structuredClone(MOCK_JOURNAL_DETAILS);
+let collectionEntries: CollectionInfo[] = structuredClone(MOCK_COLLECTION_SOURCES);
 const quickRecordReceipts = new Map<string, { payload: string; result: QuickRecordResult }>();
 
 function copy<T>(value: T): T {
@@ -145,6 +179,7 @@ function normalizeMediaProgress(currentEpisode?: number, totalEpisode?: number) 
 export function resetJournalMock(): void {
   journalEntries = structuredClone([...MOCK_JOURNAL_ENTRIES]);
   journalDetails = structuredClone(MOCK_JOURNAL_DETAILS);
+  collectionEntries = structuredClone(MOCK_COLLECTION_SOURCES);
   quickRecordReceipts.clear();
 }
 
@@ -157,7 +192,11 @@ function recordQuick(body: QuickRecordRequest, idempotencyKey: string): QuickRec
   }
 
   const lifeLogId = Math.max(0, ...journalEntries.map((entry) => entry.lifeLogId)) + 1;
-  const sourceId = Math.max(0, ...journalEntries.map((entry) => entry.sourceId)) + 1;
+  const sourceId = Math.max(
+    0,
+    ...journalEntries.map((entry) => entry.sourceId),
+    ...collectionEntries.map((entry) => entry.id),
+  ) + 1;
   const recordedAt = new Date().toISOString();
   const metadata = {
     lifeLogId,
@@ -188,6 +227,17 @@ function recordQuick(body: QuickRecordRequest, idempotencyKey: string): QuickRec
         updatedAt: recordedAt,
       },
     };
+    collectionEntries.unshift({
+      id: sourceId,
+      playerId: 6,
+      ...body.collection,
+      originalTitle: null,
+      conditionNote: null,
+      acquiredFrom: null,
+      tags: [],
+      createdAt: recordedAt,
+      updatedAt: recordedAt,
+    });
   } else if (body.type === "EXERCISE") {
     const source = {
       category: body.exercise.category,
@@ -230,6 +280,61 @@ function recordQuick(body: QuickRecordRequest, idempotencyKey: string): QuickRec
   quickRecordReceipts.set(idempotencyKey, { payload, result });
   return copy(result);
 }
+
+function collection(id: number): CollectionInfo {
+  const found = collectionEntries.find((entry) => entry.id === id);
+  if (!found) throw new Error("Collection not found.");
+  return found;
+}
+
+const MOCK_MUTATION_TIME = "2026-08-14T00:00:00Z";
+
+export const collectionMock = {
+  recent: (limit: number): CollectionInfo[] => copy(collectionEntries.slice(0, limit)),
+  search: ({ category, titleLike, page, size }: CollectionSearchParams): CollectionInfo[] => {
+    const title = titleLike?.trim().toLowerCase();
+    const filtered = collectionEntries.filter((entry) =>
+      (!category || entry.category === category)
+      && (!title || entry.title.toLowerCase().includes(title))
+    );
+    return copy(filtered.slice(page * size, (page + 1) * size));
+  },
+  get: (id: number): CollectionInfo => copy(collection(id)),
+  create: (body: CollectionCreateRequest): { id: number } => {
+    const id = Math.max(0, ...collectionEntries.map((entry) => entry.id)) + 1;
+    collectionEntries.unshift({
+      id,
+      playerId: 6,
+      category: body.category,
+      title: body.title.trim(),
+      originalTitle: body.originalTitle?.trim() || null,
+      quantity: body.quantity,
+      conditionNote: body.conditionNote?.trim() || null,
+      acquiredFrom: body.acquiredFrom?.trim() || null,
+      tags: copy(body.tags ?? []),
+      createdAt: MOCK_MUTATION_TIME,
+      updatedAt: MOCK_MUTATION_TIME,
+    });
+    return { id };
+  },
+  update: (id: number, body: CollectionUpdateRequest): CollectionInfo => {
+    const current = collection(id);
+    const updated = {
+      ...current,
+      ...(body.quantity === undefined ? {} : { quantity: body.quantity }),
+      ...(body.conditionNote === undefined ? {} : { conditionNote: body.conditionNote.trim() || null }),
+      ...(body.acquiredFrom === undefined ? {} : { acquiredFrom: body.acquiredFrom.trim() || null }),
+      updatedAt: MOCK_MUTATION_TIME,
+    };
+    collectionEntries = collectionEntries.map((entry) => entry.id === id ? updated : entry);
+    return copy(updated);
+  },
+  delete: (id: number): { id: number } => {
+    collection(id);
+    collectionEntries = collectionEntries.filter((entry) => entry.id !== id);
+    return { id };
+  },
+};
 
 export const journalMock = {
   page: ({ primaryRoleId, subtype, page, size }: JournalListParams): JournalPage => {

--- a/features/lifelog/model.ts
+++ b/features/lifelog/model.ts
@@ -1,28 +1,12 @@
 import type { LifelogSubId, PanelDataItem, PanelMenuItem } from "@/entities/nav";
 import { CRUD_ACTIONS, pad, uniqueOrderedCats, catMenuItems } from "@/entities/nav";
-import { COLLECTION_DATA, MEDIA_DATA, EXERCISE_DATA } from "./data";
+import { MEDIA_DATA, EXERCISE_DATA } from "./data";
 
 export * from "./forms";
 
-type SourceLifelogSubId = Exclude<LifelogSubId, "journal">;
+type SourceLifelogSubId = Exclude<LifelogSubId, "journal" | "collection">;
 
 export const LIFELOG_LISTS: Record<SourceLifelogSubId, PanelDataItem[]> = {
-  collection: COLLECTION_DATA.map((c, i) => ({
-    id: `lifelog-collection-${pad(i + 1, 3)}`,
-    label: c.title,
-    slotLabel: c.cat.slice(0, 2).toUpperCase(),
-    subtitle: `${c.cat} | Qty: ${c.qty} | ${c.cond}`,
-    category: c.cat,
-    detailTitle: "Collection Detail",
-    detailDescription: `${c.title} — ${c.cat}`,
-    detailRows: [
-      `Category: ${c.cat}`,
-      `Quantity: ${c.qty}`,
-      `Condition: ${c.cond}`,
-      `Source: ${c.from}`,
-    ],
-    actions: CRUD_ACTIONS,
-  })),
   media: MEDIA_DATA.map((m, i) => ({
     id: `lifelog-media-${pad(i + 1, 3)}`,
     label: m.title,
@@ -58,7 +42,6 @@ export const LIFELOG_LISTS: Record<SourceLifelogSubId, PanelDataItem[]> = {
 };
 
 export const LIFELOG_CATEGORY_ITEMS: Record<SourceLifelogSubId, PanelMenuItem[]> = {
-  collection: catMenuItems(uniqueOrderedCats(COLLECTION_DATA)),
   media:      catMenuItems(uniqueOrderedCats(MEDIA_DATA)),
   exercise:   catMenuItems(uniqueOrderedCats(EXERCISE_DATA)),
 };

--- a/features/lifelog/useCollectionQueries.test.tsx
+++ b/features/lifelog/useCollectionQueries.test.tsx
@@ -1,0 +1,99 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { CollectionInfo } from "@/shared/api/types";
+import { useCollectionQueries } from "./useCollectionQueries";
+
+const api = vi.hoisted(() => ({
+  createCollectionApi: vi.fn(),
+  deleteCollectionApi: vi.fn(),
+  getCollectionApi: vi.fn(),
+  searchCollectionsApi: vi.fn(),
+  updateCollectionApi: vi.fn(),
+}));
+
+vi.mock("./api", () => api);
+
+const first: CollectionInfo = {
+  id: 31,
+  playerId: 7,
+  category: "BOOK",
+  title: "Architecture Notes",
+  originalTitle: null,
+  quantity: 1,
+  conditionNote: "Annotated",
+  acquiredFrom: "Local bookstore",
+  tags: ["architecture"],
+  createdAt: "2026-08-12T09:00:00Z",
+  updatedAt: "2026-08-12T09:00:00Z",
+};
+const created = { ...first, id: 99, title: "Created by server" };
+
+describe("Collection query/mutation state를 관리할 때", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api.searchCollectionsApi.mockResolvedValue([first]);
+    api.getCollectionApi.mockImplementation(async (id: number) => id === created.id ? created : first);
+    api.createCollectionApi.mockResolvedValue({ id: created.id });
+    api.updateCollectionApi.mockResolvedValue({ ...created, quantity: 3, conditionNote: "Updated" });
+    api.deleteCollectionApi.mockResolvedValue({ id: created.id });
+  });
+
+  describe("search와 server page를 변경하면", () => {
+    it("category/title/page/size를 authoritative reload마다 보존한다", async () => {
+      const { result } = renderHook(() => useCollectionQueries());
+      await waitFor(() => expect(api.searchCollectionsApi).toHaveBeenCalledWith({ page: 0, size: 20 }));
+
+      act(() => result.current.search("BOOK", " Architecture "));
+      await waitFor(() => expect(api.searchCollectionsApi).toHaveBeenLastCalledWith({ category: "BOOK", titleLike: "Architecture", page: 0, size: 20 }));
+      act(() => result.current.changePage(2));
+      await waitFor(() => expect(api.searchCollectionsApi).toHaveBeenLastCalledWith({ category: "BOOK", titleLike: "Architecture", page: 2, size: 20 }));
+      await act(async () => { await result.current.list.reload(); });
+
+      expect(api.searchCollectionsApi).toHaveBeenLastCalledWith({ category: "BOOK", titleLike: "Architecture", page: 2, size: 20 });
+      expect(result.current.list.items).toEqual([first]);
+    });
+  });
+
+  describe("create/update/delete를 수행하면", () => {
+    it("각 mutation 뒤 reload하고 returned source ID로 fetch/select하며 selected delete를 clear한다", async () => {
+      api.searchCollectionsApi
+        .mockResolvedValueOnce([first])
+        .mockResolvedValueOnce([first])
+        .mockResolvedValueOnce([first])
+        .mockResolvedValueOnce([created, first])
+        .mockResolvedValueOnce([{ ...created, quantity: 3, conditionNote: "Updated" }, first])
+        .mockResolvedValueOnce([first]);
+      const { result } = renderHook(() => useCollectionQueries());
+      await waitFor(() => expect(result.current.list.items).toEqual([first]));
+      act(() => result.current.search("BOOK", "Architecture"));
+      await waitFor(() => expect(api.searchCollectionsApi).toHaveBeenLastCalledWith({ category: "BOOK", titleLike: "Architecture", page: 0, size: 20 }));
+      act(() => result.current.changePage(2));
+      await waitFor(() => expect(api.searchCollectionsApi).toHaveBeenLastCalledWith({ category: "BOOK", titleLike: "Architecture", page: 2, size: 20 }));
+
+      await act(async () => {
+        await result.current.create({ category: "BOOK", title: "Submitted title", quantity: 1 });
+      });
+      await waitFor(() => expect(result.current.detail.data?.id).toBe(created.id));
+      expect(api.getCollectionApi).toHaveBeenCalledWith(created.id);
+      expect(result.current.detail.data?.title).toBe("Created by server");
+
+      await act(async () => {
+        await result.current.update(created.id, { quantity: 3, conditionNote: "Updated", acquiredFrom: "Gift" });
+      });
+      expect(api.updateCollectionApi).toHaveBeenCalledWith(created.id, { quantity: 3, conditionNote: "Updated", acquiredFrom: "Gift" });
+      expect(result.current.detail.data).toEqual(expect.objectContaining({ quantity: 3, conditionNote: "Updated" }));
+
+      await act(async () => { await result.current.remove(created.id); });
+      expect(api.deleteCollectionApi).toHaveBeenCalledWith(created.id);
+      expect(result.current.selectedId).toBeNull();
+      expect(result.current.detail.data).toBeNull();
+      expect(api.searchCollectionsApi).toHaveBeenCalledTimes(6);
+      expect(api.searchCollectionsApi.mock.calls.slice(3)).toEqual([
+        [{ category: "BOOK", titleLike: "Architecture", page: 2, size: 20 }],
+        [{ category: "BOOK", titleLike: "Architecture", page: 2, size: 20 }],
+        [{ category: "BOOK", titleLike: "Architecture", page: 2, size: 20 }],
+      ]);
+    });
+  });
+});

--- a/features/lifelog/useCollectionQueries.ts
+++ b/features/lifelog/useCollectionQueries.ts
@@ -1,0 +1,173 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import type {
+  CollectionCategory,
+  CollectionCreateRequest,
+  CollectionInfo,
+  CollectionSearchParams,
+  CollectionUpdateRequest,
+} from "@/shared/api/types";
+import {
+  createCollectionApi,
+  deleteCollectionApi,
+  getCollectionApi,
+  searchCollectionsApi,
+  updateCollectionApi,
+} from "./api";
+
+const INITIAL_PARAMS: CollectionSearchParams = { page: 0, size: 20 };
+
+function message(caught: unknown, fallback: string): string {
+  return caught instanceof Error ? caught.message : fallback;
+}
+
+export function useCollectionQueries() {
+  const [params, setParams] = useState<CollectionSearchParams>(INITIAL_PARAMS);
+  const paramsRef = useRef(INITIAL_PARAMS);
+  const [items, setItems] = useState<CollectionInfo[]>([]);
+  const [listLoading, setListLoading] = useState(false);
+  const [listError, setListError] = useState<string | null>(null);
+  const [selectedId, setSelectedId] = useState<number | null>(null);
+  const selectedIdRef = useRef<number | null>(null);
+  const [detail, setDetail] = useState<CollectionInfo | null>(null);
+  const [detailLoading, setDetailLoading] = useState(false);
+  const [detailError, setDetailError] = useState<string | null>(null);
+  const listRequestId = useRef(0);
+  const detailRequestId = useRef(0);
+  const mutationLocked = useRef(false);
+  const [pendingMutation, setPendingMutation] = useState<string | null>(null);
+  const [mutationError, setMutationError] = useState<string | null>(null);
+
+  const clearSelection = useCallback(() => {
+    selectedIdRef.current = null;
+    detailRequestId.current += 1;
+    setSelectedId(null);
+    setDetail(null);
+    setDetailLoading(false);
+    setDetailError(null);
+  }, []);
+
+  const reload = useCallback(async () => {
+    const requestId = ++listRequestId.current;
+    setListLoading(true);
+    setListError(null);
+    try {
+      const next = await searchCollectionsApi(paramsRef.current);
+      if (requestId !== listRequestId.current) return undefined;
+      setItems(next);
+      if (selectedIdRef.current !== null && !next.some(({ id }) => id === selectedIdRef.current)) clearSelection();
+      return next;
+    } catch (caught) {
+      if (requestId === listRequestId.current) setListError(message(caught, "Unable to load Collections."));
+      return undefined;
+    } finally {
+      if (requestId === listRequestId.current) setListLoading(false);
+    }
+  }, [clearSelection]);
+
+  useEffect(() => { void reload(); }, [params, reload]);
+
+  const loadDetail = useCallback(async (id: number) => {
+    const requestId = ++detailRequestId.current;
+    setDetailLoading(true);
+    setDetailError(null);
+    try {
+      const next = await getCollectionApi(id);
+      if (requestId === detailRequestId.current) setDetail(next);
+      return next;
+    } catch (caught) {
+      if (requestId === detailRequestId.current) setDetailError(message(caught, "Unable to load Collection."));
+      return undefined;
+    } finally {
+      if (requestId === detailRequestId.current) setDetailLoading(false);
+    }
+  }, []);
+
+  const select = useCallback((id: number) => {
+    selectedIdRef.current = id;
+    setSelectedId(id);
+    setDetail(null);
+    void loadDetail(id);
+  }, [loadDetail]);
+
+  const search = (category?: CollectionCategory, titleLike?: string) => {
+    listRequestId.current += 1;
+    paramsRef.current = { page: 0, size: paramsRef.current.size, category, titleLike: titleLike?.trim() || undefined };
+    setParams(paramsRef.current);
+  };
+
+  const changePage = (page: number) => {
+    listRequestId.current += 1;
+    paramsRef.current = { ...paramsRef.current, page: Math.max(0, page) };
+    setParams(paramsRef.current);
+  };
+
+  const mutate = async <T,>(
+    key: string,
+    request: () => Promise<T>,
+    onResponse?: (result: T) => void,
+    onReload?: (result: T, next: CollectionInfo[]) => void,
+  ): Promise<boolean> => {
+    if (mutationLocked.current) return false;
+    mutationLocked.current = true;
+    setPendingMutation(key);
+    setMutationError(null);
+    try {
+      const result = await request();
+      onResponse?.(result);
+      const next = await reload();
+      if (next) onReload?.(result, next);
+      else setMutationError("Collection changed, but the authoritative list could not be reloaded.");
+      return true;
+    } catch (caught) {
+      await reload();
+      setMutationError(`Request outcome was not confirmed. Server state was reloaded. ${message(caught, "")}`.trim());
+      return false;
+    } finally {
+      mutationLocked.current = false;
+      setPendingMutation(null);
+    }
+  };
+
+  const create = (body: CollectionCreateRequest) => mutate(
+    "create",
+    () => createCollectionApi(body),
+    undefined,
+    (created, next) => {
+      if (next.some(({ id }) => id === created.id)) select(created.id);
+    },
+  );
+
+  const update = (id: number, body: CollectionUpdateRequest) => mutate(
+    `update-${id}`,
+    () => updateCollectionApi(id, body),
+    (updated) => {
+      if (selectedIdRef.current === id) setDetail(updated);
+    },
+  );
+
+  const remove = (id: number) => mutate(
+    `delete-${id}`,
+    () => deleteCollectionApi(id),
+    (deleted) => {
+      if (selectedIdRef.current === deleted.id) clearSelection();
+    },
+  );
+
+  return {
+    params,
+    list: { items, loading: listLoading, error: listError, reload },
+    detail: { data: detail, loading: detailLoading, error: detailError, retry: () => selectedIdRef.current === null ? Promise.resolve(undefined) : loadDetail(selectedIdRef.current) },
+    selectedId,
+    select,
+    search,
+    changePage,
+    pendingMutation,
+    mutationError,
+    create,
+    update,
+    remove,
+  };
+}

--- a/lib/api/endpoints/lifelog.api.ts
+++ b/lib/api/endpoints/lifelog.api.ts
@@ -1,10 +1,9 @@
 import { USE_MOCK, apiDelete, apiGet, apiPost } from "../client";
 import {
-  MOCK_COLLECTIONS,
   MOCK_EXERCISES,
   MOCK_MEDIA_LOGS,
 } from "../mock/lifelog.mock";
-import type { CollectionInfo, ExerciseInfo, MediaLogInfo } from "../types";
+import type { ExerciseInfo, MediaLogInfo } from "../types";
 
 export async function getExercisesApi(): Promise<ExerciseInfo[]> {
   if (USE_MOCK) return MOCK_EXERCISES;
@@ -68,37 +67,4 @@ export async function createMediaLogApi(data: {
     return newEntry;
   }
   return apiPost<MediaLogInfo>("/api/v1/lifelogs/me/media", data);
-}
-
-export async function getCollectionsApi(): Promise<CollectionInfo[]> {
-  if (USE_MOCK) return MOCK_COLLECTIONS;
-  const res = await apiGet<{ items: CollectionInfo[] }>("/api/v1/lifelogs/me/collections");
-  return res.items;
-}
-
-export async function createCollectionApi(data: {
-  category: string;
-  title: string;
-  originalTitle: string | null;
-  quantity: number | null;
-  conditionNote: string | null;
-  acquiredFrom: string | null;
-  tags: string[];
-}): Promise<CollectionInfo> {
-  if (USE_MOCK) {
-    const newEntry: CollectionInfo = {
-      id: Date.now(),
-      playerId: 6,
-      ...data,
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    };
-    return newEntry;
-  }
-  return apiPost<CollectionInfo>("/api/v1/lifelogs/me/collections", data);
-}
-
-export async function deleteCollectionApi(id: number): Promise<void> {
-  if (USE_MOCK) return;
-  await apiDelete(`/api/v1/lifelogs/me/collections/${id}`);
 }

--- a/lib/api/mock/lifelog.mock.ts
+++ b/lib/api/mock/lifelog.mock.ts
@@ -1,4 +1,4 @@
-import type { CollectionInfo, ExerciseInfo, MediaLogInfo } from "../types";
+import type { ExerciseInfo, MediaLogInfo } from "../types";
 
 export const MOCK_EXERCISES: ExerciseInfo[] = [
   { id: 1, playerId: 6, category: "Running", durationMinutes: 32, distanceKm: 5.2, calories: 310, exercisedOn: "2026-03-02", memo: "Morning park run. PB for 5km!", createdAt: "2026-03-02T07:30:00Z", updatedAt: "2026-03-02T07:30:00Z" },
@@ -26,15 +26,4 @@ export const MOCK_MEDIA_LOGS: MediaLogInfo[] = [
   { id: 8, playerId: 6, category: "Anime", title: "Overlord", originalTitle: "オーバーロード", currentEpisode: 13, totalEpisode: 13, status: "PLAN_TO_WATCH", rating: null, tags: ["Isekai", "Dark", "Game"], rewatchCount: 0, startedOn: null, finishedOn: null, createdAt: "2026-01-05T10:00:00Z", updatedAt: "2026-01-05T10:00:00Z" },
   { id: 9, playerId: 6, category: "Book", title: "Designing Data-Intensive Applications", originalTitle: null, currentEpisode: 250, totalEpisode: 616, status: "READING", rating: null, tags: ["Database", "Architecture", "Tech"], rewatchCount: 0, startedOn: "2026-01-15", finishedOn: null, createdAt: "2026-01-15T10:00:00Z", updatedAt: "2026-03-01T10:00:00Z" },
   { id: 10, playerId: 6, category: "Movie", title: "Spirited Away", originalTitle: "千と千尋の神隠し", currentEpisode: 1, totalEpisode: 1, status: "COMPLETED", rating: 9.9, tags: ["Fantasy", "Adventure", "Miyazaki"], rewatchCount: 5, startedOn: "2020-01-01", finishedOn: "2020-01-01", createdAt: "2020-01-01T18:00:00Z", updatedAt: "2020-01-01T20:00:00Z" },
-];
-
-export const MOCK_COLLECTIONS: CollectionInfo[] = [
-  { id: 1, playerId: 6, category: "Figure", title: "Kirito 1/7 Scale Figure", originalTitle: null, quantity: 1, conditionNote: "Mint in box", acquiredFrom: "Good Smile Online", tags: ["SAO", "Kirito", "1/7"], createdAt: "2024-06-15T10:00:00Z", updatedAt: "2024-06-15T10:00:00Z" },
-  { id: 2, playerId: 6, category: "Figure", title: "Asuna ALO Ver. Figure", originalTitle: null, quantity: 1, conditionNote: "Mint", acquiredFrom: "Kotobukiya", tags: ["SAO", "Asuna", "ALO"], createdAt: "2024-08-20T10:00:00Z", updatedAt: "2024-08-20T10:00:00Z" },
-  { id: 3, playerId: 6, category: "Manga", title: "Sword Art Online Progressive", originalTitle: "ソードアート・オンライン プログレッシブ", quantity: 8, conditionNote: "All volumes, like new", acquiredFrom: "Kyobo Bookstore", tags: ["SAO", "Manga", "Kawahara"], createdAt: "2025-01-10T10:00:00Z", updatedAt: "2025-01-10T10:00:00Z" },
-  { id: 4, playerId: 6, category: "Light Novel", title: "SAO Original Light Novel Series", originalTitle: "ソードアート・オンライン", quantity: 27, conditionNote: "JP edition, complete", acquiredFrom: "Amazon Japan", tags: ["SAO", "Novel", "JP"], createdAt: "2023-12-01T10:00:00Z", updatedAt: "2025-02-15T10:00:00Z" },
-  { id: 5, playerId: 6, category: "Artbook", title: "SAO Artbook Vol. 1", originalTitle: "ソードアート・オンライン アートワークス", quantity: 1, conditionNote: "Like new", acquiredFrom: "Comiket", tags: ["SAO", "Art", "Illustrations"], createdAt: "2024-11-03T10:00:00Z", updatedAt: "2024-11-03T10:00:00Z" },
-  { id: 6, playerId: 6, category: "Merchandise", title: "Elucidator Replica Sword", originalTitle: null, quantity: 1, conditionNote: "Display condition", acquiredFrom: "Animax Shop", tags: ["SAO", "Replica", "Sword"], createdAt: "2025-06-20T10:00:00Z", updatedAt: "2025-06-20T10:00:00Z" },
-  { id: 7, playerId: 6, category: "Bluray", title: "SAO Complete Series Bluray Box", originalTitle: null, quantity: 1, conditionNote: "Sealed", acquiredFrom: "Aniplex Official", tags: ["SAO", "Bluray", "Complete"], createdAt: "2025-09-01T10:00:00Z", updatedAt: "2025-09-01T10:00:00Z" },
-  { id: 8, playerId: 6, category: "Merchandise", title: "SAO Enamel Pin Set", originalTitle: null, quantity: 12, conditionNote: "All pins complete", acquiredFrom: "CR Shop", tags: ["SAO", "Pins", "Collection"], createdAt: "2025-03-14T10:00:00Z", updatedAt: "2025-03-14T10:00:00Z" },
 ];

--- a/shared/api/client.test.ts
+++ b/shared/api/client.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { ApiError, apiDelete, apiGet, apiGetRaw, apiPost } from "./client";
+import { ApiError, apiDelete, apiGet, apiGetRaw, apiPost, apiPostRaw } from "./client";
 import { tokenStorage } from "./tokenStorage";
 import type { ApiEnvelope, TokenPair } from "./types";
 
@@ -52,6 +52,15 @@ describe("backend API에 요청할 때", () => {
       fetchMock.mockResolvedValueOnce(new Response(JSON.stringify({ blueprints: [{ code: "Q_ONE" }] }), { status: 200 }));
 
       await expect(apiGetRaw("/api/v1/quests/catalog")).resolves.toEqual({ blueprints: [{ code: "Q_ONE" }] });
+    });
+
+    it("raw POST만 envelope 없이 반환하고 기본 POST validation은 유지한다", async () => {
+      fetchMock
+        .mockResolvedValueOnce(new Response(JSON.stringify({ id: 31 }), { status: 200 }))
+        .mockResolvedValueOnce(new Response(JSON.stringify({ id: 32 }), { status: 200 }));
+
+      await expect(apiPostRaw("/api/v1/players/collections", { title: "Book" })).resolves.toEqual({ id: 31 });
+      await expect(apiPost("/api/v1/players/collections", { title: "Book" })).rejects.toMatchObject({ code: "INVALID_RESPONSE" });
     });
   });
 

--- a/shared/api/client.ts
+++ b/shared/api/client.ts
@@ -127,6 +127,10 @@ export function apiPost<T>(path: string, body: unknown, options?: RequestOptions
   return apiRequest<T>(path, "POST", body, options);
 }
 
+export function apiPostRaw<T>(path: string, body: unknown, options?: RequestOptions): Promise<T> {
+  return apiRequest<T>(path, "POST", body, { ...options, rawResponse: true });
+}
+
 export function apiPut<T>(path: string, body: unknown, options?: RequestOptions): Promise<T> {
   return apiRequest<T>(path, "PUT", body, options);
 }

--- a/shared/api/types/lifelog.ts
+++ b/shared/api/types/lifelog.ts
@@ -29,19 +29,48 @@ export interface MediaLogInfo {
   updatedAt: string;
 }
 
+export const COLLECTION_CATEGORIES = ["FIGURE", "CARD", "BOOK", "GAME", "STAMP", "COIN", "OTHER"] as const;
+export type CollectionCategory = typeof COLLECTION_CATEGORIES[number];
+
 export interface CollectionInfo {
   id: number;
   playerId: number;
-  category: string;
+  category: CollectionCategory;
   title: string;
   originalTitle: string | null;
-  quantity: number | null;
+  quantity: number;
   conditionNote: string | null;
   acquiredFrom: string | null;
   tags: string[];
   createdAt: string;
   updatedAt: string;
 }
+
+export type CollectionSearchParams = {
+  category?: CollectionCategory;
+  titleLike?: string;
+  page: number;
+  size: number;
+};
+
+export type CollectionCreateRequest = {
+  category: CollectionCategory;
+  title: string;
+  originalTitle?: string;
+  quantity: number;
+  conditionNote?: string;
+  acquiredFrom?: string;
+  tags?: string[];
+};
+
+export type CollectionUpdateRequest = {
+  quantity?: number;
+  conditionNote?: string;
+  acquiredFrom?: string;
+};
+
+export type CollectionCreated = { id: number };
+export type CollectionDeleted = { id: number };
 
 export type JournalSourceType = "COLLECTION" | "EXERCISE" | "MEDIA";
 export type JournalEntryMode = "FULL" | "QUICK";
@@ -75,7 +104,7 @@ export type JournalEntryBase<T extends JournalSourceType, P> = JournalMetadata &
 
 export type CollectionJournalEntry = JournalEntryBase<
   "COLLECTION",
-  Pick<CollectionInfo, "category" | "title" | "quantity">
+  Pick<CollectionInfo, "category" | "title"> & { quantity: number | null }
 >;
 export type ExerciseJournalEntry = JournalEntryBase<
   "EXERCISE",
@@ -92,7 +121,10 @@ export type JournalDetailBase<T extends JournalSourceType, S> = JournalMetadata 
   source: S;
 };
 
-export type CollectionJournalDetail = JournalDetailBase<"COLLECTION", Omit<CollectionInfo, "id" | "playerId">>;
+export type CollectionJournalDetail = JournalDetailBase<
+  "COLLECTION",
+  Omit<CollectionInfo, "id" | "playerId" | "quantity"> & { quantity: number | null }
+>;
 export type ExerciseJournalDetail = JournalDetailBase<"EXERCISE", Omit<ExerciseInfo, "id" | "playerId">>;
 export type MediaJournalDetail = JournalDetailBase<"MEDIA", Omit<MediaLogInfo, "id" | "playerId">>;
 export type JournalDetail = CollectionJournalDetail | ExerciseJournalDetail | MediaJournalDetail;
@@ -113,7 +145,7 @@ export interface JournalListParams {
 }
 
 export type QuickRecordType = JournalSourceType;
-export type QuickRecordCollectionCategory = "FIGURE" | "CARD" | "BOOK" | "GAME" | "STAMP" | "COIN" | "OTHER";
+export type QuickRecordCollectionCategory = CollectionCategory;
 export type QuickRecordExerciseCategory = "RUNNING" | "WALKING" | "CYCLING" | "SWIMMING" | "GYM" | "YOGA" | "OTHER";
 export type QuickRecordMediaCategory = "ANIME" | "MOVIE" | "SERIES" | "BOOK" | "WEBTOON" | "GAME" | "MUSIC";
 export type QuickRecordMediaStatus = "PLANNED" | "WATCHING" | "COMPLETED" | "DROPPED" | "ON_HOLD";


### PR DESCRIPTION
## Body

### Purpose

Replace the legacy/static Collection surface with the backend's real Current Player Collection CRUD contract.

Closes #20

### Delivered

- real Collection recent/search/get/create/update/delete API integration
- canonical backend Collection categories
- real source detail and mutation states
- authoritative reload after mutations
- backend-compatible raw/enveloped response handling
- mock parity for Collection CRUD
- stale Collection form/data contract cleanup

### Backend Contract

Connected:

```text
GET    /api/v1/players/collections/recent
GET    /api/v1/players/collections/search
GET    /api/v1/players/collections/{collectionId}
POST   /api/v1/players/collections
POST   /api/v1/players/collections/{collectionId}
DELETE /api/v1/players/collections/{collectionId}
```

### Collection Semantics

Canonical categories:

- FIGURE
- CARD
- BOOK
- GAME
- STAMP
- COIN
- OTHER

The real flow no longer relies on stale Collection-only UI semantics unsupported by the backend.

### Authority / Identity

- Current Player remains auth-owned
- no caller player/user IDs
- Collection `id` remains source identity
- Collection `id` is never treated as `lifeLogId`
- Journal state is not optimistically fabricated

### Search Semantics

The backend search result is a raw array.

The UI preserves real page/filter state without inventing total counts or total pages.

### Structural Integrity

Touched Collection/LifeLog boundaries were audited for stale DTO/form drift, fake pagination, identity confusion, and duplicate source authority.

Only direct/local-safe findings were changed.

### Validation

Focused coverage includes:

- raw/enveloped transport contracts
- canonical categories
- create/update/delete semantics
- source identity boundaries
- filter/page preservation
- authoritative reload after mutations
- mock parity
- final lint/tests/build