### PR TITLE
[Growth] Connect canonical Current Player Achievement surface

### DIFF
--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -35,6 +35,7 @@ vi.mock("@/widgets/right-panels/RightPanels", () => ({
 vi.mock("@/features/lifelog/JournalShell", () => ({ default: ({ roles: roleOptions }: { roles: RoleDetail[] }) => <div data-testid="journal-shell">Journal · {roleOptions.map(({ name }) => name).join(", ")}</div> }));
 vi.mock("@/features/lifelog/CollectionShell", () => ({ default: () => <div data-testid="collection-shell">Collection Shell</div> }));
 vi.mock("@/features/lifelog/ExerciseShell", () => ({ default: () => <div data-testid="exercise-shell">Exercise Shell</div> }));
+vi.mock("@/features/player/AchievementShell", () => ({ default: () => <div data-testid="achievement-shell">Achievement Shell</div> }));
 vi.mock("@/features/inventory/InventoryShell", () => ({ default: ({ surface }: { surface: string }) => <div data-testid="inventory-shell">Inventory · {surface}</div> }));
 vi.mock("@/features/inventory/GearShell", () => ({ default: () => <div data-testid="gear-shell">Gear Shell</div> }));
 vi.mock("@/features/home/HomeShell", () => ({
@@ -113,7 +114,7 @@ describe("Home shell에서 feature surface를 routing할 때", () => {
       const achievement = render(<Home />);
       fireEvent.click(screen.getByRole("button", { name: "Home Achievement" }));
       expect(screen.getByRole("button", { name: "Achievement" })).toBeInTheDocument();
-      expect(screen.getByRole("button", { name: "Combat" })).toBeInTheDocument();
+      expect(screen.getByTestId("achievement-shell")).toBeInTheDocument();
       achievement.unmount();
 
       render(<Home />);

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -19,6 +19,7 @@ import ExerciseShell from "@/features/lifelog/ExerciseShell";
 import InventoryShell from "@/features/inventory/InventoryShell";
 import GearShell from "@/features/inventory/GearShell";
 import HomeShell from "@/features/home/HomeShell";
+import AchievementShell from "@/features/player/AchievementShell";
 import { useRoles } from "@/features/role/useRoles";
 import { usePanScroll } from "@/shared/hooks/usePanScroll";
 import { MOCK_CHARACTER_SHEET } from "@/features/player/mock";
@@ -152,6 +153,7 @@ function buildPanels(
 
   if (selectedMain === "player") {
     const sub = selectedMainSub as PlayerSubId;
+    if (sub === "achievement") return { panelStack, socialContext: null };
     const subLabel = mainItems.find((item) => item.id === sub)?.label ?? "Player";
     const categoryItems = PLAYER_CATEGORY_ITEMS[sub] ?? [];
     const selectedCategory = selectedPlayerCategoryBySub[sub] ?? null;
@@ -1216,6 +1218,16 @@ export default function Home() {
               }}
               onOpenRole={handleRoleSelect}
             />
+          ) : selectedMain === "player" && selectedSubByMain.player === "achievement" ? (
+            <div className="flex w-fit items-center gap-3">
+              <RightPanels
+                selectedMain="player"
+                panelStack={panelStack.slice(0, 1)}
+                panelStackKey="player-achievement-menu"
+                onPanelItemSelect={handlePanelItemSelect}
+              />
+              <AchievementShell />
+            </div>
           ) : selectedMain === "role" ? (
             <div className="flex w-fit items-center gap-3">
               <RoleShell

--- a/features/player/AchievementShell.test.tsx
+++ b/features/player/AchievementShell.test.tsx
@@ -1,0 +1,43 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { PlayerAchievementInfo } from "@/shared/api/types";
+import AchievementShell from "./AchievementShell";
+
+const api = vi.hoisted(() => ({ getPlayerAchievementApi: vi.fn(), getPlayerAchievementsApi: vi.fn() }));
+
+vi.mock("./api", () => api);
+vi.mock("@/shared/ui/PanelCard", () => ({
+  default: ({ label, subtitle, onClick }: { label: string; subtitle: string; onClick: () => void }) => <button type="button" data-testid="achievement-entry" onClick={onClick}>{label} · {subtitle}</button>,
+}));
+
+const listItem: PlayerAchievementInfo = { achievementId: 31, code: "LIST_CODE", name: "List name", category: "Growth", descMd: "List description", acquiredAt: "2026-08-13T00:00:00Z" };
+const detail: PlayerAchievementInfo = { achievementId: 31, code: "SERVER_CODE", name: "Server detail name", category: "Milestone", descMd: "**Server-owned** description", acquiredAt: "2026-08-14T00:00:00Z" };
+
+describe("Current Player Achievement surface를 사용할 때", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api.getPlayerAchievementsApi.mockResolvedValue([listItem]);
+    api.getPlayerAchievementApi.mockResolvedValue(detail);
+  });
+
+  it("acquired list/detail fields와 empty state만 렌더하고 fabricated rows는 만들지 않는다", async () => {
+    const view = render(<AchievementShell />);
+    const entry = await screen.findByTestId("achievement-entry");
+    expect(entry).toHaveTextContent("List name · Growth · 2026-08-13T00:00:00Z");
+    fireEvent.click(entry);
+
+    expect(await screen.findByText("Server detail name")).toBeInTheDocument();
+    expect(screen.getByText("Code: SERVER_CODE")).toBeInTheDocument();
+    expect(screen.getByText("Category: Milestone")).toBeInTheDocument();
+    expect(screen.getByText("Acquired: 2026-08-14T00:00:00Z")).toBeInTheDocument();
+    expect(screen.getByText("**Server-owned** description")).toBeInTheDocument();
+    expect(api.getPlayerAchievementApi).toHaveBeenCalledWith(31);
+    expect(screen.queryByText(/Status: Unlocked|source quest|reward|rarity|progress/i)).not.toBeInTheDocument();
+    view.unmount();
+
+    api.getPlayerAchievementsApi.mockResolvedValueOnce([]);
+    render(<AchievementShell />);
+    expect(await screen.findByText("No acquired Achievements.")).toBeInTheDocument();
+  });
+});

--- a/features/player/AchievementShell.tsx
+++ b/features/player/AchievementShell.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { SAO } from "@/shared/design/tokens";
+import PanelCard from "@/shared/ui/PanelCard";
+import { PanelFrame } from "@/widgets/right-panels/ui/PanelFrame";
+import { GoldRow, InfoCard } from "@/widgets/right-panels/ui/Rows";
+import { useAchievementQueries } from "./useAchievementQueries";
+
+const buttonStyle = {
+  border: `1px solid ${SAO.color.border.panel}`,
+  background: SAO.color.bg.inset,
+  color: SAO.color.text.secondary,
+  borderRadius: SAO.radius.panel,
+  padding: "7px 10px",
+  fontSize: "0.68rem",
+  letterSpacing: "0.08em",
+} as const;
+
+function ErrorState({ message, retry }: { message: string; retry: () => void }) {
+  return (
+    <div className="space-y-2 px-3">
+      <p role="alert" className="text-xs" style={{ color: SAO.color.action.red }}>{message}</p>
+      <button type="button" style={buttonStyle} onClick={retry}>Retry</button>
+    </div>
+  );
+}
+
+export default function AchievementShell() {
+  const achievements = useAchievementQueries();
+  const detail = achievements.detail.data;
+
+  return (
+    <div className="relative flex min-w-0 w-fit flex-row flex-nowrap items-center gap-3" data-testid="achievement-shell">
+      <PanelFrame title="Acquired Achievements" depth={1}>
+        <div className="space-y-3">
+          {achievements.list.loading && achievements.list.items.length === 0 ? <InfoCard>Loading Achievements...</InfoCard> : null}
+          {achievements.list.error ? <ErrorState message={achievements.list.error} retry={() => void achievements.list.reload()} /> : null}
+          {!achievements.list.loading && !achievements.list.error && achievements.list.items.length === 0 ? <InfoCard>No acquired Achievements.</InfoCard> : null}
+          <div className="space-y-2">
+            {achievements.list.items.map((item, index) => (
+              <PanelCard
+                key={item.achievementId}
+                label={item.name}
+                slotLabel={item.code.slice(0, 2)}
+                subtitle={`${item.category} · ${item.acquiredAt}`}
+                selected={achievements.selectedId === item.achievementId}
+                index={index}
+                onClick={() => achievements.select(item.achievementId)}
+              />
+            ))}
+          </div>
+        </div>
+      </PanelFrame>
+
+      <PanelFrame title="Achievement Detail" depth={0}>
+        {!achievements.selectedId ? <InfoCard>Select an acquired Achievement.</InfoCard> : null}
+        {achievements.detail.loading && !detail ? <InfoCard>Loading Achievement...</InfoCard> : null}
+        {achievements.detail.error ? <ErrorState message={achievements.detail.error} retry={() => void achievements.detail.retry()} /> : null}
+        {detail ? (
+          <div className="space-y-3 px-3">
+            <InfoCard>{detail.name}</InfoCard>
+            <GoldRow>Code: {detail.code}</GoldRow>
+            <GoldRow>Category: {detail.category}</GoldRow>
+            <GoldRow>Acquired: {detail.acquiredAt}</GoldRow>
+            <InfoCard label="Description"><span style={{ whiteSpace: "pre-wrap" }}>{detail.descMd}</span></InfoCard>
+          </div>
+        ) : null}
+      </PanelFrame>
+    </div>
+  );
+}

--- a/features/player/api.test.ts
+++ b/features/player/api.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { PlayerAchievementInfo } from "@/shared/api/types";
+import { getPlayerAchievementApi, getPlayerAchievementsApi } from "./api";
+import { achievementMock } from "./mock";
+
+const client = vi.hoisted(() => ({ apiGet: vi.fn(), apiPost: vi.fn() }));
+
+vi.mock("@/shared/api/client", () => ({ USE_MOCK: false, ...client }));
+
+const achievement: PlayerAchievementInfo = {
+  achievementId: 31,
+  code: "FIRST_STEP",
+  name: "First Step",
+  category: "GROWTH",
+  descMd: "Completed the first step.",
+  acquiredAt: "2026-08-14T00:00:00Z",
+};
+
+describe("Current Player Achievement API를 사용할 때", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("envelope-aware client로 exact list/detail paths만 호출하고 list infos를 반환한다", async () => {
+    client.apiGet.mockResolvedValueOnce({ infos: [achievement] }).mockResolvedValueOnce(achievement);
+
+    const list = await getPlayerAchievementsApi();
+    const detail = await getPlayerAchievementApi(31);
+
+    expect(client.apiGet).toHaveBeenNthCalledWith(1, "/api/v1/players/achievements");
+    expect(client.apiGet).toHaveBeenNthCalledWith(2, "/api/v1/players/achievements/31");
+    expect(client.apiGet.mock.calls.flat().join(" ")).not.toMatch(/playerId|userId|catalog|\/players\/me\/achievements/);
+    expect(list).toEqual([achievement]);
+    expect(detail).toEqual(achievement);
+  });
+
+  it("mock acquired authority는 exact fields, stable order, unknown-ID not-found를 유지한다", () => {
+    const list = achievementMock.list();
+    const first = list[0];
+
+    expect(Object.keys(first)).toEqual(["achievementId", "code", "name", "category", "descMd", "acquiredAt"]);
+    expect(achievementMock.detail(first.achievementId)).toEqual(first);
+    expect(achievementMock.list().map(({ achievementId }) => achievementId)).toEqual(list.map(({ achievementId }) => achievementId));
+    expect(() => achievementMock.detail(999_999)).toThrow("Acquired Achievement not found.");
+  });
+});

--- a/features/player/api.ts
+++ b/features/player/api.ts
@@ -1,4 +1,6 @@
-import { USE_MOCK, apiPost } from "@/shared/api/client";
+import { USE_MOCK, apiGet, apiPost } from "@/shared/api/client";
+import type { PlayerAchievementInfo } from "@/shared/api/types";
+import { achievementMock } from "./mock";
 
 export type RegisterPlayerRequest = { name: string; gender: string };
 export type CreatedPlayerWithToken = {
@@ -13,4 +15,16 @@ export async function registerPlayerApi(body: RegisterPlayerRequest): Promise<Cr
     return { id, accessToken: `mock-player-access-${id}`, refreshToken: `mock-player-refresh-${id}` };
   }
   return apiPost<CreatedPlayerWithToken>("/api/v1/players/register", body);
+}
+
+export async function getPlayerAchievementsApi(): Promise<PlayerAchievementInfo[]> {
+  if (USE_MOCK) return achievementMock.list();
+  const result = await apiGet<{ infos: PlayerAchievementInfo[] }>("/api/v1/players/achievements");
+  return result.infos;
+}
+
+export function getPlayerAchievementApi(achievementId: number): Promise<PlayerAchievementInfo> {
+  return USE_MOCK
+    ? Promise.resolve().then(() => achievementMock.detail(achievementId))
+    : apiGet<PlayerAchievementInfo>(`/api/v1/players/achievements/${achievementId}`);
 }

--- a/features/player/data.ts
+++ b/features/player/data.ts
@@ -1,24 +1,3 @@
-export const ACHIEVEMENT_DATA = [
-  { code: "FIRST_BLOOD",   name: "First Blood",           cat: "Combat",      desc: "Defeated your first monster." },
-  { code: "FLOOR_BOSS",    name: "Floor Boss Slayer",      cat: "Combat",      desc: "Defeated a floor boss." },
-  { code: "SOLO_RUN",      name: "Solo Runner",            cat: "Exploration", desc: "Cleared a dungeon entirely solo." },
-  { code: "SPEED_RUN",     name: "Speedrunner",            cat: "Completion",  desc: "Cleared a floor in record time." },
-  { code: "BLACKSMITH_1",  name: "Blacksmith Apprentice",  cat: "Crafting",    desc: "Crafted your first item." },
-  { code: "DUAL_WIELD",    name: "Dual Wield Mastery",     cat: "Combat",      desc: "Unlocked the Dual Wield skill." },
-  { code: "PERFECT_GUARD", name: "Perfect Guard",          cat: "Defense",     desc: "Blocked 100 attacks with perfect timing." },
-  { code: "MONSTER_HUNT",  name: "Monster Hunter",         cat: "Combat",      desc: "Defeated 1000 monsters." },
-  { code: "TREASURE_HUNT", name: "Treasure Hunter",        cat: "Exploration", desc: "Found 50 hidden treasure rooms." },
-  { code: "BEATER",        name: "The Beater",             cat: "Special",     desc: "Recognized as a beta tester." },
-  { code: "GUILD_FOUND",   name: "Guild Founder",          cat: "Social",      desc: "Founded your first guild." },
-  { code: "MKT_MASTER",    name: "Market Master",          cat: "Economy",     desc: "Completed 100 market trades." },
-  { code: "LVL_50",        name: "Level 50 Milestone",     cat: "Growth",      desc: "Reached character level 50." },
-  { code: "ENCHANT",       name: "Enchantment Master",     cat: "Crafting",    desc: "Enchanted 50 items successfully." },
-  { code: "NIGHT_RUN",     name: "Night Runner",           cat: "Exploration", desc: "Explored 10 dungeons at night." },
-  { code: "PARTY_LEAD",    name: "Party Leader",           cat: "Social",      desc: "Led a party to a boss clear." },
-  { code: "RARE_ITEM",     name: "Rare Collector",         cat: "Collection",  desc: "Obtained 20 rare+ items." },
-  { code: "LEGEND_KILL",   name: "Legend Slayer",          cat: "Combat",      desc: "Defeated a legendary-tier monster." },
-];
-
 export const CERTIFICATION_DATA = [
   { name: "AWS Solutions Architect",    issuer: "Amazon Web Services",       cat: "Cloud",       expires: "2028-06-15" },
   { name: "Python Professional",        issuer: "Python Institute",           cat: "Programming", expires: null },

--- a/features/player/mock.ts
+++ b/features/player/mock.ts
@@ -114,6 +114,19 @@ export const MOCK_ACHIEVEMENTS: PlayerAchievementInfo[] = [
   { achievementId: 18, code: "LEGENDARY_KILL", name: "Legend Slayer", category: "Combat", descMd: "Defeated a legendary-tier monster.", acquiredAt: "2026-03-01T21:00:00Z" },
 ];
 
+function copy<T>(value: T): T {
+  return structuredClone(value);
+}
+
+export const achievementMock = {
+  list: (): PlayerAchievementInfo[] => copy(MOCK_ACHIEVEMENTS),
+  detail: (achievementId: number): PlayerAchievementInfo => {
+    const found = MOCK_ACHIEVEMENTS.find((achievement) => achievement.achievementId === achievementId);
+    if (!found) throw new Error("Acquired Achievement not found.");
+    return copy(found);
+  },
+};
+
 export const MOCK_CERTIFICATIONS: PlayerCertificationInfo[] = [
   { certificationId: 1, name: "AWS Solutions Architect", issuer: "Amazon Web Services", category: "Cloud", acquiredDate: "2025-06-15", expiresDate: "2028-06-15", grantedAt: "2025-06-15T09:00:00Z" },
   { certificationId: 2, name: "Python Professional", issuer: "Python Institute", category: "Programming", acquiredDate: "2025-03-20", expiresDate: null, grantedAt: "2025-03-20T10:00:00Z" },

--- a/features/player/model.ts
+++ b/features/player/model.ts
@@ -1,25 +1,12 @@
 import type { PlayerSubId, PanelDataItem, PanelMenuItem } from "@/entities/nav";
 import { CRUD_ACTIONS, pad, dateAt, uniqueOrderedCats, catMenuItems } from "@/entities/nav";
-import { ACHIEVEMENT_DATA, CERTIFICATION_DATA, TITLE_DATA, HOBBY_DATA } from "./data";
+import { CERTIFICATION_DATA, TITLE_DATA, HOBBY_DATA } from "./data";
 
 export * from "./forms";
 
-export const PLAYER_LISTS: Record<PlayerSubId, PanelDataItem[]> = {
-  achievement: ACHIEVEMENT_DATA.map((a, i) => ({
-    id: `achievement-${pad(i + 1, 3)}`,
-    label: a.name,
-    slotLabel: a.code.slice(0, 2),
-    subtitle: `${a.cat} | Acquired: ${dateAt(i)}`,
-    category: a.cat,
-    detailTitle: "Achievement Detail",
-    detailDescription: a.desc,
-    detailRows: [
-      `Code: ${a.code}`,
-      `Category: ${a.cat}`,
-      `Acquired: ${dateAt(i)}`,
-      `Status: Unlocked`,
-    ],
-  })),
+type LegacyPlayerSubId = Exclude<PlayerSubId, "achievement">;
+
+export const PLAYER_LISTS: Record<LegacyPlayerSubId, PanelDataItem[]> = {
   credentials: CERTIFICATION_DATA.map((c, i) => ({
     id: `credential-${pad(i + 1, 3)}`,
     label: c.name,
@@ -69,8 +56,7 @@ export const PLAYER_LISTS: Record<PlayerSubId, PanelDataItem[]> = {
   })),
 };
 
-export const PLAYER_CATEGORY_ITEMS: Record<PlayerSubId, PanelMenuItem[]> = {
-  achievement: catMenuItems(uniqueOrderedCats(ACHIEVEMENT_DATA)),
+export const PLAYER_CATEGORY_ITEMS: Record<LegacyPlayerSubId, PanelMenuItem[]> = {
   credentials: catMenuItems(uniqueOrderedCats(CERTIFICATION_DATA)),
   title:       catMenuItems(uniqueOrderedCats(TITLE_DATA)),
   interests:   catMenuItems(uniqueOrderedCats(HOBBY_DATA)),

--- a/features/player/useAchievementQueries.test.tsx
+++ b/features/player/useAchievementQueries.test.tsx
@@ -1,0 +1,43 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { PlayerAchievementInfo } from "@/shared/api/types";
+import { useAchievementQueries } from "./useAchievementQueries";
+
+const api = vi.hoisted(() => ({ getPlayerAchievementApi: vi.fn(), getPlayerAchievementsApi: vi.fn() }));
+
+vi.mock("./api", () => api);
+
+const first: PlayerAchievementInfo = { achievementId: 1, code: "FIRST", name: "First", category: "Growth", descMd: "First detail", acquiredAt: "2026-08-13T00:00:00Z" };
+const second: PlayerAchievementInfo = { achievementId: 2, code: "SECOND", name: "Second", category: "Growth", descMd: "Second detail", acquiredAt: "2026-08-14T00:00:00Z" };
+
+describe("Achievement list/detail state를 관리할 때", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api.getPlayerAchievementsApi.mockResolvedValue([first, second]);
+  });
+
+  it("initial list, selected detail, stale response protection, selected retry를 한 흐름으로 유지한다", async () => {
+    const pending = new Map<number, { resolve: (value: PlayerAchievementInfo) => void; reject: (error: Error) => void }>();
+    api.getPlayerAchievementApi.mockImplementation((id: number) => new Promise<PlayerAchievementInfo>((resolve, reject) => pending.set(id, { resolve, reject })));
+    const { result } = renderHook(() => useAchievementQueries());
+    await waitFor(() => expect(result.current.list.items).toEqual([first, second]));
+
+    act(() => result.current.select(first.achievementId));
+    act(() => result.current.select(second.achievementId));
+    await act(async () => pending.get(second.achievementId)!.resolve(second));
+    expect(result.current.detail.data).toEqual(second);
+    await act(async () => pending.get(first.achievementId)!.resolve(first));
+    expect(result.current.detail.data).toEqual(second);
+
+    act(() => result.current.select(second.achievementId));
+    await act(async () => pending.get(second.achievementId)!.reject(new Error("detail failed")));
+    await waitFor(() => expect(result.current.detail.error).toBe("detail failed"));
+    api.getPlayerAchievementApi.mockResolvedValueOnce(second);
+    await act(async () => { await result.current.detail.retry(); });
+
+    expect(api.getPlayerAchievementApi).toHaveBeenLastCalledWith(second.achievementId);
+    expect(result.current.detail.data).toEqual(second);
+    expect(result.current.detail.error).toBeNull();
+  });
+});

--- a/features/player/useAchievementQueries.ts
+++ b/features/player/useAchievementQueries.ts
@@ -1,0 +1,74 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import type { PlayerAchievementInfo } from "@/shared/api/types";
+import { getPlayerAchievementApi, getPlayerAchievementsApi } from "./api";
+
+function message(caught: unknown, fallback: string): string {
+  return caught instanceof Error ? caught.message : fallback;
+}
+
+export function useAchievementQueries() {
+  const [items, setItems] = useState<PlayerAchievementInfo[]>([]);
+  const [listLoading, setListLoading] = useState(false);
+  const [listError, setListError] = useState<string | null>(null);
+  const [selectedId, setSelectedId] = useState<number | null>(null);
+  const selectedIdRef = useRef<number | null>(null);
+  const [detail, setDetail] = useState<PlayerAchievementInfo | null>(null);
+  const [detailLoading, setDetailLoading] = useState(false);
+  const [detailError, setDetailError] = useState<string | null>(null);
+  const detailRequestId = useRef(0);
+
+  const reload = useCallback(async () => {
+    setListLoading(true);
+    setListError(null);
+    try {
+      const next = await getPlayerAchievementsApi();
+      setItems(next);
+      return next;
+    } catch (caught) {
+      setListError(message(caught, "Unable to load acquired Achievements."));
+      return undefined;
+    } finally {
+      setListLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { void reload(); }, [reload]);
+
+  const loadDetail = useCallback(async (achievementId: number) => {
+    const requestId = ++detailRequestId.current;
+    setDetailLoading(true);
+    setDetailError(null);
+    try {
+      const next = await getPlayerAchievementApi(achievementId);
+      if (requestId === detailRequestId.current) setDetail(next);
+      return next;
+    } catch (caught) {
+      if (requestId === detailRequestId.current) setDetailError(message(caught, "Unable to load acquired Achievement."));
+      return undefined;
+    } finally {
+      if (requestId === detailRequestId.current) setDetailLoading(false);
+    }
+  }, []);
+
+  const select = useCallback((achievementId: number) => {
+    selectedIdRef.current = achievementId;
+    setSelectedId(achievementId);
+    setDetail(null);
+    void loadDetail(achievementId);
+  }, [loadDetail]);
+
+  return {
+    list: { items, loading: listLoading, error: listError, reload },
+    detail: {
+      data: detail,
+      loading: detailLoading,
+      error: detailError,
+      retry: () => selectedIdRef.current === null ? Promise.resolve(undefined) : loadDetail(selectedIdRef.current),
+    },
+    selectedId,
+    select,
+  };
+}

--- a/lib/api/endpoints/player.api.ts
+++ b/lib/api/endpoints/player.api.ts
@@ -1,6 +1,5 @@
 import { USE_MOCK, apiGet, apiPut } from "../client";
 import {
-  MOCK_ACHIEVEMENTS,
   MOCK_CHARACTER_SHEET,
   MOCK_CERTIFICATIONS,
   MOCK_HOBBIES,
@@ -8,7 +7,6 @@ import {
 } from "../mock/player.mock";
 import type {
   CharacterSheet,
-  PlayerAchievementInfo,
   PlayerCertificationInfo,
   PlayerHobbyInfo,
   PlayerTitleInfo,
@@ -17,12 +15,6 @@ import type {
 export async function getCharacterSheetApi(): Promise<CharacterSheet> {
   if (USE_MOCK) return MOCK_CHARACTER_SHEET;
   return apiGet<CharacterSheet>("/api/v1/players/me/sheet");
-}
-
-export async function getAchievementsApi(): Promise<PlayerAchievementInfo[]> {
-  if (USE_MOCK) return MOCK_ACHIEVEMENTS;
-  const res = await apiGet<{ infos: PlayerAchievementInfo[] }>("/api/v1/players/me/achievements");
-  return res.infos;
 }
 
 export async function getCertificationsApi(): Promise<PlayerCertificationInfo[]> {


### PR DESCRIPTION
### Purpose

Replace the static/fabricated player Achievement surface with the canonical Current Player acquired-Achievement list and detail contracts.

Closes #24

### Delivered

- real acquired Achievement list
- real acquired Achievement detail
- Current Player ownership-aware UI state
- real loading/error/empty states
- stale detail response protection
- feature-owned Achievement query state
- backend-parity mock authority
- static/fabricated Achievement player surface cleanup

### Backend Contract

Connected:

```text
GET /api/v1/players/achievements
GET /api/v1/players/achievements/{achievementId}
```

Canonical fields:

```text
achievementId
code
name
category
descMd
acquiredAt
```

### Ownership

The surface represents Achievements actually acquired by the authenticated Current Player.

It does not fall back to global catalog data.

No caller player/user identity is sent.

### Removed Drift

The player Achievement flow no longer depends on:

- fabricated acquisition dates
- fake Unlocked status
- stale `/api/v1/players/me/achievements`
- static player-facing Achievement authority
- locally fabricated detail

### Architecture

Achievement server state is owned by the player feature shell/hook.

`app/page.tsx` only routes the surface.

### Scope

No:

- Achievement mutation
- provenance invention
- progress/rarity invention
- Media CRUD
- Certification/Hobby/Title refactor

### Validation

Focused coverage verifies:

- exact list/detail transport
- ownership-aware detail loading
- stale response protection
- empty/error states
- player Achievement routing
- final lint/tests/build