### PR TITLE
[LifeLog] Connect real Exercise CRUD surface

### DIFF
--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -34,6 +34,7 @@ vi.mock("@/widgets/right-panels/RightPanels", () => ({
 }));
 vi.mock("@/features/lifelog/JournalShell", () => ({ default: ({ roles: roleOptions }: { roles: RoleDetail[] }) => <div data-testid="journal-shell">Journal · {roleOptions.map(({ name }) => name).join(", ")}</div> }));
 vi.mock("@/features/lifelog/CollectionShell", () => ({ default: () => <div data-testid="collection-shell">Collection Shell</div> }));
+vi.mock("@/features/lifelog/ExerciseShell", () => ({ default: () => <div data-testid="exercise-shell">Exercise Shell</div> }));
 vi.mock("@/features/inventory/InventoryShell", () => ({ default: ({ surface }: { surface: string }) => <div data-testid="inventory-shell">Inventory · {surface}</div> }));
 vi.mock("@/features/inventory/GearShell", () => ({ default: () => <div data-testid="gear-shell">Gear Shell</div> }));
 vi.mock("@/features/home/HomeShell", () => ({
@@ -136,6 +137,10 @@ describe("Home shell에서 feature surface를 routing할 때", () => {
       fireEvent.click(screen.getByRole("button", { name: "Collection" }));
       expect(screen.queryByTestId("journal-shell")).not.toBeInTheDocument();
       expect(screen.getByTestId("collection-shell")).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole("button", { name: "Exercise" }));
+      expect(screen.queryByTestId("collection-shell")).not.toBeInTheDocument();
+      expect(screen.getByTestId("exercise-shell")).toBeInTheDocument();
     });
 
     it("Role과 Journey feature shell routing을 그대로 유지한다", () => {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,6 +15,7 @@ import JourneyShell from "@/features/quests/JourneyShell";
 import RoleShell from "@/features/role/RoleShell";
 import JournalShell from "@/features/lifelog/JournalShell";
 import CollectionShell from "@/features/lifelog/CollectionShell";
+import ExerciseShell from "@/features/lifelog/ExerciseShell";
 import InventoryShell from "@/features/inventory/InventoryShell";
 import GearShell from "@/features/inventory/GearShell";
 import HomeShell from "@/features/home/HomeShell";
@@ -46,7 +47,6 @@ import {
   PLAYER_LISTS,
 } from "@/features/player/model";
 import {
-  EXERCISE_FORM_FIELDS,
   LIFELOG_CATEGORY_ITEMS,
   LIFELOG_LISTS,
   MEDIA_FORM_FIELDS,
@@ -258,7 +258,7 @@ function buildPanels(
 
   if (selectedMain === "lifelog") {
     const sub = selectedMainSub as LifelogSubId;
-    if (sub === "journal" || sub === "collection") return { panelStack, socialContext: null };
+    if (sub === "journal" || sub === "collection" || sub === "exercise") return { panelStack, socialContext: null };
     const subLabel = mainItems.find((item) => item.id === sub)?.label ?? "Lifelog";
     const categoryItems = LIFELOG_CATEGORY_ITEMS[sub] ?? [];
     const selectedCategory = selectedLifelogCategoryBySub[sub] ?? null;
@@ -806,9 +806,7 @@ export default function Home() {
     const route = panel.context.route;
     const sub = selectedSubByMain[panel.context.main];
 
-    if (route === "lifelog-list" && sub === "exercise") {
-      openForm("exercise-create", "Log Exercise", EXERCISE_FORM_FIELDS, "기록하기");
-    } else if (route === "lifelog-list" && sub === "media") {
+    if (route === "lifelog-list" && sub === "media") {
       openForm("media-create", "Log Media", MEDIA_FORM_FIELDS, "기록하기");
     } else if (route === "social-list" && sub === "party") {
       openForm("party-create", "Create Party", PARTY_FORM_FIELDS, "파티 생성");
@@ -825,16 +823,7 @@ export default function Home() {
     const sub = selectedSubByMain[selectedMain];
 
     if (actionType === "edit") {
-      const allLists = [
-        ...LIFELOG_LISTS.exercise,
-        ...LIFELOG_LISTS.media,
-      ];
-      const item = allLists.find((i) => i.id === itemId);
-
-      if (selectedMain === "lifelog" && sub === "exercise") {
-        openForm("exercise-edit", "Edit Exercise", EXERCISE_FORM_FIELDS, "수정하기",
-          item ? { category: item.detailRows[0]?.split(": ")[1] ?? "" } : undefined);
-      } else if (selectedMain === "lifelog" && sub === "media") {
+      if (selectedMain === "lifelog" && sub === "media") {
         openForm("media-edit", "Edit Media", MEDIA_FORM_FIELDS, "수정하기");
       }
 
@@ -1021,7 +1010,7 @@ export default function Home() {
     if (formKey.startsWith("credential") || formKey.startsWith("hobby")) {
       const sub = selectedSubByMain.player as PlayerSubId;
       setSelectedPlayerCategoryBySub((prev) => ({ ...prev, [sub]: value || null }));
-    } else if (formKey.startsWith("exercise") || formKey.startsWith("media")) {
+    } else if (formKey.startsWith("media")) {
       const sub = selectedSubByMain.lifelog as LifelogSubId;
       setSelectedLifelogCategoryBySub((prev) => ({ ...prev, [sub]: value || null }));
     }
@@ -1054,9 +1043,7 @@ export default function Home() {
       setSelectedLifelogCategoryBySub((prev) => ({ ...prev, [sub]: itemId }));
       updateDetailSelections({ lifelog: null });
       setEditingItemId(null);
-      if (sub === "exercise") {
-        openForm("exercise-create", "Log Exercise", EXERCISE_FORM_FIELDS, "기록하기", { category: itemId });
-      } else if (sub === "media") {
+      if (sub === "media") {
         openForm("media-create", "Log Media", MEDIA_FORM_FIELDS, "기록하기", { type: itemId });
       }
       return;
@@ -1079,9 +1066,7 @@ export default function Home() {
     } else if (selectedMain === "lifelog") {
       updateDetailSelections({ lifelog: itemId });
       setEditingItemId(itemId);
-      if (sub === "exercise") {
-        openForm("exercise-edit", "Edit Exercise", EXERCISE_FORM_FIELDS, "수정하기");
-      } else if (sub === "media") {
+      if (sub === "media") {
         openForm("media-edit", "Edit Media", MEDIA_FORM_FIELDS, "수정하기");
       }
     }
@@ -1284,6 +1269,16 @@ export default function Home() {
                 onPanelItemSelect={handlePanelItemSelect}
               />
               <CollectionShell />
+            </div>
+          ) : selectedMain === "lifelog" && selectedSubByMain.lifelog === "exercise" ? (
+            <div className="flex w-fit items-center gap-3">
+              <RightPanels
+                selectedMain="lifelog"
+                panelStack={panelStack.slice(0, 1)}
+                panelStackKey="lifelog-exercise-menu"
+                onPanelItemSelect={handlePanelItemSelect}
+              />
+              <ExerciseShell />
             </div>
           ) : (
             <RightPanels

--- a/features/lifelog/ExerciseShell.test.tsx
+++ b/features/lifelog/ExerciseShell.test.tsx
@@ -1,0 +1,72 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { EXERCISE_CATEGORIES } from "@/shared/api/types";
+import type { ExerciseInfo } from "@/shared/api/types";
+import ExerciseShell from "./ExerciseShell";
+
+const api = vi.hoisted(() => ({
+  createExerciseApi: vi.fn(),
+  deleteExerciseApi: vi.fn(),
+  getExerciseApi: vi.fn(),
+  searchExercisesApi: vi.fn(),
+  updateExerciseApi: vi.fn(),
+}));
+
+vi.mock("./api", () => api);
+vi.mock("@/shared/ui/PanelCard", () => ({
+  default: ({ label, onClick }: { label: string; onClick: () => void }) => <button type="button" data-testid="exercise-entry" onClick={onClick}>{label}</button>,
+}));
+
+const item: ExerciseInfo = { id: 41, playerId: 7, category: "RUNNING", durationMinutes: 30, distanceKm: 5, calories: 250, exercisedOn: "2026-08-14", memo: "Morning run", createdAt: "2026-08-14T00:00:00Z", updatedAt: "2026-08-14T00:00:00Z" };
+
+describe("Exercise source surface를 사용할 때", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api.searchExercisesApi.mockResolvedValue([item]);
+    api.getExerciseApi.mockResolvedValue(item);
+    api.createExerciseApi.mockResolvedValue({ id: 99 });
+    api.updateExerciseApi.mockResolvedValue({ ...item, distanceKm: 5, calories: 250, memo: null });
+    api.deleteExerciseApi.mockResolvedValue({ id: item.id });
+  });
+
+  it("canonical filters/create fields와 supported partial update만 노출한다", async () => {
+    render(<ExerciseShell />);
+    await screen.findByTestId("exercise-entry");
+
+    const filter = screen.getByLabelText("Category filter") as HTMLSelectElement;
+    expect(Array.from(filter.options, ({ value }) => value).slice(1)).toEqual([...EXERCISE_CATEGORIES]);
+    expect(screen.queryByText(/CARDIO|STRENGTH|STRETCHING|SPORTS/)).not.toBeInTheDocument();
+    fireEvent.change(filter, { target: { value: "RUNNING" } });
+    fireEvent.change(screen.getByLabelText("From date"), { target: { value: "2026-08-01" } });
+    fireEvent.change(screen.getByLabelText("To date"), { target: { value: "2026-08-14" } });
+    fireEvent.click(screen.getByRole("button", { name: "Search" }));
+    await waitFor(() => expect(api.searchExercisesApi).toHaveBeenLastCalledWith({ category: "RUNNING", from: "2026-08-01", to: "2026-08-14", page: 0, size: 20 }));
+
+    fireEvent.click(screen.getByText("Add Exercise"));
+    expect(screen.getByLabelText("Create category")).toBeRequired();
+    expect(screen.getByLabelText("Duration minutes")).toBeRequired();
+    expect(screen.getByLabelText("Exercised on")).toBeRequired();
+    expect(screen.queryByLabelText(/intensity|duration$|calories burned|notes/i)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("exercise-entry"));
+    await screen.findByText("Exercise source #41");
+    expect(screen.getByText(/Blank numeric fields preserve/)).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText("Update category"), { target: { value: "YOGA" } });
+    fireEvent.change(screen.getByLabelText("Update duration minutes"), { target: { value: "45" } });
+    fireEvent.change(screen.getByLabelText("Update distance km"), { target: { value: "" } });
+    fireEvent.change(screen.getByLabelText("Update calories"), { target: { value: "" } });
+    fireEvent.change(screen.getByLabelText("Update exercised on"), { target: { value: "2026-08-15" } });
+    fireEvent.change(screen.getByLabelText("Update memo"), { target: { value: "" } });
+    fireEvent.click(screen.getByRole("button", { name: "Update Exercise" }));
+
+    await waitFor(() => expect(api.updateExerciseApi).toHaveBeenCalledWith(41, {
+      category: "YOGA",
+      durationMinutes: 45,
+      exercisedOn: "2026-08-15",
+      memo: "",
+    }));
+    expect(api.updateExerciseApi.mock.calls[0][1]).not.toHaveProperty("distanceKm");
+    expect(api.updateExerciseApi.mock.calls[0][1]).not.toHaveProperty("calories");
+  });
+});

--- a/features/lifelog/ExerciseShell.tsx
+++ b/features/lifelog/ExerciseShell.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+import { useState } from "react";
+
+import {
+  EXERCISE_CATEGORIES,
+  type ExerciseCategory,
+  type ExerciseCreateRequest,
+  type ExerciseInfo,
+  type ExerciseUpdateRequest,
+} from "@/shared/api/types";
+import { INPUT_STYLE, SAO } from "@/shared/design/tokens";
+import PanelCard from "@/shared/ui/PanelCard";
+import { PanelFrame } from "@/widgets/right-panels/ui/PanelFrame";
+import { GoldRow, InfoCard } from "@/widgets/right-panels/ui/Rows";
+import { useExerciseQueries } from "./useExerciseQueries";
+
+const buttonStyle = {
+  border: `1px solid ${SAO.color.border.panel}`,
+  background: SAO.color.bg.inset,
+  color: SAO.color.text.secondary,
+  borderRadius: SAO.radius.panel,
+  padding: "7px 10px",
+  fontSize: "0.68rem",
+  letterSpacing: "0.08em",
+} as const;
+
+function text(form: FormData, key: string): string {
+  return String(form.get(key) ?? "").trim();
+}
+
+function optionalNumber(form: FormData, key: string): number | undefined {
+  const value = text(form, key);
+  return value === "" ? undefined : Number(value);
+}
+
+function ErrorState({ message, retry }: { message: string; retry: () => void }) {
+  return (
+    <div className="space-y-2 px-3">
+      <p role="alert" className="text-xs" style={{ color: SAO.color.action.red }}>{message}</p>
+      <button type="button" style={buttonStyle} onClick={retry}>Retry</button>
+    </div>
+  );
+}
+
+function CategorySelect({ name, label, optional = false, disabled = false, defaultValue = "" }: { name: string; label: string; optional?: boolean; disabled?: boolean; defaultValue?: ExerciseCategory | "" }) {
+  return (
+    <label className="block text-xs" style={{ color: SAO.color.text.label }}>
+      {label}
+      <select name={name} aria-label={label} defaultValue={defaultValue} required={!optional} disabled={disabled} style={INPUT_STYLE}>
+        <option value="">{optional ? "All Categories" : "Select..."}</option>
+        {EXERCISE_CATEGORIES.map((category) => <option key={category} value={category}>{category}</option>)}
+      </select>
+    </label>
+  );
+}
+
+function CreateForm({ pending, create }: { pending: boolean; create: (body: ExerciseCreateRequest) => Promise<boolean> }) {
+  const submit = async (event: React.SubmitEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const element = event.currentTarget;
+    const form = new FormData(element);
+    const distanceKm = optionalNumber(form, "distanceKm");
+    const calories = optionalNumber(form, "calories");
+    const memo = text(form, "memo");
+    const saved = await create({
+      category: text(form, "category") as ExerciseCategory,
+      durationMinutes: Number(text(form, "durationMinutes")),
+      exercisedOn: text(form, "exercisedOn"),
+      ...(distanceKm === undefined ? {} : { distanceKm }),
+      ...(calories === undefined ? {} : { calories }),
+      ...(memo ? { memo } : {}),
+    });
+    if (saved) element.reset();
+  };
+
+  return (
+    <form className="mt-3 space-y-2" onSubmit={submit}>
+      <CategorySelect name="category" label="Create category" disabled={pending} />
+      <label className="block text-xs" style={{ color: SAO.color.text.label }}>Duration minutes<input name="durationMinutes" type="number" min={1} required disabled={pending} style={INPUT_STYLE} /></label>
+      <label className="block text-xs" style={{ color: SAO.color.text.label }}>Distance km<input name="distanceKm" type="number" min={0} step="any" disabled={pending} style={INPUT_STYLE} /></label>
+      <label className="block text-xs" style={{ color: SAO.color.text.label }}>Calories<input name="calories" type="number" min={0} disabled={pending} style={INPUT_STYLE} /></label>
+      <label className="block text-xs" style={{ color: SAO.color.text.label }}>Exercised on<input name="exercisedOn" type="date" required disabled={pending} style={INPUT_STYLE} /></label>
+      <label className="block text-xs" style={{ color: SAO.color.text.label }}>Memo<textarea name="memo" disabled={pending} style={INPUT_STYLE} /></label>
+      <button type="submit" disabled={pending} style={buttonStyle}>{pending ? "Saving..." : "Create Exercise"}</button>
+    </form>
+  );
+}
+
+function ExerciseDetail({ item, pending, update, remove }: { item: ExerciseInfo; pending: boolean; update: (body: ExerciseUpdateRequest) => Promise<boolean>; remove: () => Promise<boolean> }) {
+  const submit = (event: React.SubmitEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const form = new FormData(event.currentTarget);
+    const distanceKm = optionalNumber(form, "distanceKm");
+    const calories = optionalNumber(form, "calories");
+    void update({
+      category: text(form, "category") as ExerciseCategory,
+      durationMinutes: Number(text(form, "durationMinutes")),
+      exercisedOn: text(form, "exercisedOn"),
+      memo: text(form, "memo"),
+      ...(distanceKm === undefined ? {} : { distanceKm }),
+      ...(calories === undefined ? {} : { calories }),
+    });
+  };
+
+  return (
+    <div className="space-y-3 px-3">
+      <InfoCard>{item.category} · {item.exercisedOn}</InfoCard>
+      <GoldRow>Exercise source #{item.id}</GoldRow>
+      <GoldRow>Duration: {item.durationMinutes} min</GoldRow>
+      <GoldRow>Distance: {item.distanceKm ?? "Not recorded"}</GoldRow>
+      <GoldRow>Calories: {item.calories ?? "Not recorded"}</GoldRow>
+      <GoldRow>Memo: {item.memo ?? "Not recorded"}</GoldRow>
+      <GoldRow>Created: {item.createdAt}</GoldRow>
+      <GoldRow>Updated: {item.updatedAt}</GoldRow>
+      <form key={`${item.id}-${item.updatedAt}`} className="space-y-2" onSubmit={submit}>
+        <CategorySelect name="category" label="Update category" defaultValue={item.category} disabled={pending} />
+        <label className="block text-xs" style={{ color: SAO.color.text.label }}>Update duration minutes<input name="durationMinutes" type="number" min={1} required defaultValue={item.durationMinutes} disabled={pending} style={INPUT_STYLE} /></label>
+        <label className="block text-xs" style={{ color: SAO.color.text.label }}>Update distance km<input name="distanceKm" type="number" min={0} step="any" defaultValue={item.distanceKm ?? ""} placeholder={item.distanceKm === null ? "Not recorded" : String(item.distanceKm)} disabled={pending} style={INPUT_STYLE} /></label>
+        <label className="block text-xs" style={{ color: SAO.color.text.label }}>Update calories<input name="calories" type="number" min={0} defaultValue={item.calories ?? ""} placeholder={item.calories === null ? "Not recorded" : String(item.calories)} disabled={pending} style={INPUT_STYLE} /></label>
+        <p className="text-xs" style={{ color: SAO.color.text.label }}>Blank numeric fields preserve the current server value; existing values cannot be cleared yet.</p>
+        <label className="block text-xs" style={{ color: SAO.color.text.label }}>Update exercised on<input name="exercisedOn" type="date" required defaultValue={item.exercisedOn} disabled={pending} style={INPUT_STYLE} /></label>
+        <label className="block text-xs" style={{ color: SAO.color.text.label }}>Update memo<textarea name="memo" defaultValue={item.memo ?? ""} disabled={pending} style={INPUT_STYLE} /></label>
+        <div className="flex gap-2">
+          <button type="submit" disabled={pending} style={{ ...buttonStyle, flex: 1 }}>{pending ? "Working..." : "Update Exercise"}</button>
+          <button type="button" disabled={pending} style={buttonStyle} onClick={() => {
+            if (window.confirm(`Delete ${item.category} Exercise?`)) void remove();
+          }}>Delete</button>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+export default function ExerciseShell() {
+  const exercises = useExerciseQueries();
+  const [category, setCategory] = useState<ExerciseCategory | "">("");
+  const [from, setFrom] = useState("");
+  const [to, setTo] = useState("");
+  const pending = exercises.pendingMutation !== null;
+  const nextDisabled = exercises.list.loading || exercises.list.items.length < exercises.params.size;
+
+  return (
+    <div className="relative flex min-w-0 w-fit flex-row flex-nowrap items-center gap-3" data-testid="exercise-shell">
+      <PanelFrame title="Exercise Search" depth={2}>
+        <div className="space-y-3 px-3">
+          <form className="space-y-2" onSubmit={(event) => {
+            event.preventDefault();
+            exercises.search(category || undefined, from, to);
+          }}>
+            <label className="block text-xs" style={{ color: SAO.color.text.label }}>
+              Category filter
+              <select aria-label="Category filter" value={category} onChange={(event) => setCategory(event.target.value as ExerciseCategory | "")} style={INPUT_STYLE}>
+                <option value="">All Categories</option>
+                {EXERCISE_CATEGORIES.map((value) => <option key={value} value={value}>{value}</option>)}
+              </select>
+            </label>
+            <label className="block text-xs" style={{ color: SAO.color.text.label }}>From date<input aria-label="From date" type="date" value={from} onChange={(event) => setFrom(event.target.value)} style={INPUT_STYLE} /></label>
+            <label className="block text-xs" style={{ color: SAO.color.text.label }}>To date<input aria-label="To date" type="date" value={to} onChange={(event) => setTo(event.target.value)} style={INPUT_STYLE} /></label>
+            <button type="submit" style={buttonStyle}>Search</button>
+          </form>
+          <details>
+            <summary className="cursor-pointer text-xs" style={{ color: SAO.color.text.gold }}>Add Exercise</summary>
+            <CreateForm pending={pending} create={exercises.create} />
+          </details>
+        </div>
+      </PanelFrame>
+
+      <PanelFrame title="Exercises" depth={1}>
+        <div className="space-y-3">
+          {exercises.list.loading && exercises.list.items.length === 0 ? <InfoCard>Loading Exercises...</InfoCard> : null}
+          {exercises.list.error ? <ErrorState message={exercises.list.error} retry={() => void exercises.list.reload()} /> : null}
+          {!exercises.list.loading && !exercises.list.error && exercises.list.items.length === 0 ? <InfoCard>No Exercises.</InfoCard> : null}
+          {exercises.mutationError ? <p role="alert" className="px-3 text-xs" style={{ color: SAO.color.action.red }}>{exercises.mutationError}</p> : null}
+          <div className="space-y-2">
+            {exercises.list.items.map((item, index) => (
+              <PanelCard key={item.id} label={`${item.category} · ${item.exercisedOn}`} slotLabel={`${item.durationMinutes}m`} subtitle={`${item.distanceKm ?? "–"} km · ${item.calories ?? "–"} kcal`} selected={exercises.selectedId === item.id} index={index} onClick={() => exercises.select(item.id)} />
+            ))}
+          </div>
+          <div className="flex items-center justify-between gap-2 px-3">
+            <button type="button" disabled={exercises.list.loading || exercises.params.page === 0} style={buttonStyle} onClick={() => exercises.changePage(exercises.params.page - 1)}>Previous</button>
+            <span className="text-xs" style={{ color: SAO.color.text.label }}>Page {exercises.params.page + 1}</span>
+            <button type="button" disabled={nextDisabled} style={buttonStyle} onClick={() => exercises.changePage(exercises.params.page + 1)}>Next</button>
+          </div>
+        </div>
+      </PanelFrame>
+
+      <PanelFrame title="Exercise Detail" depth={0}>
+        {!exercises.selectedId ? <InfoCard>Select an Exercise.</InfoCard> : null}
+        {exercises.detail.loading && !exercises.detail.data ? <InfoCard>Loading Exercise...</InfoCard> : null}
+        {exercises.detail.error ? <ErrorState message={exercises.detail.error} retry={() => void exercises.detail.retry()} /> : null}
+        {exercises.detail.data ? <ExerciseDetail item={exercises.detail.data} pending={pending} update={(body) => exercises.update(exercises.detail.data!.id, body)} remove={() => exercises.remove(exercises.detail.data!.id)} /> : null}
+      </PanelFrame>
+    </div>
+  );
+}

--- a/features/lifelog/api.test.ts
+++ b/features/lifelog/api.test.ts
@@ -1,19 +1,25 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { COLLECTION_CATEGORIES } from "@/shared/api/types";
-import type { CollectionCreateRequest, CollectionInfo, CollectionUpdateRequest, JournalPage, JournalSubtype, QuickRecordRequest } from "@/shared/api/types";
+import { COLLECTION_CATEGORIES, EXERCISE_CATEGORIES } from "@/shared/api/types";
+import type { CollectionCreateRequest, CollectionInfo, CollectionUpdateRequest, ExerciseCreateRequest, ExerciseInfo, ExerciseUpdateRequest, JournalPage, JournalSubtype, QuickRecordRequest } from "@/shared/api/types";
 import {
   createCollectionApi,
+  createExerciseApi,
   deleteCollectionApi,
+  deleteExerciseApi,
   getCollectionApi,
+  getExerciseApi,
   getJournalDetailApi,
   listJournalApi,
   quickRecordApi,
   recentCollectionsApi,
+  recentExercisesApi,
   searchCollectionsApi,
+  searchExercisesApi,
   updateCollectionApi,
+  updateExerciseApi,
 } from "./api";
-import { collectionMock, journalMock, MOCK_JOURNAL_ENTRIES, resetJournalMock } from "./mock";
+import { collectionMock, exerciseMock, journalMock, MOCK_JOURNAL_ENTRIES, resetJournalMock } from "./mock";
 
 const client = vi.hoisted(() => ({
   apiDelete: vi.fn(),
@@ -39,6 +45,64 @@ const collection: CollectionInfo = {
   createdAt: "2026-08-12T09:00:00Z",
   updatedAt: "2026-08-12T09:00:00Z",
 };
+const exercise: ExerciseInfo = {
+  id: 41,
+  playerId: 7,
+  category: "RUNNING",
+  durationMinutes: 30,
+  distanceKm: 5,
+  calories: 250,
+  exercisedOn: "2026-08-14",
+  memo: "Morning run",
+  createdAt: "2026-08-14T00:00:00Z",
+  updatedAt: "2026-08-14T00:00:00Z",
+};
+
+describe("Exercise source API를 호출할 때", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetJournalMock();
+  });
+
+  it("exact six paths에서 recent/search/create/update는 raw, get/delete는 envelope client를 사용한다", async () => {
+    client.apiGetRaw.mockResolvedValue([exercise]);
+    client.apiGet.mockResolvedValue(exercise);
+    client.apiPostRaw.mockResolvedValueOnce({ id: 41 }).mockResolvedValueOnce(exercise);
+    client.apiDelete.mockResolvedValue({ id: 41 });
+    const create: ExerciseCreateRequest = { category: "RUNNING", durationMinutes: 30, distanceKm: 5, calories: 250, exercisedOn: "2026-08-14", memo: "Morning run" };
+    const update: ExerciseUpdateRequest = { category: "YOGA", durationMinutes: 45, exercisedOn: "2026-08-15", memo: "" };
+
+    await recentExercisesApi(12);
+    const search = await searchExercisesApi({ category: "RUNNING", from: "2026-08-01", to: "2026-08-14", page: 2, size: 20 });
+    await getExerciseApi(41);
+    await createExerciseApi(create);
+    await updateExerciseApi(41, update);
+    await deleteExerciseApi(41);
+
+    expect(client.apiGetRaw).toHaveBeenNthCalledWith(1, "/api/v1/players/exercises/recent?limit=12");
+    expect(client.apiGetRaw).toHaveBeenNthCalledWith(2, "/api/v1/players/exercises/search?category=RUNNING&from=2026-08-01&to=2026-08-14&page=2&size=20");
+    expect(client.apiGet).toHaveBeenCalledWith("/api/v1/players/exercises/41");
+    expect(client.apiPostRaw).toHaveBeenNthCalledWith(1, "/api/v1/players/exercises", create);
+    expect(client.apiPostRaw).toHaveBeenNthCalledWith(2, "/api/v1/players/exercises/41", update);
+    expect(client.apiDelete).toHaveBeenCalledWith("/api/v1/players/exercises/41");
+    expect(search).toEqual([exercise]);
+    expect(search).not.toHaveProperty("totalElements");
+  });
+
+  it("canonical request fields와 partial/null mock semantics를 한 authority에서 유지한다", () => {
+    const journalIds = journalMock.page({ page: 0, size: 20 }).content.map(({ lifeLogId }) => lifeLogId);
+    const create: ExerciseCreateRequest = { category: "CYCLING", durationMinutes: 60, distanceKm: 0, calories: 0, exercisedOn: "2026-08-14", memo: "Ride" };
+    const created = exerciseMock.create(create);
+    const updated = exerciseMock.update(created.id, { durationMinutes: 75, distanceKm: null, calories: null, memo: "" });
+
+    expect(EXERCISE_CATEGORIES).toEqual(["RUNNING", "WALKING", "CYCLING", "SWIMMING", "GYM", "YOGA", "OTHER"]);
+    for (const unsupported of ["playerId", "userId", "ownerPlayerId", "intensity", "duration", "caloriesBurned", "notes"]) expect(create).not.toHaveProperty(unsupported);
+    expect(updated).toEqual(expect.objectContaining({ durationMinutes: 75, distanceKm: 0, calories: 0, memo: null }));
+    expect(exerciseMock.search({ category: "CYCLING", from: "2026-08-14", to: "2026-08-14", page: 0, size: 1 }).map(({ id }) => id)).toEqual([created.id]);
+    expect(exerciseMock.delete(created.id)).toEqual({ id: created.id });
+    expect(journalMock.page({ page: 0, size: 20 }).content.map(({ lifeLogId }) => lifeLogId)).toEqual(journalIds);
+  });
+});
 
 describe("Collection source API를 호출할 때", () => {
   beforeEach(() => {

--- a/features/lifelog/api.ts
+++ b/features/lifelog/api.ts
@@ -6,15 +6,64 @@ import type {
   CollectionInfo,
   CollectionSearchParams,
   CollectionUpdateRequest,
+  ExerciseCreateRequest,
+  ExerciseCreated,
+  ExerciseDeleted,
+  ExerciseInfo,
+  ExerciseSearchParams,
+  ExerciseUpdateRequest,
   JournalDetail,
   JournalListParams,
   JournalPage,
   QuickRecordRequest,
   QuickRecordResult,
 } from "@/shared/api/types";
-import { collectionMock, journalMock } from "./mock";
+import { collectionMock, exerciseMock, journalMock } from "./mock";
 
 const COLLECTION_PATH = "/api/v1/players/collections";
+const EXERCISE_PATH = "/api/v1/players/exercises";
+
+export function recentExercisesApi(limit: number): Promise<ExerciseInfo[]> {
+  return USE_MOCK
+    ? Promise.resolve(exerciseMock.recent(limit))
+    : apiGetRaw<ExerciseInfo[]>(`${EXERCISE_PATH}/recent?limit=${limit}`);
+}
+
+export function searchExercisesApi(params: ExerciseSearchParams): Promise<ExerciseInfo[]> {
+  const query = new URLSearchParams();
+  if (params.category) query.set("category", params.category);
+  if (params.from) query.set("from", params.from);
+  if (params.to) query.set("to", params.to);
+  query.set("page", String(params.page));
+  query.set("size", String(params.size));
+  return USE_MOCK
+    ? Promise.resolve(exerciseMock.search(params))
+    : apiGetRaw<ExerciseInfo[]>(`${EXERCISE_PATH}/search?${query}`);
+}
+
+export function getExerciseApi(exerciseId: number): Promise<ExerciseInfo> {
+  return USE_MOCK
+    ? Promise.resolve().then(() => exerciseMock.get(exerciseId))
+    : apiGet<ExerciseInfo>(`${EXERCISE_PATH}/${exerciseId}`);
+}
+
+export function createExerciseApi(body: ExerciseCreateRequest): Promise<ExerciseCreated> {
+  return USE_MOCK
+    ? Promise.resolve().then(() => exerciseMock.create(body))
+    : apiPostRaw<ExerciseCreated>(EXERCISE_PATH, body);
+}
+
+export function updateExerciseApi(exerciseId: number, body: ExerciseUpdateRequest): Promise<ExerciseInfo> {
+  return USE_MOCK
+    ? Promise.resolve().then(() => exerciseMock.update(exerciseId, body))
+    : apiPostRaw<ExerciseInfo>(`${EXERCISE_PATH}/${exerciseId}`, body);
+}
+
+export function deleteExerciseApi(exerciseId: number): Promise<ExerciseDeleted> {
+  return USE_MOCK
+    ? Promise.resolve().then(() => exerciseMock.delete(exerciseId))
+    : apiDelete<ExerciseDeleted>(`${EXERCISE_PATH}/${exerciseId}`);
+}
 
 export function recentCollectionsApi(limit: number): Promise<CollectionInfo[]> {
   return USE_MOCK

--- a/features/lifelog/data.ts
+++ b/features/lifelog/data.ts
@@ -10,18 +10,3 @@ export const MEDIA_DATA = [
   { title: "Designing Data-Intensive Apps",     cat: "Book",   cur: 250, total: 616, status: "READING",      rating: null },
   { title: "Spirited Away",                     cat: "Movie",  cur: 1,   total: 1,   status: "COMPLETED",    rating: 9.9 },
 ];
-
-export const EXERCISE_DATA = [
-  { cat: "Running",          dur: 32,  dist: 5.2,  cal: 310, date: "2026-03-02" },
-  { cat: "Cycling",          dur: 75,  dist: 28.4, cal: 620, date: "2026-03-01" },
-  { cat: "Strength Training",dur: 55,  dist: null, cal: 380, date: "2026-02-28" },
-  { cat: "Swimming",         dur: 40,  dist: 1.5,  cal: 420, date: "2026-02-26" },
-  { cat: "Running",          dur: 28,  dist: 4.8,  cal: 285, date: "2026-02-25" },
-  { cat: "Yoga",             dur: 45,  dist: null, cal: 120, date: "2026-02-24" },
-  { cat: "Hiking",           dur: 180, dist: 12.0, cal: 850, date: "2026-02-22" },
-  { cat: "Strength Training",dur: 60,  dist: null, cal: 420, date: "2026-02-21" },
-  { cat: "Running",          dur: 35,  dist: 6.0,  cal: 360, date: "2026-02-19" },
-  { cat: "Cycling",          dur: 90,  dist: 35.2, cal: 750, date: "2026-02-16" },
-  { cat: "Jump Rope",        dur: 20,  dist: null, cal: 200, date: "2026-02-15" },
-  { cat: "Swimming",         dur: 50,  dist: 2.0,  cal: 530, date: "2026-02-12" },
-];

--- a/features/lifelog/forms.ts
+++ b/features/lifelog/forms.ts
@@ -1,24 +1,5 @@
 import type { FormFieldSpec } from "@/entities/nav";
 
-export const EXERCISE_FORM_FIELDS: FormFieldSpec[] = [
-  { key: "category",      label: "Category",       type: "select", required: true, options: [
-    { value: "CARDIO",    label: "Cardio" },    { value: "STRENGTH",  label: "Strength" },
-    { value: "YOGA",      label: "Yoga" },      { value: "STRETCHING",label: "Stretching" },
-    { value: "WALKING",   label: "Walking" },   { value: "CYCLING",   label: "Cycling" },
-    { value: "SWIMMING",  label: "Swimming" },  { value: "SPORTS",    label: "Sports" },
-    { value: "OTHER",     label: "Other" },
-  ]},
-  { key: "duration",      label: "Duration (min)",  type: "number",   placeholder: "30",  required: true },
-  { key: "intensity",     label: "Intensity",        type: "select",   required: true, options: [
-    { value: "LOW",       label: "Low" },
-    { value: "MODERATE",  label: "Moderate" },
-    { value: "HIGH",      label: "High" },
-    { value: "VERY_HIGH", label: "Very High" },
-  ]},
-  { key: "caloriesBurned",label: "Calories Burned", type: "number",   placeholder: "300" },
-  { key: "notes",         label: "Notes",            type: "textarea", placeholder: "Session notes..." },
-];
-
 export const MEDIA_FORM_FIELDS: FormFieldSpec[] = [
   { key: "type",          label: "Type",    type: "select", required: true, options: [
     { value: "ANIME",  label: "Anime" },  { value: "BOOK",   label: "Book" },

--- a/features/lifelog/mock.ts
+++ b/features/lifelog/mock.ts
@@ -3,6 +3,10 @@ import type {
   CollectionInfo,
   CollectionSearchParams,
   CollectionUpdateRequest,
+  ExerciseCreateRequest,
+  ExerciseInfo,
+  ExerciseSearchParams,
+  ExerciseUpdateRequest,
   JournalDetail,
   JournalEntry,
   JournalListParams,
@@ -162,9 +166,15 @@ export const MOCK_COLLECTION_SOURCES = [
   },
 ] satisfies CollectionInfo[];
 
+export const MOCK_EXERCISE_SOURCES = [
+  { id: 203, playerId: 6, category: "RUNNING", durationMinutes: 25, distanceKm: 4.2, calories: 240, exercisedOn: "2026-08-12", memo: "Morning run", createdAt: "2026-08-12T08:00:00Z", updatedAt: "2026-08-12T08:00:00Z" },
+  { id: 200, playerId: 6, category: "YOGA", durationMinutes: 45, distanceKm: null, calories: 120, exercisedOn: "2026-08-09", memo: null, createdAt: "2026-08-09T07:00:00Z", updatedAt: "2026-08-09T07:00:00Z" },
+] satisfies ExerciseInfo[];
+
 let journalEntries: JournalEntry[] = structuredClone([...MOCK_JOURNAL_ENTRIES]);
 let journalDetails: JournalDetail[] = structuredClone(MOCK_JOURNAL_DETAILS);
 let collectionEntries: CollectionInfo[] = structuredClone(MOCK_COLLECTION_SOURCES);
+let exerciseEntries: ExerciseInfo[] = structuredClone(MOCK_EXERCISE_SOURCES);
 const quickRecordReceipts = new Map<string, { payload: string; result: QuickRecordResult }>();
 
 function copy<T>(value: T): T {
@@ -180,6 +190,7 @@ export function resetJournalMock(): void {
   journalEntries = structuredClone([...MOCK_JOURNAL_ENTRIES]);
   journalDetails = structuredClone(MOCK_JOURNAL_DETAILS);
   collectionEntries = structuredClone(MOCK_COLLECTION_SOURCES);
+  exerciseEntries = structuredClone(MOCK_EXERCISE_SOURCES);
   quickRecordReceipts.clear();
 }
 
@@ -196,6 +207,7 @@ function recordQuick(body: QuickRecordRequest, idempotencyKey: string): QuickRec
     0,
     ...journalEntries.map((entry) => entry.sourceId),
     ...collectionEntries.map((entry) => entry.id),
+    ...exerciseEntries.map((entry) => entry.id),
   ) + 1;
   const recordedAt = new Date().toISOString();
   const metadata = {
@@ -249,6 +261,7 @@ function recordQuick(body: QuickRecordRequest, idempotencyKey: string): QuickRec
     };
     entry = { ...metadata, sourceType: "EXERCISE", preview: source };
     detail = { ...metadata, sourceType: "EXERCISE", source: { ...source, createdAt: recordedAt, updatedAt: recordedAt } };
+    exerciseEntries.unshift({ id: sourceId, playerId: 6, ...source, createdAt: recordedAt, updatedAt: recordedAt });
   } else {
     const source = {
       category: body.media.category,
@@ -288,6 +301,59 @@ function collection(id: number): CollectionInfo {
 }
 
 const MOCK_MUTATION_TIME = "2026-08-14T00:00:00Z";
+
+function exercise(id: number): ExerciseInfo {
+  const found = exerciseEntries.find((entry) => entry.id === id);
+  if (!found) throw new Error("Exercise not found.");
+  return found;
+}
+
+export const exerciseMock = {
+  recent: (limit: number): ExerciseInfo[] => copy(exerciseEntries.slice(0, limit)),
+  search: ({ category, from, to, page, size }: ExerciseSearchParams): ExerciseInfo[] => {
+    const filtered = exerciseEntries.filter((entry) =>
+      (!category || entry.category === category)
+      && (!from || entry.exercisedOn >= from)
+      && (!to || entry.exercisedOn <= to)
+    );
+    return copy(filtered.slice(page * size, (page + 1) * size));
+  },
+  get: (id: number): ExerciseInfo => copy(exercise(id)),
+  create: (body: ExerciseCreateRequest): { id: number } => {
+    const id = Math.max(0, ...exerciseEntries.map((entry) => entry.id)) + 1;
+    exerciseEntries.unshift({
+      id,
+      playerId: 6,
+      ...body,
+      distanceKm: body.distanceKm ?? null,
+      calories: body.calories ?? null,
+      memo: body.memo?.trim() || null,
+      createdAt: MOCK_MUTATION_TIME,
+      updatedAt: MOCK_MUTATION_TIME,
+    });
+    return { id };
+  },
+  update: (id: number, body: ExerciseUpdateRequest): ExerciseInfo => {
+    const current = exercise(id);
+    const updated = {
+      ...current,
+      ...(body.category == null ? {} : { category: body.category }),
+      ...(body.durationMinutes == null ? {} : { durationMinutes: body.durationMinutes }),
+      ...(body.distanceKm == null ? {} : { distanceKm: body.distanceKm }),
+      ...(body.calories == null ? {} : { calories: body.calories }),
+      ...(body.exercisedOn == null ? {} : { exercisedOn: body.exercisedOn }),
+      ...(body.memo == null ? {} : { memo: body.memo.trim() || null }),
+      updatedAt: MOCK_MUTATION_TIME,
+    };
+    exerciseEntries = exerciseEntries.map((entry) => entry.id === id ? updated : entry);
+    return copy(updated);
+  },
+  delete: (id: number): { id: number } => {
+    exercise(id);
+    exerciseEntries = exerciseEntries.filter((entry) => entry.id !== id);
+    return { id };
+  },
+};
 
 export const collectionMock = {
   recent: (limit: number): CollectionInfo[] => copy(collectionEntries.slice(0, limit)),

--- a/features/lifelog/model.ts
+++ b/features/lifelog/model.ts
@@ -1,12 +1,12 @@
 import type { LifelogSubId, PanelDataItem, PanelMenuItem } from "@/entities/nav";
 import { CRUD_ACTIONS, pad, uniqueOrderedCats, catMenuItems } from "@/entities/nav";
-import { MEDIA_DATA, EXERCISE_DATA } from "./data";
+import { MEDIA_DATA } from "./data";
 
 export * from "./forms";
 
-type SourceLifelogSubId = Exclude<LifelogSubId, "journal" | "collection">;
+type LegacySourceLifelogSubId = Extract<LifelogSubId, "media">;
 
-export const LIFELOG_LISTS: Record<SourceLifelogSubId, PanelDataItem[]> = {
+export const LIFELOG_LISTS: Record<LegacySourceLifelogSubId, PanelDataItem[]> = {
   media: MEDIA_DATA.map((m, i) => ({
     id: `lifelog-media-${pad(i + 1, 3)}`,
     label: m.title,
@@ -23,25 +23,8 @@ export const LIFELOG_LISTS: Record<SourceLifelogSubId, PanelDataItem[]> = {
     ],
     actions: CRUD_ACTIONS,
   })),
-  exercise: EXERCISE_DATA.map((e, i) => ({
-    id: `lifelog-exercise-${pad(i + 1, 3)}`,
-    label: `${e.cat} — ${e.date}`,
-    slotLabel: e.cat.slice(0, 2).toUpperCase(),
-    subtitle: `${e.dur}min | ${e.cal} kcal${e.dist !== null ? ` | ${e.dist}km` : ""}`,
-    category: e.cat,
-    detailTitle: "Exercise Detail",
-    detailDescription: `${e.cat} session on ${e.date}.`,
-    detailRows: [
-      `Category: ${e.cat}`,
-      `Duration: ${e.dur} min`,
-      `Calories Burned: ${e.cal} kcal`,
-      e.dist !== null ? `Distance: ${e.dist} km` : `No distance tracked`,
-    ],
-    actions: CRUD_ACTIONS,
-  })),
 };
 
-export const LIFELOG_CATEGORY_ITEMS: Record<SourceLifelogSubId, PanelMenuItem[]> = {
+export const LIFELOG_CATEGORY_ITEMS: Record<LegacySourceLifelogSubId, PanelMenuItem[]> = {
   media:      catMenuItems(uniqueOrderedCats(MEDIA_DATA)),
-  exercise:   catMenuItems(uniqueOrderedCats(EXERCISE_DATA)),
 };

--- a/features/lifelog/useExerciseQueries.test.tsx
+++ b/features/lifelog/useExerciseQueries.test.tsx
@@ -1,0 +1,69 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ExerciseInfo } from "@/shared/api/types";
+import { useExerciseQueries } from "./useExerciseQueries";
+
+const api = vi.hoisted(() => ({
+  createExerciseApi: vi.fn(),
+  deleteExerciseApi: vi.fn(),
+  getExerciseApi: vi.fn(),
+  searchExercisesApi: vi.fn(),
+  updateExerciseApi: vi.fn(),
+}));
+
+vi.mock("./api", () => api);
+
+const first: ExerciseInfo = { id: 41, playerId: 7, category: "RUNNING", durationMinutes: 30, distanceKm: 5, calories: 250, exercisedOn: "2026-08-14", memo: "Morning run", createdAt: "2026-08-14T00:00:00Z", updatedAt: "2026-08-14T00:00:00Z" };
+const created = { ...first, id: 99, category: "YOGA" as const, memo: "Server detail" };
+const updated = { ...created, durationMinutes: 45, distanceKm: 5, memo: null };
+
+describe("Exercise query/mutation state를 관리할 때", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api.searchExercisesApi.mockResolvedValue([first]);
+    api.getExerciseApi.mockImplementation(async (id: number) => id === created.id ? created : first);
+    api.createExerciseApi.mockResolvedValue({ id: created.id });
+    api.updateExerciseApi.mockResolvedValue(updated);
+    api.deleteExerciseApi.mockResolvedValue({ id: created.id });
+  });
+
+  it("search는 page를 reset하고 filters/page를 reload마다 보존한다", async () => {
+    const { result } = renderHook(() => useExerciseQueries());
+    await waitFor(() => expect(api.searchExercisesApi).toHaveBeenCalledWith({ page: 0, size: 20 }));
+
+    act(() => result.current.changePage(3));
+    await waitFor(() => expect(api.searchExercisesApi).toHaveBeenLastCalledWith({ page: 3, size: 20 }));
+    act(() => result.current.search("RUNNING", "2026-08-01", "2026-08-14"));
+    await waitFor(() => expect(api.searchExercisesApi).toHaveBeenLastCalledWith({ category: "RUNNING", from: "2026-08-01", to: "2026-08-14", page: 0, size: 20 }));
+    act(() => result.current.changePage(2));
+    await waitFor(() => expect(api.searchExercisesApi).toHaveBeenLastCalledWith({ category: "RUNNING", from: "2026-08-01", to: "2026-08-14", page: 2, size: 20 }));
+    await act(async () => { await result.current.list.reload(); });
+    expect(api.searchExercisesApi).toHaveBeenLastCalledWith({ category: "RUNNING", from: "2026-08-01", to: "2026-08-14", page: 2, size: 20 });
+  });
+
+  it("create reload 후 returned ID를 fetch/select하고 update reload, delete clear를 수행한다", async () => {
+    const { result } = renderHook(() => useExerciseQueries());
+    await waitFor(() => expect(result.current.list.items).toEqual([first]));
+    act(() => result.current.search("RUNNING", "2026-08-01", "2026-08-14"));
+    await waitFor(() => expect(api.searchExercisesApi).toHaveBeenCalledTimes(2));
+    act(() => result.current.changePage(2));
+    await waitFor(() => expect(api.searchExercisesApi).toHaveBeenCalledTimes(3));
+
+    await act(async () => { await result.current.create({ category: "YOGA", durationMinutes: 45, exercisedOn: "2026-08-14" }); });
+    await waitFor(() => expect(result.current.detail.data).toEqual(created));
+    expect(api.getExerciseApi).toHaveBeenCalledWith(created.id);
+
+    await act(async () => { await result.current.update(created.id, { durationMinutes: 45, memo: "" }); });
+    expect(result.current.detail.data).toEqual(updated);
+
+    await act(async () => { await result.current.remove(created.id); });
+    expect(result.current.selectedId).toBeNull();
+    expect(result.current.detail.data).toBeNull();
+    expect(api.searchExercisesApi.mock.calls.slice(3)).toEqual([
+      [{ category: "RUNNING", from: "2026-08-01", to: "2026-08-14", page: 2, size: 20 }],
+      [{ category: "RUNNING", from: "2026-08-01", to: "2026-08-14", page: 2, size: 20 }],
+      [{ category: "RUNNING", from: "2026-08-01", to: "2026-08-14", page: 2, size: 20 }],
+    ]);
+  });
+});

--- a/features/lifelog/useExerciseQueries.ts
+++ b/features/lifelog/useExerciseQueries.ts
@@ -1,0 +1,169 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import type {
+  ExerciseCategory,
+  ExerciseCreateRequest,
+  ExerciseInfo,
+  ExerciseSearchParams,
+  ExerciseUpdateRequest,
+} from "@/shared/api/types";
+import {
+  createExerciseApi,
+  deleteExerciseApi,
+  getExerciseApi,
+  searchExercisesApi,
+  updateExerciseApi,
+} from "./api";
+
+const INITIAL_PARAMS: ExerciseSearchParams = { page: 0, size: 20 };
+
+function message(caught: unknown, fallback: string): string {
+  return caught instanceof Error ? caught.message : fallback;
+}
+
+export function useExerciseQueries() {
+  const [params, setParams] = useState<ExerciseSearchParams>(INITIAL_PARAMS);
+  const paramsRef = useRef(INITIAL_PARAMS);
+  const [items, setItems] = useState<ExerciseInfo[]>([]);
+  const [listLoading, setListLoading] = useState(false);
+  const [listError, setListError] = useState<string | null>(null);
+  const [selectedId, setSelectedId] = useState<number | null>(null);
+  const selectedIdRef = useRef<number | null>(null);
+  const [detail, setDetail] = useState<ExerciseInfo | null>(null);
+  const [detailLoading, setDetailLoading] = useState(false);
+  const [detailError, setDetailError] = useState<string | null>(null);
+  const listRequestId = useRef(0);
+  const detailRequestId = useRef(0);
+  const mutationLocked = useRef(false);
+  const [pendingMutation, setPendingMutation] = useState<string | null>(null);
+  const [mutationError, setMutationError] = useState<string | null>(null);
+
+  const clearSelection = useCallback(() => {
+    selectedIdRef.current = null;
+    detailRequestId.current += 1;
+    setSelectedId(null);
+    setDetail(null);
+    setDetailLoading(false);
+    setDetailError(null);
+  }, []);
+
+  const reload = useCallback(async () => {
+    const requestId = ++listRequestId.current;
+    setListLoading(true);
+    setListError(null);
+    try {
+      const next = await searchExercisesApi(paramsRef.current);
+      if (requestId !== listRequestId.current) return undefined;
+      setItems(next);
+      return next;
+    } catch (caught) {
+      if (requestId === listRequestId.current) setListError(message(caught, "Unable to load Exercises."));
+      return undefined;
+    } finally {
+      if (requestId === listRequestId.current) setListLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { void reload(); }, [params, reload]);
+
+  const loadDetail = useCallback(async (id: number) => {
+    const requestId = ++detailRequestId.current;
+    setDetailLoading(true);
+    setDetailError(null);
+    try {
+      const next = await getExerciseApi(id);
+      if (requestId === detailRequestId.current) setDetail(next);
+      return next;
+    } catch (caught) {
+      if (requestId === detailRequestId.current) setDetailError(message(caught, "Unable to load Exercise."));
+      return undefined;
+    } finally {
+      if (requestId === detailRequestId.current) setDetailLoading(false);
+    }
+  }, []);
+
+  const select = useCallback((id: number) => {
+    selectedIdRef.current = id;
+    setSelectedId(id);
+    setDetail(null);
+    void loadDetail(id);
+  }, [loadDetail]);
+
+  const search = (category?: ExerciseCategory, from?: string, to?: string) => {
+    listRequestId.current += 1;
+    paramsRef.current = { page: 0, size: paramsRef.current.size, category, from: from || undefined, to: to || undefined };
+    setParams(paramsRef.current);
+  };
+
+  const changePage = (page: number) => {
+    listRequestId.current += 1;
+    paramsRef.current = { ...paramsRef.current, page: Math.max(0, page) };
+    setParams(paramsRef.current);
+  };
+
+  const mutate = async <T,>(
+    key: string,
+    request: () => Promise<T>,
+    onResponse?: (result: T) => void,
+    onReload?: (result: T) => void,
+  ): Promise<boolean> => {
+    if (mutationLocked.current) return false;
+    mutationLocked.current = true;
+    setPendingMutation(key);
+    setMutationError(null);
+    try {
+      const result = await request();
+      onResponse?.(result);
+      if (await reload()) onReload?.(result);
+      else setMutationError("Exercise changed, but the authoritative list could not be reloaded.");
+      return true;
+    } catch (caught) {
+      await reload();
+      setMutationError(`Request outcome was not confirmed. Server state was reloaded. ${message(caught, "")}`.trim());
+      return false;
+    } finally {
+      mutationLocked.current = false;
+      setPendingMutation(null);
+    }
+  };
+
+  const create = (body: ExerciseCreateRequest) => mutate(
+    "create",
+    () => createExerciseApi(body),
+    undefined,
+    ({ id }) => select(id),
+  );
+
+  const update = (id: number, body: ExerciseUpdateRequest) => mutate(
+    `update-${id}`,
+    () => updateExerciseApi(id, body),
+    (updated) => {
+      if (selectedIdRef.current === id) setDetail(updated);
+    },
+  );
+
+  const remove = (id: number) => mutate(
+    `delete-${id}`,
+    () => deleteExerciseApi(id),
+    ({ id: deletedId }) => {
+      if (selectedIdRef.current === deletedId) clearSelection();
+    },
+  );
+
+  return {
+    params,
+    list: { items, loading: listLoading, error: listError, reload },
+    detail: { data: detail, loading: detailLoading, error: detailError, retry: () => selectedIdRef.current === null ? Promise.resolve(undefined) : loadDetail(selectedIdRef.current) },
+    selectedId,
+    select,
+    search,
+    changePage,
+    pendingMutation,
+    mutationError,
+    create,
+    update,
+    remove,
+  };
+}

--- a/lib/api/endpoints/lifelog.api.ts
+++ b/lib/api/endpoints/lifelog.api.ts
@@ -1,41 +1,6 @@
-import { USE_MOCK, apiDelete, apiGet, apiPost } from "../client";
-import {
-  MOCK_EXERCISES,
-  MOCK_MEDIA_LOGS,
-} from "../mock/lifelog.mock";
-import type { ExerciseInfo, MediaLogInfo } from "../types";
-
-export async function getExercisesApi(): Promise<ExerciseInfo[]> {
-  if (USE_MOCK) return MOCK_EXERCISES;
-  const res = await apiGet<{ items: ExerciseInfo[] }>("/api/v1/lifelogs/me/exercises");
-  return res.items;
-}
-
-export async function createExerciseApi(data: {
-  category: string;
-  durationMinutes: number | null;
-  distanceKm: number | null;
-  calories: number | null;
-  exercisedOn: string;
-  memo: string | null;
-}): Promise<ExerciseInfo> {
-  if (USE_MOCK) {
-    const newEntry: ExerciseInfo = {
-      id: Date.now(),
-      playerId: 6,
-      ...data,
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    };
-    return newEntry;
-  }
-  return apiPost<ExerciseInfo>("/api/v1/lifelogs/me/exercises", data);
-}
-
-export async function deleteExerciseApi(id: number): Promise<void> {
-  if (USE_MOCK) return;
-  await apiDelete(`/api/v1/lifelogs/me/exercises/${id}`);
-}
+import { USE_MOCK, apiGet, apiPost } from "../client";
+import { MOCK_MEDIA_LOGS } from "../mock/lifelog.mock";
+import type { MediaLogInfo } from "../types";
 
 export async function getMediaLogsApi(): Promise<MediaLogInfo[]> {
   if (USE_MOCK) return MOCK_MEDIA_LOGS;

--- a/lib/api/mock/lifelog.mock.ts
+++ b/lib/api/mock/lifelog.mock.ts
@@ -1,19 +1,4 @@
-import type { ExerciseInfo, MediaLogInfo } from "../types";
-
-export const MOCK_EXERCISES: ExerciseInfo[] = [
-  { id: 1, playerId: 6, category: "Running", durationMinutes: 32, distanceKm: 5.2, calories: 310, exercisedOn: "2026-03-02", memo: "Morning park run. PB for 5km!", createdAt: "2026-03-02T07:30:00Z", updatedAt: "2026-03-02T07:30:00Z" },
-  { id: 2, playerId: 6, category: "Cycling", durationMinutes: 75, distanceKm: 28.4, calories: 620, exercisedOn: "2026-03-01", memo: "Weekend road ride around Han River.", createdAt: "2026-03-01T09:00:00Z", updatedAt: "2026-03-01T09:00:00Z" },
-  { id: 3, playerId: 6, category: "Strength Training", durationMinutes: 55, distanceKm: null, calories: 380, exercisedOn: "2026-02-28", memo: "Upper body — bench, rows, curls.", createdAt: "2026-02-28T18:30:00Z", updatedAt: "2026-02-28T18:30:00Z" },
-  { id: 4, playerId: 6, category: "Swimming", durationMinutes: 40, distanceKm: 1.5, calories: 420, exercisedOn: "2026-02-26", memo: "Lap swimming at the university pool.", createdAt: "2026-02-26T19:00:00Z", updatedAt: "2026-02-26T19:00:00Z" },
-  { id: 5, playerId: 6, category: "Running", durationMinutes: 28, distanceKm: 4.8, calories: 285, exercisedOn: "2026-02-25", memo: "Evening run in the neighborhood.", createdAt: "2026-02-25T19:30:00Z", updatedAt: "2026-02-25T19:30:00Z" },
-  { id: 6, playerId: 6, category: "Yoga", durationMinutes: 45, distanceKm: null, calories: 120, exercisedOn: "2026-02-24", memo: "Morning yoga routine. 10 poses.", createdAt: "2026-02-24T07:00:00Z", updatedAt: "2026-02-24T07:00:00Z" },
-  { id: 7, playerId: 6, category: "Hiking", durationMinutes: 180, distanceKm: 12.0, calories: 850, exercisedOn: "2026-02-22", memo: "Bukhansan National Park trail.", createdAt: "2026-02-22T08:00:00Z", updatedAt: "2026-02-22T08:00:00Z" },
-  { id: 8, playerId: 6, category: "Strength Training", durationMinutes: 60, distanceKm: null, calories: 420, exercisedOn: "2026-02-21", memo: "Leg day. Squat PR: 120kg!", createdAt: "2026-02-21T17:00:00Z", updatedAt: "2026-02-21T17:00:00Z" },
-  { id: 9, playerId: 6, category: "Running", durationMinutes: 35, distanceKm: 6.0, calories: 360, exercisedOn: "2026-02-19", memo: "Interval training — fast/slow splits.", createdAt: "2026-02-19T07:15:00Z", updatedAt: "2026-02-19T07:15:00Z" },
-  { id: 10, playerId: 6, category: "Cycling", durationMinutes: 90, distanceKm: 35.2, calories: 750, exercisedOn: "2026-02-16", memo: "Long ride to Suwon and back.", createdAt: "2026-02-16T09:30:00Z", updatedAt: "2026-02-16T09:30:00Z" },
-  { id: 11, playerId: 6, category: "Jump Rope", durationMinutes: 20, distanceKm: null, calories: 200, exercisedOn: "2026-02-15", memo: "Double-unders, 1000 reps.", createdAt: "2026-02-15T08:00:00Z", updatedAt: "2026-02-15T08:00:00Z" },
-  { id: 12, playerId: 6, category: "Swimming", durationMinutes: 50, distanceKm: 2.0, calories: 530, exercisedOn: "2026-02-12", memo: "Butterfly and freestyle sets.", createdAt: "2026-02-12T18:30:00Z", updatedAt: "2026-02-12T18:30:00Z" },
-];
+import type { MediaLogInfo } from "../types";
 
 export const MOCK_MEDIA_LOGS: MediaLogInfo[] = [
   { id: 1, playerId: 6, category: "Anime", title: "Sword Art Online", originalTitle: "ソードアート・オンライン", currentEpisode: 25, totalEpisode: 25, status: "COMPLETED", rating: 9.5, tags: ["VR", "RPG", "Action"], rewatchCount: 3, startedOn: "2023-01-10", finishedOn: "2023-01-25", createdAt: "2023-01-10T20:00:00Z", updatedAt: "2023-01-25T22:00:00Z" },

--- a/shared/api/types/lifelog.ts
+++ b/shared/api/types/lifelog.ts
@@ -1,8 +1,11 @@
+export const EXERCISE_CATEGORIES = ["RUNNING", "WALKING", "CYCLING", "SWIMMING", "GYM", "YOGA", "OTHER"] as const;
+export type ExerciseCategory = typeof EXERCISE_CATEGORIES[number];
+
 export interface ExerciseInfo {
   id: number;
   playerId: number;
-  category: string;
-  durationMinutes: number | null;
+  category: ExerciseCategory;
+  durationMinutes: number;
   distanceKm: number | null;
   calories: number | null;
   exercisedOn: string;
@@ -10,6 +13,34 @@ export interface ExerciseInfo {
   createdAt: string;
   updatedAt: string;
 }
+
+export type ExerciseSearchParams = {
+  category?: ExerciseCategory;
+  from?: string;
+  to?: string;
+  page: number;
+  size: number;
+};
+
+export type ExerciseCreateRequest = {
+  category: ExerciseCategory;
+  durationMinutes: number;
+  distanceKm?: number;
+  calories?: number;
+  exercisedOn: string;
+  memo?: string;
+};
+
+export type ExerciseUpdateRequest = {
+  category?: ExerciseCategory | null;
+  durationMinutes?: number | null;
+  distanceKm?: number | null;
+  calories?: number | null;
+  exercisedOn?: string | null;
+  memo?: string | null;
+};
+export type ExerciseCreated = { id: number };
+export type ExerciseDeleted = { id: number };
 
 export interface MediaLogInfo {
   id: number;
@@ -146,7 +177,7 @@ export interface JournalListParams {
 
 export type QuickRecordType = JournalSourceType;
 export type QuickRecordCollectionCategory = CollectionCategory;
-export type QuickRecordExerciseCategory = "RUNNING" | "WALKING" | "CYCLING" | "SWIMMING" | "GYM" | "YOGA" | "OTHER";
+export type QuickRecordExerciseCategory = ExerciseCategory;
 export type QuickRecordMediaCategory = "ANIME" | "MOVIE" | "SERIES" | "BOOK" | "WEBTOON" | "GAME" | "MUSIC";
 export type QuickRecordMediaStatus = "PLANNED" | "WATCHING" | "COMPLETED" | "DROPPED" | "ON_HOLD";
 


### PR DESCRIPTION
### Purpose

Replace the legacy/static Exercise surface with the backend's real Current Player Exercise CRUD contract.

Closes #22

### Delivered

- real Exercise recent/search/get/create/update/delete integration
- canonical backend Exercise categories
- category and date-range search
- real source detail/create/update/delete states
- authoritative reload after mutations
- Backend #270 partial-update semantics
- backend-compatible raw/enveloped response handling
- mock parity for Exercise CRUD
- stale Exercise form/data/API cleanup

### Backend Contract

Connected:

```text
GET    /api/v1/players/exercises/recent
GET    /api/v1/players/exercises/search
GET    /api/v1/players/exercises/{exerciseId}
POST   /api/v1/players/exercises
POST   /api/v1/players/exercises/{exerciseId}
DELETE /api/v1/players/exercises/{exerciseId}
```

### Categories

Canonical values:

- RUNNING
- WALKING
- CYCLING
- SWIMMING
- GYM
- YOGA
- OTHER

Legacy frontend-only categories and `intensity` semantics are removed from the real flow.

### Partial Update

Backend #270 semantics are preserved:

```text
non-null supplied -> apply
null / omitted    -> preserve
blank memo        -> clear
```

The UI does not pretend nullable numeric metrics can be explicitly cleared when the backend does not expose that operation.

### Authority / Identity

- Current Player remains auth-owned
- no caller player/user IDs
- Exercise `id` remains source identity
- Exercise `id` is never treated as `lifeLogId`
- Journal state is not optimistically fabricated
- mutation success reloads authoritative Exercise state

### Search

Backend search returns a raw array.

The UI keeps real category/date/page state without inventing total counts or page totals.

### Structural Integrity

Touched Exercise/LifeLog boundaries were checked for:

- stale DTO/form drift
- invalid categories
- unsupported fields
- fake pagination
- source/LifeLog identity confusion
- duplicate source authority
- unsupported numeric-clear behavior

Only direct/local-safe findings were changed.

### Validation

Focused coverage includes:

- exact transport and raw/envelope contracts
- canonical categories and fields
- partial update semantics
- filter/page preservation
- create returned-ID selection
- authoritative reload after mutations
- selected delete clearing
- mock parity
- final lint/tests/build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a dedicated Exercise experience with search, filters, pagination, details, and forms.
  - Users can create, edit, and delete exercise records with confirmation and validation.
  - Added supported exercise categories and exercise activity tracking.

- **Bug Fixes**
  - Improved exercise form handling, including optional fields and reliable updates.
  - Preserved selections and refreshed results after exercise changes.

- **Tests**
  - Added coverage for exercise search, filtering, forms, updates, deletion, and navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->