### PR TITLE
[Character] Connect real Current Player Certification management surface

### DIFF
--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -36,6 +36,7 @@ vi.mock("@/features/lifelog/JournalShell", () => ({ default: ({ roles: roleOptio
 vi.mock("@/features/lifelog/CollectionShell", () => ({ default: () => <div data-testid="collection-shell">Collection Shell</div> }));
 vi.mock("@/features/lifelog/ExerciseShell", () => ({ default: () => <div data-testid="exercise-shell">Exercise Shell</div> }));
 vi.mock("@/features/player/AchievementShell", () => ({ default: () => <div data-testid="achievement-shell">Achievement Shell</div> }));
+vi.mock("@/features/player/CertificationShell", () => ({ default: () => <div data-testid="certification-shell">Certification Shell</div> }));
 vi.mock("@/features/inventory/InventoryShell", () => ({ default: ({ surface }: { surface: string }) => <div data-testid="inventory-shell">Inventory · {surface}</div> }));
 vi.mock("@/features/inventory/GearShell", () => ({ default: () => <div data-testid="gear-shell">Gear Shell</div> }));
 vi.mock("@/features/home/HomeShell", () => ({
@@ -151,6 +152,18 @@ describe("Home shell에서 feature surface를 routing할 때", () => {
       expect(screen.getByTestId("role-shell")).toBeInTheDocument();
       fireEvent.click(screen.getByRole("button", { name: "Journey" }));
       expect(screen.getByTestId("journey-shell")).toBeInTheDocument();
+    });
+  });
+
+  describe("인증된 player가 Credentials를 선택하면", () => {
+    it("generic static panels 대신 feature-owned CertificationShell로 routing한다", () => {
+      render(<Home />);
+
+      fireEvent.click(screen.getByRole("button", { name: "Player" }));
+      fireEvent.click(screen.getByRole("button", { name: "Credentials" }));
+
+      expect(screen.getByTestId("certification-shell")).toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: "Cloud" })).not.toBeInTheDocument();
     });
   });
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -20,6 +20,7 @@ import InventoryShell from "@/features/inventory/InventoryShell";
 import GearShell from "@/features/inventory/GearShell";
 import HomeShell from "@/features/home/HomeShell";
 import AchievementShell from "@/features/player/AchievementShell";
+import CertificationShell from "@/features/player/CertificationShell";
 import { useRoles } from "@/features/role/useRoles";
 import { usePanScroll } from "@/shared/hooks/usePanScroll";
 import { MOCK_CHARACTER_SHEET } from "@/features/player/mock";
@@ -42,7 +43,6 @@ import type {
   SocialContextData,
 } from "@/entities/nav";
 import {
-  CERTIFICATION_FORM_FIELDS,
   HOBBY_FORM_FIELDS,
   PLAYER_CATEGORY_ITEMS,
   PLAYER_LISTS,
@@ -153,7 +153,7 @@ function buildPanels(
 
   if (selectedMain === "player") {
     const sub = selectedMainSub as PlayerSubId;
-    if (sub === "achievement") return { panelStack, socialContext: null };
+    if (sub === "achievement" || sub === "credentials") return { panelStack, socialContext: null };
     const subLabel = mainItems.find((item) => item.id === sub)?.label ?? "Player";
     const categoryItems = PLAYER_CATEGORY_ITEMS[sub] ?? [];
     const selectedCategory = selectedPlayerCategoryBySub[sub] ?? null;
@@ -1009,7 +1009,7 @@ export default function Home() {
   // Called when any field in a form panel changes — syncs category panel selection
   const handlePanelFormFieldChange = (formKey: string, fieldKey: string, value: string) => {
     if (fieldKey !== "category") return;
-    if (formKey.startsWith("credential") || formKey.startsWith("hobby")) {
+    if (formKey.startsWith("hobby")) {
       const sub = selectedSubByMain.player as PlayerSubId;
       setSelectedPlayerCategoryBySub((prev) => ({ ...prev, [sub]: value || null }));
     } else if (formKey.startsWith("media")) {
@@ -1032,9 +1032,7 @@ export default function Home() {
       setSelectedPlayerCategoryBySub((prev) => ({ ...prev, [sub]: itemId }));
       updateDetailSelections({ player: null });
       setEditingItemId(null);
-      if (sub === "credentials") {
-        openForm("credential-create", "Add Credential", CERTIFICATION_FORM_FIELDS, "추가하기", { category: itemId });
-      } else if (sub === "interests") {
+      if (sub === "interests") {
         openForm("hobby-create", "Add Interest", HOBBY_FORM_FIELDS, "추가하기", { category: itemId });
       }
       return;
@@ -1056,11 +1054,7 @@ export default function Home() {
     if (selectedMain === "player") {
       updateDetailSelections({ player: itemId });
       setEditingItemId(itemId);
-      if (sub === "credentials") {
-        const item = PLAYER_LISTS.credentials.find((i) => i.id === itemId);
-        openForm("credential-edit", "Edit Credential", CERTIFICATION_FORM_FIELDS, "수정하기",
-          item ? { name: item.label, issuer: item.subtitle?.split(" | ")[0] ?? "", category: item.category ?? "", acquiredDate: item.detailRows[2]?.split(": ")[1] ?? "" } : undefined);
-      } else if (sub === "interests") {
+      if (sub === "interests") {
         const item = PLAYER_LISTS.interests.find((i) => i.id === itemId);
         openForm("hobby-edit", "Edit Interest", HOBBY_FORM_FIELDS, "수정하기",
           item ? { customName: item.label, category: item.category ?? "", proficiency: item.detailRows[2]?.split(": ")[1]?.replace("/100", "") ?? "", status: item.detailRows[1]?.split(": ")[1] ?? "" } : undefined);
@@ -1227,6 +1221,16 @@ export default function Home() {
                 onPanelItemSelect={handlePanelItemSelect}
               />
               <AchievementShell />
+            </div>
+          ) : selectedMain === "player" && selectedSubByMain.player === "credentials" ? (
+            <div className="flex w-fit items-center gap-3">
+              <RightPanels
+                selectedMain="player"
+                panelStack={panelStack.slice(0, 1)}
+                panelStackKey="player-certification-menu"
+                onPanelItemSelect={handlePanelItemSelect}
+              />
+              <CertificationShell />
             </div>
           ) : selectedMain === "role" ? (
             <div className="flex w-fit items-center gap-3">

--- a/features/player/CertificationShell.test.tsx
+++ b/features/player/CertificationShell.test.tsx
@@ -1,0 +1,58 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { CertificationCatalogInfo, PlayerCertificationInfo } from "@/shared/api/types";
+import CertificationShell from "./CertificationShell";
+
+const api = vi.hoisted(() => ({
+  deletePlayerCertificationApi: vi.fn(),
+  getCertificationCatalogApi: vi.fn(),
+  getPlayerCertificationsApi: vi.fn(),
+  registerPlayerCertificationApi: vi.fn(),
+  updatePlayerCertificationApi: vi.fn(),
+}));
+
+vi.mock("./api", () => api);
+vi.mock("@/shared/ui/PanelCard", () => ({
+  default: ({ label, subtitle, onClick }: { label: string; subtitle: string; onClick: () => void }) => <button type="button" data-testid="certification-entry" onClick={onClick}>{label} · {subtitle}</button>,
+}));
+
+const catalog: CertificationCatalogInfo[] = [
+  { certificationId: 1, name: "AWS", issuer: "Amazon", category: "Cloud" },
+  { certificationId: 3, name: "Kubernetes", issuer: "CNCF", category: "DevOps" },
+];
+const owned: PlayerCertificationInfo = { ...catalog[0], acquiredDate: null, expiresDate: null, grantedAt: "2026-08-01T00:00:00Z" };
+const reloaded = { ...owned, expiresDate: "2027-08-01" };
+
+describe("Certification management surface를 사용할 때", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api.getCertificationCatalogApi.mockResolvedValue(catalog);
+    api.getPlayerCertificationsApi.mockResolvedValueOnce([owned]).mockResolvedValue([reloaded]);
+    api.registerPlayerCertificationApi.mockResolvedValue({ certificationId: 3, acquiredDate: null, expiresDate: null });
+    api.updatePlayerCertificationApi.mockResolvedValue({ certificationId: 1, acquiredDate: null, expiresDate: "2027-08-01" });
+    api.deletePlayerCertificationApi.mockResolvedValue(1);
+  });
+
+  it("nullable owned dates, catalog-only selector와 blank-preserving edit controls만 렌더한다", async () => {
+    render(<CertificationShell />);
+    const entry = await screen.findByTestId("certification-entry");
+    expect(entry).toHaveTextContent("Acquired: Not recorded");
+    const selector = screen.getByLabelText("Certification") as HTMLSelectElement;
+    expect(Array.from(selector.options, ({ text }) => text)).toEqual(["Select...", "Kubernetes · CNCF"]);
+    expect(screen.queryByText("React Developer Certification")).not.toBeInTheDocument();
+
+    fireEvent.click(entry);
+    expect(screen.getByText("Acquired: Not recorded", { selector: "span" })).toBeInTheDocument();
+    expect(screen.getByText("Expires: Not recorded")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Update Dates" }));
+    expect(api.updatePlayerCertificationApi).not.toHaveBeenCalled();
+    fireEvent.change(screen.getByLabelText("New expires date"), { target: { value: "2027-08-01" } });
+    fireEvent.click(screen.getByRole("button", { name: "Update Dates" }));
+
+    await waitFor(() => expect(api.updatePlayerCertificationApi).toHaveBeenCalledWith(1, { expiresDate: "2027-08-01" }));
+    expect(api.updatePlayerCertificationApi.mock.calls[0][1]).not.toHaveProperty("acquiredDate");
+    expect(api.updatePlayerCertificationApi.mock.calls[0][1]).not.toEqual(expect.objectContaining({ expiresDate: "" }));
+    expect(screen.getByText("Blank dates preserve current values; dates cannot be cleared.")).toBeInTheDocument();
+  });
+});

--- a/features/player/CertificationShell.tsx
+++ b/features/player/CertificationShell.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { useState } from "react";
+
+import type { PlayerCertificationDatesRequest } from "@/shared/api/types";
+import { INPUT_STYLE, SAO } from "@/shared/design/tokens";
+import PanelCard from "@/shared/ui/PanelCard";
+import { PanelFrame } from "@/widgets/right-panels/ui/PanelFrame";
+import { GoldRow, InfoCard } from "@/widgets/right-panels/ui/Rows";
+import { useCertificationQueries } from "./useCertificationQueries";
+
+const buttonStyle = {
+  border: `1px solid ${SAO.color.border.panel}`,
+  background: SAO.color.bg.inset,
+  color: SAO.color.text.secondary,
+  borderRadius: SAO.radius.panel,
+  padding: "7px 10px",
+  fontSize: "0.68rem",
+  letterSpacing: "0.08em",
+} as const;
+
+function optionalDate(form: FormData, key: string): string | undefined {
+  return String(form.get(key) ?? "").trim() || undefined;
+}
+
+function dates(form: FormData): PlayerCertificationDatesRequest {
+  const acquiredDate = optionalDate(form, "acquiredDate");
+  const expiresDate = optionalDate(form, "expiresDate");
+  return {
+    ...(acquiredDate ? { acquiredDate } : {}),
+    ...(expiresDate ? { expiresDate } : {}),
+  };
+}
+
+function ErrorState({ message, retry }: { message: string; retry: () => void }) {
+  return (
+    <div className="space-y-2 px-3">
+      <p role="alert" className="text-xs" style={{ color: SAO.color.action.red }}>{message}</p>
+      <button type="button" style={buttonStyle} onClick={retry}>Retry</button>
+    </div>
+  );
+}
+
+export default function CertificationShell() {
+  const certifications = useCertificationQueries();
+  const [catalogId, setCatalogId] = useState("");
+  const pending = certifications.pendingMutation !== null;
+  const available = certifications.catalog.items.filter((item) => !certifications.owned.items.some((owned) => owned.certificationId === item.certificationId));
+  const selected = certifications.selected;
+
+  return (
+    <div className="relative flex min-w-0 w-fit flex-row flex-nowrap items-center gap-3" data-testid="certification-shell">
+      <PanelFrame title="Certification Catalog" depth={2}>
+        <div className="space-y-3 px-3">
+          {certifications.catalog.loading && certifications.catalog.items.length === 0 ? <InfoCard>Loading Certification catalog...</InfoCard> : null}
+          {certifications.catalog.error ? <ErrorState message={certifications.catalog.error} retry={() => void certifications.catalog.retry()} /> : null}
+          {!certifications.catalog.loading && !certifications.catalog.error ? (
+            <form className="space-y-2" onSubmit={async (event) => {
+              event.preventDefault();
+              const element = event.currentTarget;
+              const saved = await certifications.register(Number(catalogId), dates(new FormData(element)));
+              if (saved) {
+                element.reset();
+                setCatalogId("");
+              }
+            }}>
+              <label className="block text-xs" style={{ color: SAO.color.text.label }}>
+                Certification
+                <select aria-label="Certification" value={catalogId} onChange={(event) => setCatalogId(event.target.value)} required disabled={pending} style={INPUT_STYLE}>
+                  <option value="">Select...</option>
+                  {available.map((item) => <option key={item.certificationId} value={item.certificationId}>{item.name} · {item.issuer}</option>)}
+                </select>
+              </label>
+              <label className="block text-xs" style={{ color: SAO.color.text.label }}>Acquired date<input name="acquiredDate" type="date" disabled={pending} style={INPUT_STYLE} /></label>
+              <label className="block text-xs" style={{ color: SAO.color.text.label }}>Expires date<input name="expiresDate" type="date" disabled={pending} style={INPUT_STYLE} /></label>
+              <button type="submit" disabled={pending || available.length === 0} style={buttonStyle}>{pending ? "Working..." : "Register Certification"}</button>
+            </form>
+          ) : null}
+        </div>
+      </PanelFrame>
+
+      <PanelFrame title="My Certifications" depth={1}>
+        <div className="space-y-3">
+          {certifications.owned.loading && certifications.owned.items.length === 0 ? <InfoCard>Loading Certifications...</InfoCard> : null}
+          {certifications.owned.error ? <ErrorState message={certifications.owned.error} retry={() => void certifications.owned.reload()} /> : null}
+          {!certifications.owned.loading && !certifications.owned.error && certifications.owned.items.length === 0 ? <InfoCard>No owned Certifications.</InfoCard> : null}
+          {certifications.mutationError ? <p role="alert" className="px-3 text-xs" style={{ color: SAO.color.action.red }}>{certifications.mutationError}</p> : null}
+          <div className="space-y-2">
+            {certifications.owned.items.map((item, index) => (
+              <PanelCard key={item.certificationId} label={item.name} slotLabel={item.category.slice(0, 2).toUpperCase()} subtitle={`${item.issuer} · Acquired: ${item.acquiredDate ?? "Not recorded"}`} selected={certifications.selectedId === item.certificationId} index={index} onClick={() => certifications.select(item.certificationId)} />
+            ))}
+          </div>
+        </div>
+      </PanelFrame>
+
+      <PanelFrame title="Certification Detail" depth={0}>
+        {!selected ? <InfoCard>Select an owned Certification.</InfoCard> : (
+          <div className="space-y-3 px-3">
+            <InfoCard>{selected.name}</InfoCard>
+            <GoldRow>Issuer: {selected.issuer}</GoldRow>
+            <GoldRow>Category: {selected.category}</GoldRow>
+            <GoldRow>Acquired: {selected.acquiredDate ?? "Not recorded"}</GoldRow>
+            <GoldRow>Expires: {selected.expiresDate ?? "Not recorded"}</GoldRow>
+            <GoldRow>Granted: {selected.grantedAt}</GoldRow>
+            <form className="space-y-2" onSubmit={(event) => {
+              event.preventDefault();
+              const body = dates(new FormData(event.currentTarget));
+              if (Object.keys(body).length > 0) void certifications.update(selected.certificationId, body);
+            }}>
+              <label className="block text-xs" style={{ color: SAO.color.text.label }}>New acquired date<input name="acquiredDate" type="date" disabled={pending} style={INPUT_STYLE} /></label>
+              <label className="block text-xs" style={{ color: SAO.color.text.label }}>New expires date<input name="expiresDate" type="date" disabled={pending} style={INPUT_STYLE} /></label>
+              <p className="text-xs" style={{ color: SAO.color.text.label }}>Blank dates preserve current values; dates cannot be cleared.</p>
+              <div className="flex gap-2">
+                <button type="submit" disabled={pending} style={{ ...buttonStyle, flex: 1 }}>{pending ? "Working..." : "Update Dates"}</button>
+                <button type="button" disabled={pending} style={buttonStyle} onClick={() => {
+                  if (window.confirm(`Delete ${selected.name}?`)) void certifications.remove(selected.certificationId);
+                }}>Delete</button>
+              </div>
+            </form>
+          </div>
+        )}
+      </PanelFrame>
+    </div>
+  );
+}

--- a/features/player/api.test.ts
+++ b/features/player/api.test.ts
@@ -1,10 +1,18 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { PlayerAchievementInfo } from "@/shared/api/types";
-import { getPlayerAchievementApi, getPlayerAchievementsApi } from "./api";
-import { achievementMock } from "./mock";
+import type { PlayerAchievementInfo, PlayerCertificationInfo } from "@/shared/api/types";
+import {
+  deletePlayerCertificationApi,
+  getCertificationCatalogApi,
+  getPlayerAchievementApi,
+  getPlayerAchievementsApi,
+  getPlayerCertificationsApi,
+  registerPlayerCertificationApi,
+  updatePlayerCertificationApi,
+} from "./api";
+import { achievementMock, certificationMock, resetCertificationMock } from "./mock";
 
-const client = vi.hoisted(() => ({ apiGet: vi.fn(), apiPost: vi.fn() }));
+const client = vi.hoisted(() => ({ apiDelete: vi.fn(), apiGet: vi.fn(), apiPatch: vi.fn(), apiPost: vi.fn() }));
 
 vi.mock("@/shared/api/client", () => ({ USE_MOCK: false, ...client }));
 
@@ -41,5 +49,46 @@ describe("Current Player Achievement API를 사용할 때", () => {
     expect(achievementMock.detail(first.achievementId)).toEqual(first);
     expect(achievementMock.list().map(({ achievementId }) => achievementId)).toEqual(list.map(({ achievementId }) => achievementId));
     expect(() => achievementMock.detail(999_999)).toThrow("Acquired Achievement not found.");
+  });
+});
+
+describe("Current Player Certification API를 사용할 때", () => {
+  const owned: PlayerCertificationInfo = { certificationId: 3, name: "Kubernetes Administrator", issuer: "CNCF", category: "DevOps", acquiredDate: null, expiresDate: null, grantedAt: "2026-08-14T00:00:00Z" };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetCertificationMock();
+  });
+
+  it("envelope-aware helpers로 exact five operations와 bodies만 전송한다", async () => {
+    client.apiGet.mockResolvedValueOnce({ infos: [{ certificationId: 3, name: owned.name, issuer: owned.issuer, category: owned.category }] }).mockResolvedValueOnce({ infos: [owned] });
+    client.apiPost.mockResolvedValue({ certificationId: 3, acquiredDate: null, expiresDate: null });
+    client.apiPatch.mockResolvedValue({ certificationId: 3, acquiredDate: "2026-08-01", expiresDate: null });
+    client.apiDelete.mockResolvedValue(3);
+
+    await getCertificationCatalogApi();
+    await getPlayerCertificationsApi();
+    await registerPlayerCertificationApi(3, {});
+    await updatePlayerCertificationApi(3, { acquiredDate: "2026-08-01" });
+    await deletePlayerCertificationApi(3);
+
+    expect(client.apiGet).toHaveBeenNthCalledWith(1, "/api/v1/certifications");
+    expect(client.apiGet).toHaveBeenNthCalledWith(2, "/api/v1/players/certifications");
+    expect(client.apiPost).toHaveBeenCalledWith("/api/v1/players/certifications/3", {});
+    expect(client.apiPatch).toHaveBeenCalledWith("/api/v1/players/certifications/3", { acquiredDate: "2026-08-01" });
+    expect(client.apiDelete).toHaveBeenCalledWith("/api/v1/players/certifications/3");
+    expect(client.apiGet.mock.calls.flat().join(" ")).not.toMatch(/playerId|userId|\/players\/me\/certifications/);
+  });
+
+  it("mock는 catalog/owned를 분리하고 duplicate, preserve, date order, delete semantics를 지킨다", () => {
+    expect(certificationMock.catalog()).toHaveLength(4);
+    expect(certificationMock.owned()).toHaveLength(2);
+    expect(() => certificationMock.register(1, {})).toThrow("Certification already registered.");
+
+    certificationMock.register(3, { acquiredDate: "2026-08-01" });
+    expect(certificationMock.update(3, { expiresDate: null })).toEqual({ certificationId: 3, acquiredDate: "2026-08-01", expiresDate: null });
+    expect(() => certificationMock.update(3, { expiresDate: "2026-07-31" })).toThrow("Expiration date cannot be before acquired date.");
+    expect(certificationMock.delete(3)).toBe(3);
+    expect(certificationMock.owned().some(({ certificationId }) => certificationId === 3)).toBe(false);
   });
 });

--- a/features/player/api.ts
+++ b/features/player/api.ts
@@ -1,6 +1,12 @@
-import { USE_MOCK, apiGet, apiPost } from "@/shared/api/client";
-import type { PlayerAchievementInfo } from "@/shared/api/types";
-import { achievementMock } from "./mock";
+import { USE_MOCK, apiDelete, apiGet, apiPatch, apiPost } from "@/shared/api/client";
+import type {
+  CertificationCatalogInfo,
+  PlayerAchievementInfo,
+  PlayerCertificationDatesRequest,
+  PlayerCertificationInfo,
+  PlayerCertificationMutationResult,
+} from "@/shared/api/types";
+import { achievementMock, certificationMock } from "./mock";
 
 export type RegisterPlayerRequest = { name: string; gender: string };
 export type CreatedPlayerWithToken = {
@@ -27,4 +33,34 @@ export function getPlayerAchievementApi(achievementId: number): Promise<PlayerAc
   return USE_MOCK
     ? Promise.resolve().then(() => achievementMock.detail(achievementId))
     : apiGet<PlayerAchievementInfo>(`/api/v1/players/achievements/${achievementId}`);
+}
+
+export async function getCertificationCatalogApi(): Promise<CertificationCatalogInfo[]> {
+  if (USE_MOCK) return certificationMock.catalog();
+  const result = await apiGet<{ infos: CertificationCatalogInfo[] }>("/api/v1/certifications");
+  return result.infos;
+}
+
+export async function getPlayerCertificationsApi(): Promise<PlayerCertificationInfo[]> {
+  if (USE_MOCK) return certificationMock.owned();
+  const result = await apiGet<{ infos: PlayerCertificationInfo[] }>("/api/v1/players/certifications");
+  return result.infos;
+}
+
+export function registerPlayerCertificationApi(certificationId: number, body: PlayerCertificationDatesRequest): Promise<PlayerCertificationMutationResult> {
+  return USE_MOCK
+    ? Promise.resolve().then(() => certificationMock.register(certificationId, body))
+    : apiPost<PlayerCertificationMutationResult>(`/api/v1/players/certifications/${certificationId}`, body);
+}
+
+export function updatePlayerCertificationApi(certificationId: number, body: PlayerCertificationDatesRequest): Promise<PlayerCertificationMutationResult> {
+  return USE_MOCK
+    ? Promise.resolve().then(() => certificationMock.update(certificationId, body))
+    : apiPatch<PlayerCertificationMutationResult>(`/api/v1/players/certifications/${certificationId}`, body);
+}
+
+export function deletePlayerCertificationApi(certificationId: number): Promise<number> {
+  return USE_MOCK
+    ? Promise.resolve().then(() => certificationMock.delete(certificationId))
+    : apiDelete<number>(`/api/v1/players/certifications/${certificationId}`);
 }

--- a/features/player/data.ts
+++ b/features/player/data.ts
@@ -1,18 +1,3 @@
-export const CERTIFICATION_DATA = [
-  { name: "AWS Solutions Architect",    issuer: "Amazon Web Services",       cat: "Cloud",       expires: "2028-06-15" },
-  { name: "Python Professional",        issuer: "Python Institute",           cat: "Programming", expires: null },
-  { name: "Kubernetes Administrator",   issuer: "CNCF",                       cat: "DevOps",      expires: "2027-09-10" },
-  { name: "TOEIC 935",                  issuer: "ETS Korea",                  cat: "Language",    expires: "2026-11-02" },
-  { name: "Google Cloud Professional",  issuer: "Google",                     cat: "Cloud",       expires: "2027-12-01" },
-  { name: "React Developer Certification", issuer: "Meta",                    cat: "Frontend",    expires: null },
-  { name: "Computer Science B.S.",      issuer: "Seoul National University",  cat: "Academic",    expires: null },
-  { name: "SQLD Database Developer",    issuer: "Korea Data Agency",          cat: "Database",    expires: null },
-  { name: "Security+ Certified",        issuer: "CompTIA",                    cat: "Security",    expires: "2028-10-05" },
-  { name: "TypeScript Advanced",        issuer: "Microsoft",                  cat: "Programming", expires: null },
-  { name: "Docker Certified Associate", issuer: "Docker Inc.",                cat: "DevOps",      expires: "2027-05-28" },
-  { name: "JLPT N3 Japanese",           issuer: "Japan Foundation",           cat: "Language",    expires: null },
-];
-
 export const TITLE_DATA = [
   { code: "BLACK_SWORDSMAN", name: "Black Swordsman", cat: "Achievement", desc: "The legendary solo player." },
   { code: "BEATER",          name: "Beater",           cat: "Special",     desc: "A beta tester with prior knowledge." },

--- a/features/player/forms.ts
+++ b/features/player/forms.ts
@@ -1,23 +1,5 @@
 import type { FormFieldSpec } from "@/entities/nav";
 
-export const CERTIFICATION_FORM_FIELDS: FormFieldSpec[] = [
-  { key: "name",         label: "Name",          type: "text",   placeholder: "e.g. AWS Solutions Architect", required: true },
-  { key: "issuer",       label: "Issuer",         type: "text",   placeholder: "e.g. Amazon Web Services",    required: true },
-  { key: "category",     label: "Category",       type: "select", required: true, options: [
-    { value: "Cloud",       label: "Cloud" },
-    { value: "Programming", label: "Programming" },
-    { value: "DevOps",      label: "DevOps" },
-    { value: "Language",    label: "Language" },
-    { value: "Academic",    label: "Academic" },
-    { value: "Database",    label: "Database" },
-    { value: "Security",    label: "Security" },
-    { value: "Frontend",    label: "Frontend" },
-    { value: "Other",       label: "Other" },
-  ]},
-  { key: "acquiredDate", label: "Acquired Date", type: "date", required: true },
-  { key: "expiresDate",  label: "Expires Date",  type: "date" },
-];
-
 export const HOBBY_FORM_FIELDS: FormFieldSpec[] = [
   { key: "customName",  label: "Display Name", type: "text",   placeholder: "e.g. Full-Stack Dev", required: true },
   { key: "category",    label: "Category",     type: "select", required: true, options: [

--- a/features/player/mock.ts
+++ b/features/player/mock.ts
@@ -1,7 +1,10 @@
 import type {
   CharacterSheet,
+  CertificationCatalogInfo,
   PlayerAchievementInfo,
+  PlayerCertificationDatesRequest,
   PlayerCertificationInfo,
+  PlayerCertificationMutationResult,
   PlayerHobbyInfo,
   PlayerTitleInfo,
 } from "@/shared/api/types";
@@ -127,20 +130,57 @@ export const achievementMock = {
   },
 };
 
-export const MOCK_CERTIFICATIONS: PlayerCertificationInfo[] = [
-  { certificationId: 1, name: "AWS Solutions Architect", issuer: "Amazon Web Services", category: "Cloud", acquiredDate: "2025-06-15", expiresDate: "2028-06-15", grantedAt: "2025-06-15T09:00:00Z" },
-  { certificationId: 2, name: "Python Professional", issuer: "Python Institute", category: "Programming", acquiredDate: "2025-03-20", expiresDate: null, grantedAt: "2025-03-20T10:00:00Z" },
-  { certificationId: 3, name: "Kubernetes Administrator", issuer: "CNCF", category: "DevOps", acquiredDate: "2025-09-10", expiresDate: "2027-09-10", grantedAt: "2025-09-10T11:00:00Z" },
-  { certificationId: 4, name: "TOEIC 935", issuer: "ETS Korea", category: "Language", acquiredDate: "2024-11-02", expiresDate: "2026-11-02", grantedAt: "2024-11-02T08:00:00Z" },
-  { certificationId: 5, name: "Google Cloud Professional", issuer: "Google", category: "Cloud", acquiredDate: "2025-12-01", expiresDate: "2027-12-01", grantedAt: "2025-12-01T14:00:00Z" },
-  { certificationId: 6, name: "React Developer", issuer: "Meta", category: "Frontend", acquiredDate: "2025-04-15", expiresDate: null, grantedAt: "2025-04-15T10:00:00Z" },
-  { certificationId: 7, name: "Computer Science Bachelor", issuer: "Seoul National University", category: "Academic", acquiredDate: "2024-02-28", expiresDate: null, grantedAt: "2024-02-28T09:00:00Z" },
-  { certificationId: 8, name: "SQLD Database Developer", issuer: "Korea Data Agency", category: "Database", acquiredDate: "2025-07-20", expiresDate: null, grantedAt: "2025-07-20T10:00:00Z" },
-  { certificationId: 9, name: "Security+ Certified", issuer: "CompTIA", category: "Security", acquiredDate: "2025-10-05", expiresDate: "2028-10-05", grantedAt: "2025-10-05T09:00:00Z" },
-  { certificationId: 10, name: "TypeScript Advanced", issuer: "Microsoft", category: "Programming", acquiredDate: "2025-08-12", expiresDate: null, grantedAt: "2025-08-12T11:00:00Z" },
-  { certificationId: 11, name: "Docker Certified Associate", issuer: "Docker Inc.", category: "DevOps", acquiredDate: "2025-05-28", expiresDate: "2027-05-28", grantedAt: "2025-05-28T10:00:00Z" },
-  { certificationId: 12, name: "JLPT N3 Japanese", issuer: "Japan Foundation", category: "Language", acquiredDate: "2025-01-10", expiresDate: null, grantedAt: "2025-01-10T08:00:00Z" },
-];
+export const MOCK_CERTIFICATION_CATALOG = [
+  { certificationId: 1, name: "AWS Solutions Architect", issuer: "Amazon Web Services", category: "Cloud" },
+  { certificationId: 2, name: "Python Professional", issuer: "Python Institute", category: "Programming" },
+  { certificationId: 3, name: "Kubernetes Administrator", issuer: "CNCF", category: "DevOps" },
+  { certificationId: 4, name: "TOEIC 935", issuer: "ETS Korea", category: "Language" },
+] satisfies CertificationCatalogInfo[];
+
+export const MOCK_PLAYER_CERTIFICATIONS = [
+  { ...MOCK_CERTIFICATION_CATALOG[0], acquiredDate: "2025-06-15", expiresDate: "2028-06-15", grantedAt: "2025-06-15T09:00:00Z" },
+  { ...MOCK_CERTIFICATION_CATALOG[1], acquiredDate: null, expiresDate: null, grantedAt: "2025-03-20T10:00:00Z" },
+] satisfies PlayerCertificationInfo[];
+
+let playerCertifications: PlayerCertificationInfo[] = copy(MOCK_PLAYER_CERTIFICATIONS);
+
+function validateDates(acquiredDate: string | null, expiresDate: string | null): void {
+  if (acquiredDate && expiresDate && expiresDate < acquiredDate) throw new Error("Expiration date cannot be before acquired date.");
+}
+
+export function resetCertificationMock(): void {
+  playerCertifications = copy(MOCK_PLAYER_CERTIFICATIONS);
+}
+
+export const certificationMock = {
+  catalog: (): CertificationCatalogInfo[] => copy(MOCK_CERTIFICATION_CATALOG),
+  owned: (): PlayerCertificationInfo[] => copy(playerCertifications),
+  register: (certificationId: number, body: PlayerCertificationDatesRequest): PlayerCertificationMutationResult => {
+    if (playerCertifications.some((item) => item.certificationId === certificationId)) throw new Error("Certification already registered.");
+    const catalog = MOCK_CERTIFICATION_CATALOG.find((item) => item.certificationId === certificationId);
+    if (!catalog) throw new Error("Certification not found.");
+    const acquiredDate = body.acquiredDate ?? null;
+    const expiresDate = body.expiresDate ?? null;
+    validateDates(acquiredDate, expiresDate);
+    playerCertifications.push({ ...catalog, acquiredDate, expiresDate, grantedAt: "2026-08-14T00:00:00Z" });
+    return { certificationId, acquiredDate, expiresDate };
+  },
+  update: (certificationId: number, body: PlayerCertificationDatesRequest): PlayerCertificationMutationResult => {
+    const current = playerCertifications.find((item) => item.certificationId === certificationId);
+    if (!current) throw new Error("Player Certification not found.");
+    const acquiredDate = body.acquiredDate ?? current.acquiredDate;
+    const expiresDate = body.expiresDate ?? current.expiresDate;
+    validateDates(acquiredDate, expiresDate);
+    const updated = { ...current, acquiredDate, expiresDate };
+    playerCertifications = playerCertifications.map((item) => item.certificationId === certificationId ? updated : item);
+    return { certificationId, acquiredDate, expiresDate };
+  },
+  delete: (certificationId: number): number => {
+    if (!playerCertifications.some((item) => item.certificationId === certificationId)) throw new Error("Player Certification not found.");
+    playerCertifications = playerCertifications.filter((item) => item.certificationId !== certificationId);
+    return certificationId;
+  },
+};
 
 export const MOCK_TITLES: PlayerTitleInfo[] = [
   { titleId: 1, code: "BLACK_SWORDSMAN", name: "Black Swordsman", category: "Achievement", descMd: "The legendary solo player known for his black equipment.", acquiredAt: "2026-02-08T20:30:00Z" },

--- a/features/player/model.ts
+++ b/features/player/model.ts
@@ -1,28 +1,12 @@
 import type { PlayerSubId, PanelDataItem, PanelMenuItem } from "@/entities/nav";
 import { CRUD_ACTIONS, pad, dateAt, uniqueOrderedCats, catMenuItems } from "@/entities/nav";
-import { CERTIFICATION_DATA, TITLE_DATA, HOBBY_DATA } from "./data";
+import { TITLE_DATA, HOBBY_DATA } from "./data";
 
 export * from "./forms";
 
-type LegacyPlayerSubId = Exclude<PlayerSubId, "achievement">;
+type LegacyPlayerSubId = Exclude<PlayerSubId, "achievement" | "credentials">;
 
 export const PLAYER_LISTS: Record<LegacyPlayerSubId, PanelDataItem[]> = {
-  credentials: CERTIFICATION_DATA.map((c, i) => ({
-    id: `credential-${pad(i + 1, 3)}`,
-    label: c.name,
-    slotLabel: c.cat.slice(0, 2).toUpperCase(),
-    subtitle: `${c.issuer} | ${c.cat}`,
-    category: c.cat,
-    detailTitle: "Credential Detail",
-    detailDescription: `${c.name} issued by ${c.issuer}.`,
-    detailRows: [
-      `Issuer: ${c.issuer}`,
-      `Category: ${c.cat}`,
-      `Acquired: ${dateAt(i)}`,
-      c.expires ? `Expires: ${c.expires}` : `Expires: Never`,
-    ],
-    actions: CRUD_ACTIONS,
-  })),
   title: TITLE_DATA.map((t, i) => ({
     id: `title-${pad(i + 1, 3)}`,
     label: t.name,
@@ -57,7 +41,6 @@ export const PLAYER_LISTS: Record<LegacyPlayerSubId, PanelDataItem[]> = {
 };
 
 export const PLAYER_CATEGORY_ITEMS: Record<LegacyPlayerSubId, PanelMenuItem[]> = {
-  credentials: catMenuItems(uniqueOrderedCats(CERTIFICATION_DATA)),
   title:       catMenuItems(uniqueOrderedCats(TITLE_DATA)),
   interests:   catMenuItems(uniqueOrderedCats(HOBBY_DATA)),
 };

--- a/features/player/useCertificationQueries.test.tsx
+++ b/features/player/useCertificationQueries.test.tsx
@@ -1,0 +1,60 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { CertificationCatalogInfo, PlayerCertificationInfo } from "@/shared/api/types";
+import { useCertificationQueries } from "./useCertificationQueries";
+
+const api = vi.hoisted(() => ({
+  deletePlayerCertificationApi: vi.fn(),
+  getCertificationCatalogApi: vi.fn(),
+  getPlayerCertificationsApi: vi.fn(),
+  registerPlayerCertificationApi: vi.fn(),
+  updatePlayerCertificationApi: vi.fn(),
+}));
+
+vi.mock("./api", () => api);
+
+const catalog: CertificationCatalogInfo[] = [
+  { certificationId: 1, name: "AWS", issuer: "Amazon", category: "Cloud" },
+  { certificationId: 3, name: "Kubernetes", issuer: "CNCF", category: "DevOps" },
+];
+const first: PlayerCertificationInfo = { ...catalog[0], acquiredDate: null, expiresDate: null, grantedAt: "2026-08-01T00:00:00Z" };
+const registered: PlayerCertificationInfo = { ...catalog[1], acquiredDate: null, expiresDate: null, grantedAt: "2026-08-14T00:00:00Z" };
+const updated = { ...registered, acquiredDate: "2026-08-10" };
+
+describe("Certification query/mutation state를 관리할 때", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api.getCertificationCatalogApi.mockResolvedValue(catalog);
+    api.getPlayerCertificationsApi
+      .mockResolvedValueOnce([first])
+      .mockResolvedValueOnce([first, registered])
+      .mockResolvedValueOnce([first, updated])
+      .mockResolvedValueOnce([first]);
+    api.registerPlayerCertificationApi.mockResolvedValue({ certificationId: 3, acquiredDate: null, expiresDate: null });
+    api.updatePlayerCertificationApi.mockResolvedValue({ certificationId: 3, acquiredDate: "2026-08-10", expiresDate: null });
+    api.deletePlayerCertificationApi.mockResolvedValue(3);
+  });
+
+  it("initial load와 register/update/delete authoritative reload 및 blank no-op을 유지한다", async () => {
+    const { result } = renderHook(() => useCertificationQueries());
+    await waitFor(() => expect(result.current.catalog.items).toEqual(catalog));
+    await waitFor(() => expect(result.current.owned.items).toEqual([first]));
+
+    await act(async () => { await result.current.register(3, {}); });
+    expect(result.current.selectedId).toBe(3);
+    expect(result.current.selected).toEqual(registered);
+
+    await act(async () => { await result.current.update(3, {}); });
+    expect(api.updatePlayerCertificationApi).not.toHaveBeenCalled();
+    await act(async () => { await result.current.update(3, { acquiredDate: "2026-08-10" }); });
+    expect(api.updatePlayerCertificationApi).toHaveBeenCalledWith(3, { acquiredDate: "2026-08-10" });
+    expect(result.current.selectedId).toBe(3);
+    expect(result.current.selected).toEqual(updated);
+
+    await act(async () => { await result.current.remove(3); });
+    expect(result.current.selectedId).toBeNull();
+    expect(result.current.selected).toBeNull();
+    expect(api.getPlayerCertificationsApi).toHaveBeenCalledTimes(4);
+  });
+});

--- a/features/player/useCertificationQueries.ts
+++ b/features/player/useCertificationQueries.ts
@@ -1,0 +1,140 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import type {
+  CertificationCatalogInfo,
+  PlayerCertificationDatesRequest,
+  PlayerCertificationInfo,
+} from "@/shared/api/types";
+import {
+  deletePlayerCertificationApi,
+  getCertificationCatalogApi,
+  getPlayerCertificationsApi,
+  registerPlayerCertificationApi,
+  updatePlayerCertificationApi,
+} from "./api";
+
+function message(caught: unknown, fallback: string): string {
+  return caught instanceof Error ? caught.message : fallback;
+}
+
+export function useCertificationQueries() {
+  const [catalog, setCatalog] = useState<CertificationCatalogInfo[]>([]);
+  const [catalogLoading, setCatalogLoading] = useState(false);
+  const [catalogError, setCatalogError] = useState<string | null>(null);
+  const [owned, setOwned] = useState<PlayerCertificationInfo[]>([]);
+  const [ownedLoading, setOwnedLoading] = useState(false);
+  const [ownedError, setOwnedError] = useState<string | null>(null);
+  const [selectedId, setSelectedId] = useState<number | null>(null);
+  const selectedIdRef = useRef<number | null>(null);
+  const mutationLocked = useRef(false);
+  const [pendingMutation, setPendingMutation] = useState<string | null>(null);
+  const [mutationError, setMutationError] = useState<string | null>(null);
+
+  const loadCatalog = useCallback(async () => {
+    setCatalogLoading(true);
+    setCatalogError(null);
+    try {
+      const next = await getCertificationCatalogApi();
+      setCatalog(next);
+      return next;
+    } catch (caught) {
+      setCatalogError(message(caught, "Unable to load Certification catalog."));
+      return undefined;
+    } finally {
+      setCatalogLoading(false);
+    }
+  }, []);
+
+  const reloadOwned = useCallback(async () => {
+    setOwnedLoading(true);
+    setOwnedError(null);
+    try {
+      const next = await getPlayerCertificationsApi();
+      setOwned(next);
+      if (selectedIdRef.current !== null && !next.some((item) => item.certificationId === selectedIdRef.current)) {
+        selectedIdRef.current = null;
+        setSelectedId(null);
+      }
+      return next;
+    } catch (caught) {
+      setOwnedError(message(caught, "Unable to load owned Certifications."));
+      return undefined;
+    } finally {
+      setOwnedLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { void Promise.all([loadCatalog(), reloadOwned()]); }, [loadCatalog, reloadOwned]);
+
+  const select = (certificationId: number) => {
+    selectedIdRef.current = certificationId;
+    setSelectedId(certificationId);
+  };
+
+  const mutate = async <T,>(
+    key: string,
+    request: () => Promise<T>,
+    onResponse?: (result: T) => void,
+    onReload?: (result: T, next: PlayerCertificationInfo[]) => void,
+  ): Promise<boolean> => {
+    if (mutationLocked.current) return false;
+    mutationLocked.current = true;
+    setPendingMutation(key);
+    setMutationError(null);
+    try {
+      const result = await request();
+      onResponse?.(result);
+      const next = await reloadOwned();
+      if (next) onReload?.(result, next);
+      else setMutationError("Certification changed, but the authoritative owned list could not be reloaded.");
+      return true;
+    } catch (caught) {
+      await reloadOwned();
+      setMutationError(`Request outcome was not confirmed. Server state was reloaded. ${message(caught, "")}`.trim());
+      return false;
+    } finally {
+      mutationLocked.current = false;
+      setPendingMutation(null);
+    }
+  };
+
+  const register = (certificationId: number, body: PlayerCertificationDatesRequest) => mutate(
+    "register",
+    () => registerPlayerCertificationApi(certificationId, body),
+    undefined,
+    (_, next) => {
+      if (next.some((item) => item.certificationId === certificationId)) select(certificationId);
+    },
+  );
+
+  const update = (certificationId: number, body: PlayerCertificationDatesRequest) => {
+    if (Object.keys(body).length === 0) return Promise.resolve(false);
+    return mutate(`update-${certificationId}`, () => updatePlayerCertificationApi(certificationId, body));
+  };
+
+  const remove = (certificationId: number) => mutate(
+    `delete-${certificationId}`,
+    () => deletePlayerCertificationApi(certificationId),
+    () => {
+      if (selectedIdRef.current === certificationId) {
+        selectedIdRef.current = null;
+        setSelectedId(null);
+      }
+    },
+  );
+
+  return {
+    catalog: { items: catalog, loading: catalogLoading, error: catalogError, retry: loadCatalog },
+    owned: { items: owned, loading: ownedLoading, error: ownedError, reload: reloadOwned },
+    selectedId,
+    selected: owned.find((item) => item.certificationId === selectedId) ?? null,
+    select,
+    pendingMutation,
+    mutationError,
+    register,
+    update,
+    remove,
+  };
+}

--- a/lib/api/endpoints/player.api.ts
+++ b/lib/api/endpoints/player.api.ts
@@ -1,13 +1,11 @@
 import { USE_MOCK, apiGet, apiPut } from "../client";
 import {
   MOCK_CHARACTER_SHEET,
-  MOCK_CERTIFICATIONS,
   MOCK_HOBBIES,
   MOCK_TITLES,
 } from "../mock/player.mock";
 import type {
   CharacterSheet,
-  PlayerCertificationInfo,
   PlayerHobbyInfo,
   PlayerTitleInfo,
 } from "../types";
@@ -15,12 +13,6 @@ import type {
 export async function getCharacterSheetApi(): Promise<CharacterSheet> {
   if (USE_MOCK) return MOCK_CHARACTER_SHEET;
   return apiGet<CharacterSheet>("/api/v1/players/me/sheet");
-}
-
-export async function getCertificationsApi(): Promise<PlayerCertificationInfo[]> {
-  if (USE_MOCK) return MOCK_CERTIFICATIONS;
-  const res = await apiGet<{ infos: PlayerCertificationInfo[] }>("/api/v1/players/me/certifications");
-  return res.infos;
 }
 
 export async function getTitlesApi(): Promise<PlayerTitleInfo[]> {

--- a/lib/api/mock/player.mock.ts
+++ b/lib/api/mock/player.mock.ts
@@ -1,7 +1,6 @@
 import type {
   CharacterSheet,
   PlayerAchievementInfo,
-  PlayerCertificationInfo,
   PlayerHobbyInfo,
   PlayerTitleInfo,
 } from "../types";
@@ -96,21 +95,6 @@ export const MOCK_ACHIEVEMENTS: PlayerAchievementInfo[] = [
   { achievementId: 16, code: "PARTY_LEADER", name: "Party Leader", category: "Social", descMd: "Led a party to clear a boss without casualties.", acquiredAt: "2026-03-02T12:00:00Z" },
   { achievementId: 17, code: "RARE_ITEM", name: "Rare Collector", category: "Collection", descMd: "Obtained 20 rare-tier or above items.", acquiredAt: "2026-02-15T16:30:00Z" },
   { achievementId: 18, code: "LEGENDARY_KILL", name: "Legend Slayer", category: "Combat", descMd: "Defeated a legendary-tier monster.", acquiredAt: "2026-03-01T21:00:00Z" },
-];
-
-export const MOCK_CERTIFICATIONS: PlayerCertificationInfo[] = [
-  { certificationId: 1, name: "AWS Solutions Architect", issuer: "Amazon Web Services", category: "Cloud", acquiredDate: "2025-06-15", expiresDate: "2028-06-15", grantedAt: "2025-06-15T09:00:00Z" },
-  { certificationId: 2, name: "Python Professional", issuer: "Python Institute", category: "Programming", acquiredDate: "2025-03-20", expiresDate: null, grantedAt: "2025-03-20T10:00:00Z" },
-  { certificationId: 3, name: "Kubernetes Administrator", issuer: "CNCF", category: "DevOps", acquiredDate: "2025-09-10", expiresDate: "2027-09-10", grantedAt: "2025-09-10T11:00:00Z" },
-  { certificationId: 4, name: "TOEIC 935", issuer: "ETS Korea", category: "Language", acquiredDate: "2024-11-02", expiresDate: "2026-11-02", grantedAt: "2024-11-02T08:00:00Z" },
-  { certificationId: 5, name: "Google Cloud Professional", issuer: "Google", category: "Cloud", acquiredDate: "2025-12-01", expiresDate: "2027-12-01", grantedAt: "2025-12-01T14:00:00Z" },
-  { certificationId: 6, name: "React Developer", issuer: "Meta", category: "Frontend", acquiredDate: "2025-04-15", expiresDate: null, grantedAt: "2025-04-15T10:00:00Z" },
-  { certificationId: 7, name: "Computer Science Bachelor", issuer: "Seoul National University", category: "Academic", acquiredDate: "2024-02-28", expiresDate: null, grantedAt: "2024-02-28T09:00:00Z" },
-  { certificationId: 8, name: "SQLD Database Developer", issuer: "Korea Data Agency", category: "Database", acquiredDate: "2025-07-20", expiresDate: null, grantedAt: "2025-07-20T10:00:00Z" },
-  { certificationId: 9, name: "Security+ Certified", issuer: "CompTIA", category: "Security", acquiredDate: "2025-10-05", expiresDate: "2028-10-05", grantedAt: "2025-10-05T09:00:00Z" },
-  { certificationId: 10, name: "TypeScript Advanced", issuer: "Microsoft", category: "Programming", acquiredDate: "2025-08-12", expiresDate: null, grantedAt: "2025-08-12T11:00:00Z" },
-  { certificationId: 11, name: "Docker Certified Associate", issuer: "Docker Inc.", category: "DevOps", acquiredDate: "2025-05-28", expiresDate: "2027-05-28", grantedAt: "2025-05-28T10:00:00Z" },
-  { certificationId: 12, name: "JLPT N3 Japanese", issuer: "Japan Foundation", category: "Language", acquiredDate: "2025-01-10", expiresDate: null, grantedAt: "2025-01-10T08:00:00Z" },
 ];
 
 export const MOCK_TITLES: PlayerTitleInfo[] = [

--- a/shared/api/types/character.ts
+++ b/shared/api/types/character.ts
@@ -62,10 +62,28 @@ export interface PlayerCertificationInfo {
   name: string;
   issuer: string;
   category: string;
-  acquiredDate: string;
+  acquiredDate: string | null;
   expiresDate: string | null;
   grantedAt: string;
 }
+
+export interface CertificationCatalogInfo {
+  certificationId: number;
+  name: string;
+  issuer: string;
+  category: string;
+}
+
+export type PlayerCertificationDatesRequest = {
+  acquiredDate?: string | null;
+  expiresDate?: string | null;
+};
+
+export type PlayerCertificationMutationResult = {
+  certificationId: number;
+  acquiredDate: string | null;
+  expiresDate: string | null;
+};
 
 export interface PlayerHobbyInfo {
   hobbyId: number;


### PR DESCRIPTION
### Purpose

Replace the static Credentials surface with the real Certification catalog and Current Player Certification management contracts.

Closes #26

### Delivered

- real Certification catalog
- real Current Player Certification list
- registration
- partial date update
- delete
- nullable date contract alignment
- authoritative reload after mutations
- feature-owned Certification state
- backend-parity mock behavior
- stale static Credentials cleanup

### Backend Contracts

Connected:

```text
GET    /api/v1/certifications
GET    /api/v1/players/certifications
POST   /api/v1/players/certifications/{certificationId}
PATCH  /api/v1/players/certifications/{certificationId}
DELETE /api/v1/players/certifications/{certificationId}
```

### Partial Update

Merged Backend #272 semantics are preserved:

```text
non-null supplied -> apply
null / omitted    -> preserve
```

Blank edit inputs are omitted.

Explicit date clearing is not presented because the current backend request contract does not support tri-state clearing.

### Ownership

- Current Player identity is authentication-owned
- no caller player/user IDs
- catalog existence is separate from Player ownership
- mutations reload the authoritative owned list

### Type Integrity

Owned Certification dates are modeled as nullable:

```text
acquiredDate: string | null
expiresDate: string | null
```

### Removed Drift

The active Credentials flow no longer depends on:

- static Certification rows
- fabricated acquisition dates
- stale `/api/v1/players/me/certifications`
- local fabricated owned rows

### Scope

No:

- explicit date clear protocol
- verification/evidence workflow
- Certification admin management
- Hobby/Title refactor
- Media CRUD

### Validation

Focused coverage verifies:

- exact transport contracts
- catalog/ownership separation
- registration authoritative reload
- partial update semantics
- delete selection clearing
- nullable date rendering
- final lint/tests/build

Integret with branch 26