### PR TITLE
[Character] Connect real Current Player Title and representative selection surface

### DIFF
--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -37,6 +37,7 @@ vi.mock("@/features/lifelog/CollectionShell", () => ({ default: () => <div data-
 vi.mock("@/features/lifelog/ExerciseShell", () => ({ default: () => <div data-testid="exercise-shell">Exercise Shell</div> }));
 vi.mock("@/features/player/AchievementShell", () => ({ default: () => <div data-testid="achievement-shell">Achievement Shell</div> }));
 vi.mock("@/features/player/CertificationShell", () => ({ default: () => <div data-testid="certification-shell">Certification Shell</div> }));
+vi.mock("@/features/player/TitleShell", () => ({ default: () => <div data-testid="title-shell">Title Shell</div> }));
 vi.mock("@/features/inventory/InventoryShell", () => ({ default: ({ surface }: { surface: string }) => <div data-testid="inventory-shell">Inventory · {surface}</div> }));
 vi.mock("@/features/inventory/GearShell", () => ({ default: () => <div data-testid="gear-shell">Gear Shell</div> }));
 vi.mock("@/features/home/HomeShell", () => ({
@@ -164,6 +165,18 @@ describe("Home shell에서 feature surface를 routing할 때", () => {
 
       expect(screen.getByTestId("certification-shell")).toBeInTheDocument();
       expect(screen.queryByRole("button", { name: "Cloud" })).not.toBeInTheDocument();
+    });
+  });
+
+  describe("인증된 player가 Title을 선택하면", () => {
+    it("generic static panels 대신 feature-owned TitleShell로 routing한다", () => {
+      render(<Home />);
+
+      fireEvent.click(screen.getByRole("button", { name: "Player" }));
+      fireEvent.click(screen.getByRole("button", { name: "Title" }));
+
+      expect(screen.getByTestId("title-shell")).toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: "Combat" })).not.toBeInTheDocument();
     });
   });
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -21,6 +21,7 @@ import GearShell from "@/features/inventory/GearShell";
 import HomeShell from "@/features/home/HomeShell";
 import AchievementShell from "@/features/player/AchievementShell";
 import CertificationShell from "@/features/player/CertificationShell";
+import TitleShell from "@/features/player/TitleShell";
 import { useRoles } from "@/features/role/useRoles";
 import { usePanScroll } from "@/shared/hooks/usePanScroll";
 import { MOCK_CHARACTER_SHEET } from "@/features/player/mock";
@@ -153,7 +154,7 @@ function buildPanels(
 
   if (selectedMain === "player") {
     const sub = selectedMainSub as PlayerSubId;
-    if (sub === "achievement" || sub === "credentials") return { panelStack, socialContext: null };
+    if (sub === "achievement" || sub === "credentials" || sub === "title") return { panelStack, socialContext: null };
     const subLabel = mainItems.find((item) => item.id === sub)?.label ?? "Player";
     const categoryItems = PLAYER_CATEGORY_ITEMS[sub] ?? [];
     const selectedCategory = selectedPlayerCategoryBySub[sub] ?? null;
@@ -1231,6 +1232,16 @@ export default function Home() {
                 onPanelItemSelect={handlePanelItemSelect}
               />
               <CertificationShell />
+            </div>
+          ) : selectedMain === "player" && selectedSubByMain.player === "title" ? (
+            <div className="flex w-fit items-center gap-3">
+              <RightPanels
+                selectedMain="player"
+                panelStack={panelStack.slice(0, 1)}
+                panelStackKey="player-title-menu"
+                onPanelItemSelect={handlePanelItemSelect}
+              />
+              <TitleShell />
             </div>
           ) : selectedMain === "role" ? (
             <div className="flex w-fit items-center gap-3">

--- a/features/player/TitleShell.test.tsx
+++ b/features/player/TitleShell.test.tsx
@@ -1,0 +1,45 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { PlayerTitleInfo } from "@/shared/api/types";
+import { MOCK_CHARACTER_SHEET } from "./mock";
+import TitleShell from "./TitleShell";
+
+const api = vi.hoisted(() => ({
+  getCurrentPlayerApi: vi.fn(),
+  getPlayerTitlesApi: vi.fn(),
+  setRepresentativeTitleApi: vi.fn(),
+}));
+
+vi.mock("./api", () => api);
+vi.mock("@/shared/ui/PanelCard", () => ({
+  default: ({ label, subtitle, onClick }: { label: string; subtitle: string; onClick: () => void }) => <button type="button" data-testid="title-entry" onClick={onClick}>{label} · {subtitle}</button>,
+}));
+
+const title: PlayerTitleInfo = { titleId: 1, code: "BLACK_SWORDSMAN", name: "Black Swordsman", category: "Combat", descMd: "Canonical description.", acquiredAt: "2026-08-01T00:00:00Z" };
+
+describe("Title surface와 routing을 사용할 때", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api.getCurrentPlayerApi.mockResolvedValue({ ...MOCK_CHARACTER_SHEET.player, representativeTitleId: 1 });
+    api.getPlayerTitlesApi.mockResolvedValue([title]);
+  });
+
+  it("acquired fields와 representative marker를 표시하고 fabricated state는 만들지 않는다", async () => {
+    const { unmount } = render(<TitleShell />);
+    const entry = await screen.findByTestId("title-entry");
+    expect(entry).toHaveTextContent("Combat · 2026-08-01T00:00:00Z · Representative Title");
+    fireEvent.click(entry);
+    expect(screen.getByText("Code: BLACK_SWORDSMAN")).toBeInTheDocument();
+    expect(screen.getByText("Canonical description.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Representative Title" })).toBeDisabled();
+    expect(screen.queryByText(/Status: Unlocked/)).not.toBeInTheDocument();
+    unmount();
+
+    api.getCurrentPlayerApi.mockResolvedValue({ ...MOCK_CHARACTER_SHEET.player, representativeTitleId: 99 });
+    api.getPlayerTitlesApi.mockResolvedValue([]);
+    render(<TitleShell />);
+    expect(await screen.findByText("No acquired Titles.")).toBeInTheDocument();
+    expect(screen.getByText("Representative Title #99 is unavailable in acquired Titles.")).toBeInTheDocument();
+  });
+});

--- a/features/player/TitleShell.tsx
+++ b/features/player/TitleShell.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { SAO } from "@/shared/design/tokens";
+import PanelCard from "@/shared/ui/PanelCard";
+import { PanelFrame } from "@/widgets/right-panels/ui/PanelFrame";
+import { GoldRow, InfoCard } from "@/widgets/right-panels/ui/Rows";
+import { useTitleQueries } from "./useTitleQueries";
+
+const buttonStyle = {
+  border: `1px solid ${SAO.color.border.panel}`,
+  background: SAO.color.bg.inset,
+  color: SAO.color.text.secondary,
+  borderRadius: SAO.radius.panel,
+  padding: "7px 10px",
+  fontSize: "0.68rem",
+  letterSpacing: "0.08em",
+} as const;
+
+function ErrorState({ message, retry }: { message: string; retry: () => void }) {
+  return (
+    <div className="space-y-2 px-3">
+      <p role="alert" className="text-xs" style={{ color: SAO.color.action.red }}>{message}</p>
+      <button type="button" style={buttonStyle} onClick={retry}>Retry</button>
+    </div>
+  );
+}
+
+export default function TitleShell() {
+  const titles = useTitleQueries();
+  const selected = titles.selected;
+  const representative = titles.representativeTitleId;
+  const representativeAvailable = representative === null || titles.titles.items.some(({ titleId }) => titleId === representative);
+
+  return (
+    <div className="relative flex min-w-0 w-fit flex-row flex-nowrap items-center gap-3" data-testid="title-shell">
+      <PanelFrame title="Acquired Titles" depth={1}>
+        <div className="space-y-3">
+          {titles.player.loading && !titles.player.data ? <InfoCard>Loading Current Player...</InfoCard> : null}
+          {titles.player.error ? <ErrorState message={titles.player.error} retry={() => void titles.player.reload()} /> : null}
+          {titles.titles.loading && titles.titles.items.length === 0 ? <InfoCard>Loading Titles...</InfoCard> : null}
+          {titles.titles.error ? <ErrorState message={titles.titles.error} retry={() => void titles.titles.reload()} /> : null}
+          {!titles.titles.loading && !titles.titles.error && titles.titles.items.length === 0 ? <InfoCard>No acquired Titles.</InfoCard> : null}
+          {!representativeAvailable ? <InfoCard>Representative Title #{representative} is unavailable in acquired Titles.</InfoCard> : null}
+          {titles.mutationError ? <p role="alert" className="px-3 text-xs" style={{ color: SAO.color.action.red }}>{titles.mutationError}</p> : null}
+          <div className="space-y-2">
+            {titles.titles.items.map((title, index) => (
+              <PanelCard
+                key={title.titleId}
+                label={title.name}
+                slotLabel={title.code.slice(0, 2)}
+                subtitle={`${title.category} · ${title.acquiredAt}${representative === title.titleId ? " · Representative Title" : ""}`}
+                selected={titles.selectedId === title.titleId}
+                index={index}
+                onClick={() => titles.select(title.titleId)}
+              />
+            ))}
+          </div>
+        </div>
+      </PanelFrame>
+
+      <PanelFrame title="Title Detail" depth={0}>
+        {!selected ? <InfoCard>Select an acquired Title.</InfoCard> : (
+          <div className="space-y-3 px-3">
+            <InfoCard>{selected.name}</InfoCard>
+            <GoldRow>Code: {selected.code}</GoldRow>
+            <GoldRow>Category: {selected.category}</GoldRow>
+            <GoldRow>Acquired: {selected.acquiredAt}</GoldRow>
+            {representative === selected.titleId ? <GoldRow>Representative Title</GoldRow> : null}
+            <InfoCard label="Description"><span style={{ whiteSpace: "pre-wrap" }}>{selected.descMd}</span></InfoCard>
+            <button
+              type="button"
+              disabled={titles.pendingMutation || representative === selected.titleId}
+              style={buttonStyle}
+              onClick={() => void titles.setRepresentative(selected.titleId)}
+            >
+              {titles.pendingMutation ? "Working..." : representative === selected.titleId ? "Representative Title" : "Set Representative"}
+            </button>
+          </div>
+        )}
+      </PanelFrame>
+    </div>
+  );
+}

--- a/features/player/api.test.ts
+++ b/features/player/api.test.ts
@@ -1,16 +1,19 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { PlayerAchievementInfo, PlayerCertificationInfo } from "@/shared/api/types";
+import type { PlayerAchievementInfo, PlayerCertificationInfo, PlayerInfo, PlayerTitleInfo } from "@/shared/api/types";
 import {
   deletePlayerCertificationApi,
   getCertificationCatalogApi,
   getPlayerAchievementApi,
   getPlayerAchievementsApi,
   getPlayerCertificationsApi,
+  getCurrentPlayerApi,
+  getPlayerTitlesApi,
   registerPlayerCertificationApi,
   updatePlayerCertificationApi,
+  setRepresentativeTitleApi,
 } from "./api";
-import { achievementMock, certificationMock, resetCertificationMock } from "./mock";
+import { achievementMock, certificationMock, resetCertificationMock, resetTitleMock, titleMock } from "./mock";
 
 const client = vi.hoisted(() => ({ apiDelete: vi.fn(), apiGet: vi.fn(), apiPatch: vi.fn(), apiPost: vi.fn() }));
 
@@ -90,5 +93,36 @@ describe("Current Player Certification API를 사용할 때", () => {
     expect(() => certificationMock.update(3, { expiresDate: "2026-07-31" })).toThrow("Expiration date cannot be before acquired date.");
     expect(certificationMock.delete(3)).toBe(3);
     expect(certificationMock.owned().some(({ certificationId }) => certificationId === 3)).toBe(false);
+  });
+});
+
+describe("Current Player Title API를 사용할 때", () => {
+  const player = { playerId: 7, representativeTitleId: 31 } as PlayerInfo;
+  const title: PlayerTitleInfo = { titleId: 31, code: "VANGUARD", name: "Vanguard", category: "Combat", descMd: "Leads from the front.", acquiredAt: "2026-08-14T00:00:00Z" };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetTitleMock();
+  });
+
+  it("exact Current Player/list GET과 body 없는 PATCH만 호출하고 list envelope를 푼다", async () => {
+    client.apiGet.mockResolvedValueOnce(player).mockResolvedValueOnce({ infos: [title] });
+    client.apiPatch.mockResolvedValue({ titleId: 31 });
+
+    expect(await getCurrentPlayerApi()).toEqual(player);
+    expect(await getPlayerTitlesApi()).toEqual([title]);
+    expect(await setRepresentativeTitleApi(31)).toEqual({ titleId: 31 });
+
+    expect(client.apiGet).toHaveBeenNthCalledWith(1, "/api/v1/players");
+    expect(client.apiGet).toHaveBeenNthCalledWith(2, "/api/v1/players/titles");
+    expect(client.apiPatch).toHaveBeenCalledWith("/api/v1/players/titles/31", undefined);
+    expect([...client.apiGet.mock.calls, ...client.apiPatch.mock.calls].flat().join(" ")).not.toMatch(/playerId|userId|\/players\/me\/|\/api\/v1\/titles/);
+  });
+
+  it("mock authority는 acquired ID만 대표로 설정하고 Current Player에 반영한다", () => {
+    const nextId = titleMock.titles()[1].titleId;
+    expect(titleMock.setRepresentative(nextId)).toEqual({ titleId: nextId });
+    expect(titleMock.player().representativeTitleId).toBe(nextId);
+    expect(() => titleMock.setRepresentative(999_999)).toThrow("Acquired Title not found.");
   });
 });

--- a/features/player/api.ts
+++ b/features/player/api.ts
@@ -1,12 +1,14 @@
 import { USE_MOCK, apiDelete, apiGet, apiPatch, apiPost } from "@/shared/api/client";
 import type {
   CertificationCatalogInfo,
+  PlayerInfo,
   PlayerAchievementInfo,
   PlayerCertificationDatesRequest,
   PlayerCertificationInfo,
   PlayerCertificationMutationResult,
+  PlayerTitleInfo,
 } from "@/shared/api/types";
-import { achievementMock, certificationMock } from "./mock";
+import { achievementMock, certificationMock, titleMock } from "./mock";
 
 export type RegisterPlayerRequest = { name: string; gender: string };
 export type CreatedPlayerWithToken = {
@@ -63,4 +65,20 @@ export function deletePlayerCertificationApi(certificationId: number): Promise<n
   return USE_MOCK
     ? Promise.resolve().then(() => certificationMock.delete(certificationId))
     : apiDelete<number>(`/api/v1/players/certifications/${certificationId}`);
+}
+
+export function getCurrentPlayerApi(): Promise<PlayerInfo> {
+  return USE_MOCK ? Promise.resolve(titleMock.player()) : apiGet<PlayerInfo>("/api/v1/players");
+}
+
+export async function getPlayerTitlesApi(): Promise<PlayerTitleInfo[]> {
+  if (USE_MOCK) return titleMock.titles();
+  const result = await apiGet<{ infos: PlayerTitleInfo[] }>("/api/v1/players/titles");
+  return result.infos;
+}
+
+export function setRepresentativeTitleApi(titleId: number): Promise<{ titleId: number }> {
+  return USE_MOCK
+    ? Promise.resolve().then(() => titleMock.setRepresentative(titleId))
+    : apiPatch<{ titleId: number }>(`/api/v1/players/titles/${titleId}`, undefined);
 }

--- a/features/player/data.ts
+++ b/features/player/data.ts
@@ -1,18 +1,3 @@
-export const TITLE_DATA = [
-  { code: "BLACK_SWORDSMAN", name: "Black Swordsman", cat: "Achievement", desc: "The legendary solo player." },
-  { code: "BEATER",          name: "Beater",           cat: "Special",     desc: "A beta tester with prior knowledge." },
-  { code: "SOLO_KING",       name: "Solo King",        cat: "Exploration", desc: "Cleared 10 floors solo." },
-  { code: "FLOOR_CLEARER",   name: "Floor Clearer",    cat: "Combat",      desc: "Front-line floor clearing." },
-  { code: "DUAL_WIELDER",    name: "Dual Wielder",     cat: "Combat",      desc: "Holder of Dual Wield skill." },
-  { code: "MASTER_CRAFTER",  name: "Master Crafter",   cat: "Crafting",    desc: "Crafted masterwork items." },
-  { code: "GUILD_CHIEF",     name: "Guild Chief",      cat: "Social",      desc: "Leader of a recognized guild." },
-  { code: "LEGEND_SLAYER",   name: "Legend Slayer",    cat: "Combat",      desc: "Slayer of legendary monsters." },
-  { code: "MARKET_KING",     name: "Market King",      cat: "Economy",     desc: "100 trades, perfect ratings." },
-  { code: "NIGHT_WALKER",    name: "Night Walker",     cat: "Exploration", desc: "Nocturnal dungeon master." },
-  { code: "FRONTLINER",      name: "Frontliner",       cat: "Rank",        desc: "Active front-line team member." },
-  { code: "RARE_HUNTER",     name: "Rare Hunter",      cat: "Collection",  desc: "Collector of rare items." },
-];
-
 export const HOBBY_DATA = [
   { name: "Programming",      cat: "Tech",          custom: "Full-Stack Dev",    proficiency: 85, status: "ACTIVE",   xp: 42000 },
   { name: "Reading",          cat: "Learning",      custom: "Tech & Fiction",    proficiency: 72, status: "ACTIVE",   xp: 28500 },

--- a/features/player/mock.ts
+++ b/features/player/mock.ts
@@ -6,6 +6,7 @@ import type {
   PlayerCertificationInfo,
   PlayerCertificationMutationResult,
   PlayerHobbyInfo,
+  PlayerInfo,
   PlayerTitleInfo,
 } from "@/shared/api/types";
 
@@ -196,6 +197,23 @@ export const MOCK_TITLES: PlayerTitleInfo[] = [
   { titleId: 11, code: "FRONTLINER", name: "Frontliner", category: "Rank", descMd: "Active member of the front-line clearing team.", acquiredAt: "2026-01-20T12:00:00Z" },
   { titleId: 12, code: "RARE_HUNTER", name: "Rare Hunter", category: "Collection", descMd: "Collector of rare and legendary items.", acquiredAt: "2026-02-15T16:30:00Z" },
 ];
+
+const MOCK_CURRENT_PLAYER: PlayerInfo = copy(MOCK_CHARACTER_SHEET.player);
+let currentPlayer: PlayerInfo = copy(MOCK_CURRENT_PLAYER);
+
+export function resetTitleMock(): void {
+  currentPlayer = copy(MOCK_CURRENT_PLAYER);
+}
+
+export const titleMock = {
+  player: (): PlayerInfo => copy(currentPlayer),
+  titles: (): PlayerTitleInfo[] => copy(MOCK_TITLES),
+  setRepresentative: (titleId: number): { titleId: number } => {
+    if (!MOCK_TITLES.some((title) => title.titleId === titleId)) throw new Error("Acquired Title not found.");
+    currentPlayer = { ...currentPlayer, representativeTitleId: titleId };
+    return { titleId };
+  },
+};
 
 export const MOCK_HOBBIES: PlayerHobbyInfo[] = [
   { hobbyId: 1, name: "Programming", category: "Tech", customName: "Full-Stack Dev", detail: "Next.js, TypeScript, Spring Boot", proficiency: 85, status: "ACTIVE", startedOn: "2020-03-01", xp: 42000 },

--- a/features/player/model.ts
+++ b/features/player/model.ts
@@ -1,27 +1,12 @@
 import type { PlayerSubId, PanelDataItem, PanelMenuItem } from "@/entities/nav";
-import { CRUD_ACTIONS, pad, dateAt, uniqueOrderedCats, catMenuItems } from "@/entities/nav";
-import { TITLE_DATA, HOBBY_DATA } from "./data";
+import { CRUD_ACTIONS, pad, uniqueOrderedCats, catMenuItems } from "@/entities/nav";
+import { HOBBY_DATA } from "./data";
 
 export * from "./forms";
 
-type LegacyPlayerSubId = Exclude<PlayerSubId, "achievement" | "credentials">;
+type LegacyPlayerSubId = Exclude<PlayerSubId, "achievement" | "credentials" | "title">;
 
 export const PLAYER_LISTS: Record<LegacyPlayerSubId, PanelDataItem[]> = {
-  title: TITLE_DATA.map((t, i) => ({
-    id: `title-${pad(i + 1, 3)}`,
-    label: t.name,
-    slotLabel: t.code.slice(0, 2),
-    subtitle: `${t.cat} | Acquired: ${dateAt(i)}`,
-    category: t.cat,
-    detailTitle: "Title Detail",
-    detailDescription: t.desc,
-    detailRows: [
-      `Code: ${t.code}`,
-      `Category: ${t.cat}`,
-      `Acquired: ${dateAt(i)}`,
-      `Status: Unlocked`,
-    ],
-  })),
   interests: HOBBY_DATA.map((h, i) => ({
     id: `hobby-${pad(i + 1, 3)}`,
     label: h.custom,
@@ -41,6 +26,5 @@ export const PLAYER_LISTS: Record<LegacyPlayerSubId, PanelDataItem[]> = {
 };
 
 export const PLAYER_CATEGORY_ITEMS: Record<LegacyPlayerSubId, PanelMenuItem[]> = {
-  title:       catMenuItems(uniqueOrderedCats(TITLE_DATA)),
   interests:   catMenuItems(uniqueOrderedCats(HOBBY_DATA)),
 };

--- a/features/player/useTitleQueries.test.tsx
+++ b/features/player/useTitleQueries.test.tsx
@@ -1,0 +1,51 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { PlayerTitleInfo } from "@/shared/api/types";
+import { MOCK_CHARACTER_SHEET } from "./mock";
+import { useTitleQueries } from "./useTitleQueries";
+
+const api = vi.hoisted(() => ({
+  getCurrentPlayerApi: vi.fn(),
+  getPlayerTitlesApi: vi.fn(),
+  setRepresentativeTitleApi: vi.fn(),
+}));
+
+vi.mock("./api", () => api);
+
+const titles: PlayerTitleInfo[] = [
+  { titleId: 1, code: "FIRST", name: "First", category: "Combat", descMd: "First title.", acquiredAt: "2026-08-01T00:00:00Z" },
+  { titleId: 2, code: "SECOND", name: "Second", category: "Growth", descMd: "Second title.", acquiredAt: "2026-08-02T00:00:00Z" },
+];
+const player = { ...MOCK_CHARACTER_SHEET.player, representativeTitleId: 1 };
+
+describe("Title query/mutation state를 관리할 때", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api.getPlayerTitlesApi.mockResolvedValue(titles);
+    api.getCurrentPlayerApi.mockResolvedValue(player);
+    api.setRepresentativeTitleApi.mockResolvedValue({ titleId: 2 });
+  });
+
+  it("authority를 함께 로드하고 PATCH 후 Player를 새로 읽으며 no-op과 refresh failure에서 state를 만들지 않는다", async () => {
+    const { result } = renderHook(() => useTitleQueries());
+    await waitFor(() => expect(result.current.titles.items).toEqual(titles));
+    await waitFor(() => expect(result.current.representativeTitleId).toBe(1));
+
+    await act(async () => { await result.current.setRepresentative(1); });
+    expect(api.setRepresentativeTitleApi).not.toHaveBeenCalled();
+
+    act(() => result.current.select(2));
+    api.getCurrentPlayerApi.mockResolvedValueOnce({ ...player, representativeTitleId: 2 });
+    await act(async () => { await result.current.setRepresentative(2); });
+    expect(api.setRepresentativeTitleApi).toHaveBeenCalledWith(2);
+    expect(api.getCurrentPlayerApi).toHaveBeenCalledTimes(2);
+    expect(result.current.representativeTitleId).toBe(2);
+
+    api.getCurrentPlayerApi.mockRejectedValueOnce(new Error("refresh failed"));
+    api.setRepresentativeTitleApi.mockResolvedValueOnce({ titleId: 1 });
+    await act(async () => { await result.current.setRepresentative(1); });
+    expect(result.current.representativeTitleId).toBe(2);
+    expect(result.current.mutationError).toMatch(/authority could not be reloaded/);
+  });
+});

--- a/features/player/useTitleQueries.ts
+++ b/features/player/useTitleQueries.ts
@@ -1,0 +1,94 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import type { PlayerInfo, PlayerTitleInfo } from "@/shared/api/types";
+import { getCurrentPlayerApi, getPlayerTitlesApi, setRepresentativeTitleApi } from "./api";
+
+function message(caught: unknown, fallback: string): string {
+  return caught instanceof Error ? caught.message : fallback;
+}
+
+export function useTitleQueries() {
+  const [player, setPlayer] = useState<PlayerInfo | null>(null);
+  const [playerLoading, setPlayerLoading] = useState(false);
+  const [playerError, setPlayerError] = useState<string | null>(null);
+  const [titles, setTitles] = useState<PlayerTitleInfo[]>([]);
+  const [titlesLoading, setTitlesLoading] = useState(false);
+  const [titlesError, setTitlesError] = useState<string | null>(null);
+  const [selectedId, setSelectedId] = useState<number | null>(null);
+  const mutationLocked = useRef(false);
+  const [pendingMutation, setPendingMutation] = useState(false);
+  const [mutationError, setMutationError] = useState<string | null>(null);
+
+  const loadPlayer = useCallback(async () => {
+    setPlayerLoading(true);
+    setPlayerError(null);
+    try {
+      const next = await getCurrentPlayerApi();
+      setPlayer(next);
+      return next;
+    } catch (caught) {
+      setPlayerError(message(caught, "Unable to load Current Player."));
+      return undefined;
+    } finally {
+      setPlayerLoading(false);
+    }
+  }, []);
+
+  const loadTitles = useCallback(async () => {
+    setTitlesLoading(true);
+    setTitlesError(null);
+    try {
+      const next = await getPlayerTitlesApi();
+      setTitles(next);
+      setSelectedId((current) => current !== null && next.some(({ titleId }) => titleId === current) ? current : null);
+      return next;
+    } catch (caught) {
+      setTitlesError(message(caught, "Unable to load acquired Titles."));
+      return undefined;
+    } finally {
+      setTitlesLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { void Promise.all([loadPlayer(), loadTitles()]); }, [loadPlayer, loadTitles]);
+
+  const select = (titleId: number) => {
+    if (titles.some((title) => title.titleId === titleId)) setSelectedId(titleId);
+  };
+
+  const setRepresentative = async (titleId: number): Promise<boolean> => {
+    if (mutationLocked.current || player?.representativeTitleId === titleId || !titles.some((title) => title.titleId === titleId)) return false;
+    mutationLocked.current = true;
+    setPendingMutation(true);
+    setMutationError(null);
+    try {
+      await setRepresentativeTitleApi(titleId);
+      const refreshed = await loadPlayer();
+      if (!refreshed) {
+        setMutationError("Representative Title changed, but Current Player authority could not be reloaded.");
+        return false;
+      }
+      return true;
+    } catch (caught) {
+      setMutationError(message(caught, "Unable to set representative Title."));
+      return false;
+    } finally {
+      mutationLocked.current = false;
+      setPendingMutation(false);
+    }
+  };
+
+  return {
+    player: { data: player, loading: playerLoading, error: playerError, reload: loadPlayer },
+    titles: { items: titles, loading: titlesLoading, error: titlesError, reload: loadTitles },
+    representativeTitleId: player?.representativeTitleId ?? null,
+    selectedId,
+    selected: titles.find((title) => title.titleId === selectedId) ?? null,
+    select,
+    pendingMutation,
+    mutationError,
+    setRepresentative,
+  };
+}

--- a/lib/api/endpoints/player.api.ts
+++ b/lib/api/endpoints/player.api.ts
@@ -1,13 +1,11 @@
-import { USE_MOCK, apiGet, apiPut } from "../client";
+import { USE_MOCK, apiGet } from "../client";
 import {
   MOCK_CHARACTER_SHEET,
   MOCK_HOBBIES,
-  MOCK_TITLES,
 } from "../mock/player.mock";
 import type {
   CharacterSheet,
   PlayerHobbyInfo,
-  PlayerTitleInfo,
 } from "../types";
 
 export async function getCharacterSheetApi(): Promise<CharacterSheet> {
@@ -15,19 +13,8 @@ export async function getCharacterSheetApi(): Promise<CharacterSheet> {
   return apiGet<CharacterSheet>("/api/v1/players/me/sheet");
 }
 
-export async function getTitlesApi(): Promise<PlayerTitleInfo[]> {
-  if (USE_MOCK) return MOCK_TITLES;
-  const res = await apiGet<{ infos: PlayerTitleInfo[] }>("/api/v1/players/me/titles");
-  return res.infos;
-}
-
 export async function getHobbiesApi(): Promise<PlayerHobbyInfo[]> {
   if (USE_MOCK) return MOCK_HOBBIES;
   const res = await apiGet<{ infos: PlayerHobbyInfo[] }>("/api/v1/players/me/hobbies");
   return res.infos;
-}
-
-export async function setRepresentativeTitleApi(titleId: number): Promise<void> {
-  if (USE_MOCK) return;
-  await apiPut(`/api/v1/players/me/title/${titleId}`, {});
 }

--- a/lib/api/mock/player.mock.ts
+++ b/lib/api/mock/player.mock.ts
@@ -2,7 +2,6 @@ import type {
   CharacterSheet,
   PlayerAchievementInfo,
   PlayerHobbyInfo,
-  PlayerTitleInfo,
 } from "../types";
 
 export const MOCK_CHARACTER_SHEET: CharacterSheet = {
@@ -95,21 +94,6 @@ export const MOCK_ACHIEVEMENTS: PlayerAchievementInfo[] = [
   { achievementId: 16, code: "PARTY_LEADER", name: "Party Leader", category: "Social", descMd: "Led a party to clear a boss without casualties.", acquiredAt: "2026-03-02T12:00:00Z" },
   { achievementId: 17, code: "RARE_ITEM", name: "Rare Collector", category: "Collection", descMd: "Obtained 20 rare-tier or above items.", acquiredAt: "2026-02-15T16:30:00Z" },
   { achievementId: 18, code: "LEGENDARY_KILL", name: "Legend Slayer", category: "Combat", descMd: "Defeated a legendary-tier monster.", acquiredAt: "2026-03-01T21:00:00Z" },
-];
-
-export const MOCK_TITLES: PlayerTitleInfo[] = [
-  { titleId: 1, code: "BLACK_SWORDSMAN", name: "Black Swordsman", category: "Achievement", descMd: "The legendary solo player known for his black equipment.", acquiredAt: "2026-02-08T20:30:00Z" },
-  { titleId: 2, code: "BEATER", name: "Beater", category: "Special", descMd: "A beta tester who used prior knowledge to gain an advantage.", acquiredAt: "2026-01-10T07:00:00Z" },
-  { titleId: 3, code: "SOLO_KING", name: "Solo King", category: "Exploration", descMd: "Cleared 10 floors completely solo.", acquiredAt: "2026-02-18T15:00:00Z" },
-  { titleId: 4, code: "FLOOR_CLEARER", name: "Floor Clearer", category: "Combat", descMd: "Participated in clearing the frontline floors.", acquiredAt: "2026-01-25T16:00:00Z" },
-  { titleId: 5, code: "DUAL_WIELDER", name: "Dual Wielder", category: "Combat", descMd: "Holder of the unique Dual Wield skill.", acquiredAt: "2026-02-08T20:30:00Z" },
-  { titleId: 6, code: "MASTER_CRAFTER", name: "Master Crafter", category: "Crafting", descMd: "Crafted items rated as masterwork quality.", acquiredAt: "2026-02-20T14:00:00Z" },
-  { titleId: 7, code: "GUILD_CHIEF", name: "Guild Chief", category: "Social", descMd: "Leader of a recognized guild.", acquiredAt: "2026-02-25T19:00:00Z" },
-  { titleId: 8, code: "LEGEND_SLAYER", name: "Legend Slayer", category: "Combat", descMd: "Slayer of legendary-tier monsters.", acquiredAt: "2026-03-01T21:00:00Z" },
-  { titleId: 9, code: "MARKET_KING", name: "Market King", category: "Economy", descMd: "Completed 100 market trades with perfect ratings.", acquiredAt: "2026-03-01T10:30:00Z" },
-  { titleId: 10, code: "NIGHT_WALKER", name: "Night Walker", category: "Exploration", descMd: "Master of nocturnal dungeon exploration.", acquiredAt: "2026-02-28T23:00:00Z" },
-  { titleId: 11, code: "FRONTLINER", name: "Frontliner", category: "Rank", descMd: "Active member of the front-line clearing team.", acquiredAt: "2026-01-20T12:00:00Z" },
-  { titleId: 12, code: "RARE_HUNTER", name: "Rare Hunter", category: "Collection", descMd: "Collector of rare and legendary items.", acquiredAt: "2026-02-15T16:30:00Z" },
 ];
 
 export const MOCK_HOBBIES: PlayerHobbyInfo[] = [


### PR DESCRIPTION
### Purpose

Replace the static/fabricated player Title surface with the canonical acquired-title list and representative-title selection contract.

Closes #28

### Delivered

- real Current Player acquired Title list
- authoritative representative-title state
- representative selection through PATCH
- Current Player reload after mutation
- feature-owned Title state
- loading/error/empty states
- backend-parity mock behavior
- stale static Title player surface cleanup

### Backend Contracts

Connected:

```text
GET   /api/v1/players
GET   /api/v1/players/titles
PATCH /api/v1/players/titles/{titleId}
```

### Ownership

Only Titles acquired by the authenticated Current Player are selectable.

Global catalog Titles are not used as owned state.

No caller player/user identity is sent.

### Representative State

The representative Title is derived from:

```text
PlayerInfo.representativeTitleId
```

After a successful PATCH, Current Player state is reloaded before the UI treats the new representative selection as authoritative.

### Removed Drift

The active player Title flow no longer depends on:

- static TITLE_DATA
- fabricated acquisition dates
- fake Unlocked status
- stale `/api/v1/players/me/titles`
- stale PUT `/api/v1/players/me/title/{titleId}`
- duplicate local representative state

### Scope

No:

- manual Title acquisition
- Title deletion/revocation
- representative clear operation
- provenance/rarity/progress invention
- Hobby refactor
- Media CRUD

### Validation

Focused coverage verifies:

- exact transport contracts
- acquired ownership semantics
- representative authority reload
- no-op already representative selection
- empty/static-fallback behavior
- final lint/tests/build