### PR TITLE
[Growth] Connect canonical Current Player Growth overview

### DIFF
--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -11,10 +11,12 @@ const roles = vi.hoisted((): RoleDetail[] => [
   { id: 1, roleType: "PROFESSIONAL", name: "Backend Engineer", description: "Build systems", status: "ACTIVE", createdAt: "2026-01-01T00:00:00Z", updatedAt: "2026-01-01T00:00:00Z", version: 0 },
 ]);
 const roleHook = vi.hoisted(() => ({ useRoles: vi.fn(() => ({ roles, isLoading: false, error: null, refresh: vi.fn() })) }));
+const growthApi = vi.hoisted(() => ({ getPlayerGrowthApi: vi.fn() }));
 
 vi.mock("next/navigation", () => ({ useRouter: () => router }));
 vi.mock("@/features/auth/AuthContext", () => ({ useAuth: () => auth.state }));
 vi.mock("@/features/role/useRoles", () => roleHook);
+vi.mock("@/features/player/api", () => growthApi);
 vi.mock("@/context/ToastContext", () => ({ useToast: () => ({ showToast: vi.fn() }) }));
 vi.mock("@/shared/hooks/usePanScroll", () => ({ usePanScroll: vi.fn() }));
 vi.mock("@/widgets/left-context/LeftContext", () => ({ default: () => null }));
@@ -71,6 +73,13 @@ describe("Home shell에서 feature surface를 routing할 때", () => {
     vi.clearAllMocks();
     auth.state = { isAuthenticated: true, playerId: 7, isLoading: false, logout: vi.fn() };
     vi.stubGlobal("requestAnimationFrame", () => 1);
+    growthApi.getPlayerGrowthApi.mockResolvedValue({
+      current: { level: 8, exp: 842, str: 12, agi: 11, dex: 10, intel: 9, vit: 8, luc: 7, extraStats: { Focus: 6 }, representativeTitleId: null },
+      recentExpChanges: [
+        { changeId: 2, requestedExp: 100, appliedExp: 80, leftoverExp: 20, beforeLevel: 7, afterLevel: 8, beforeTotalExp: 762, afterTotalExp: 842, occurredAt: "2026-08-14T09:00:00Z", sourceType: "QUEST", sourceId: 31 },
+        { changeId: 1, requestedExp: 10, appliedExp: 10, leftoverExp: 0, beforeLevel: 7, afterLevel: 7, beforeTotalExp: 752, afterTotalExp: 762, occurredAt: "2026-08-13T09:00:00Z", sourceType: null, sourceId: null },
+      ],
+    });
   });
 
   describe("인증된 player가 처음 진입하면", () => {
@@ -171,6 +180,28 @@ describe("Home shell에서 feature surface를 routing할 때", () => {
 
       expect(screen.getByTestId("certification-shell")).toBeInTheDocument();
       expect(screen.queryByRole("button", { name: "Cloud" })).not.toBeInTheDocument();
+    });
+  });
+
+  describe("인증된 player가 Growth를 선택하면", () => {
+    it("첫 Player submenu에서 backend-owned overview와 ordered history를 렌더한다", async () => {
+      render(<Home />);
+      fireEvent.click(screen.getByRole("button", { name: "Player" }));
+
+      const submenu = screen.getByTestId("right-panels").querySelectorAll("button");
+      expect([...submenu].map((button) => button.textContent)).toEqual(["Growth", "Achievement", "Credentials", "Title", "Interests"]);
+      fireEvent.click(screen.getByRole("button", { name: "Growth" }));
+
+      expect(await screen.findByTestId("growth-shell")).toBeInTheDocument();
+      expect(screen.getByText("Level: 8")).toBeInTheDocument();
+      expect(screen.getByText("EXP: 842")).toBeInTheDocument();
+      expect(screen.getByText("Focus: 6")).toBeInTheDocument();
+      expect(screen.getByText("Requested EXP: 100")).toBeInTheDocument();
+      expect(screen.getByText("Applied EXP: 80")).toBeInTheDocument();
+      expect(screen.getByText("Leftover EXP: 20")).toBeInTheDocument();
+      expect(screen.getAllByText("Source Type: —")).toHaveLength(1);
+      expect(screen.queryByText(/next level|percentage|remaining exp|radar/i)).not.toBeInTheDocument();
+      expect(growthApi.getPlayerGrowthApi).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -74,10 +74,10 @@ describe("Home shell에서 feature surface를 routing할 때", () => {
     auth.state = { isAuthenticated: true, playerId: 7, isLoading: false, logout: vi.fn() };
     vi.stubGlobal("requestAnimationFrame", () => 1);
     growthApi.getPlayerGrowthApi.mockResolvedValue({
-      current: { level: 8, exp: 842, str: 12, agi: 11, dex: 10, intel: 9, vit: 8, luc: 7, extraStats: { Focus: 6 }, representativeTitleId: null },
+      current: { level: 8, exp: 842, str: 12, agi: 11, dex: 10, intel: 9, vit: 8, luc: 7, extraStats: {}, representativeTitleId: null },
       recentExpChanges: [
         { changeId: 2, requestedExp: 100, appliedExp: 80, leftoverExp: 20, beforeLevel: 7, afterLevel: 8, beforeTotalExp: 762, afterTotalExp: 842, occurredAt: "2026-08-14T09:00:00Z", sourceType: "QUEST", sourceId: 31 },
-        { changeId: 1, requestedExp: 10, appliedExp: 10, leftoverExp: 0, beforeLevel: 7, afterLevel: 7, beforeTotalExp: 752, afterTotalExp: 762, occurredAt: "2026-08-13T09:00:00Z", sourceType: null, sourceId: null },
+        { changeId: 1, requestedExp: 10, appliedExp: 10, leftoverExp: 0, beforeLevel: 7, afterLevel: 7, beforeTotalExp: 752, afterTotalExp: 762, occurredAt: "2026-08-13T09:00:00Z", sourceType: null, sourceId: 999 },
       ],
     });
   });
@@ -195,11 +195,14 @@ describe("Home shell에서 feature surface를 routing할 때", () => {
       expect(await screen.findByTestId("growth-shell")).toBeInTheDocument();
       expect(screen.getByText("Level: 8")).toBeInTheDocument();
       expect(screen.getByText("EXP: 842")).toBeInTheDocument();
-      expect(screen.getByText("Focus: 6")).toBeInTheDocument();
+      expect(screen.getByText("No extra stats.")).toBeInTheDocument();
       expect(screen.getByText("Requested EXP: 100")).toBeInTheDocument();
       expect(screen.getByText("Applied EXP: 80")).toBeInTheDocument();
       expect(screen.getByText("Leftover EXP: 20")).toBeInTheDocument();
-      expect(screen.getAllByText("Source Type: —")).toHaveLength(1);
+      expect(screen.getByText("Source Type: QUEST")).toBeInTheDocument();
+      expect(screen.getByText("Source ID: 31")).toBeInTheDocument();
+      expect(screen.getByText("Source unavailable.")).toBeInTheDocument();
+      expect(screen.queryByText("Source ID: 999")).not.toBeInTheDocument();
       expect(screen.queryByText(/next level|percentage|remaining exp|radar/i)).not.toBeInTheDocument();
       expect(growthApi.getPlayerGrowthApi).toHaveBeenCalledTimes(1);
     });

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -24,6 +24,7 @@ import AchievementShell from "@/features/player/AchievementShell";
 import CertificationShell from "@/features/player/CertificationShell";
 import TitleShell from "@/features/player/TitleShell";
 import HobbyShell from "@/features/player/HobbyShell";
+import GrowthShell from "@/features/player/GrowthShell";
 import { useRoles } from "@/features/role/useRoles";
 import { usePanScroll } from "@/shared/hooks/usePanScroll";
 import { MOCK_CHARACTER_SHEET } from "@/features/player/mock";
@@ -993,6 +994,16 @@ export default function Home() {
               }}
               onOpenRole={handleRoleSelect}
             />
+          ) : selectedMain === "player" && selectedSubByMain.player === "growth" ? (
+            <div className="flex w-fit items-center gap-3">
+              <RightPanels
+                selectedMain="player"
+                panelStack={panelStack.slice(0, 1)}
+                panelStackKey="player-growth-menu"
+                onPanelItemSelect={handlePanelItemSelect}
+              />
+              <GrowthShell />
+            </div>
           ) : selectedMain === "player" && selectedSubByMain.player === "achievement" ? (
             <div className="flex w-fit items-center gap-3">
               <RightPanels

--- a/entities/nav/config.ts
+++ b/entities/nav/config.ts
@@ -23,6 +23,7 @@ export const MAIN_PANEL_TITLES: Record<MainNavId, string> = {
 
 export const SUBMENUS_BY_MAIN: Record<MainNavId, PanelMenuItem[]> = {
   player: [
+    { id: "growth",      label: "Growth",      slotLabel: "GR" },
     { id: "achievement", label: "Achievement", slotLabel: "AC" },
     { id: "credentials", label: "Credentials", slotLabel: "CR" },
     { id: "title",       label: "Title",       slotLabel: "TI" },

--- a/entities/nav/types.ts
+++ b/entities/nav/types.ts
@@ -9,7 +9,7 @@ export type MainNavId =
   | "market"
   | "system";
 
-export type PlayerSubId = "achievement" | "credentials" | "title" | "interests";
+export type PlayerSubId = "growth" | "achievement" | "credentials" | "title" | "interests";
 export type SkillsSubId = "passive" | "active";
 export type InventorySubId = "items" | "gear" | "inbox";
 export type InventoryGearPartId = "weapon" | "armor" | "accessory" | "boots";

--- a/features/player/GrowthShell.tsx
+++ b/features/player/GrowthShell.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { PanelFrame } from "@/widgets/right-panels/ui/PanelFrame";
+import { GoldRow, InfoCard } from "@/widgets/right-panels/ui/Rows";
+import { useGrowthQuery } from "./useGrowthQuery";
+
+const CORE_STATS = [
+  ["STR", "str"], ["AGI", "agi"], ["DEX", "dex"],
+  ["INT", "intel"], ["VIT", "vit"], ["LUC", "luc"],
+] as const;
+
+export default function GrowthShell() {
+  const growth = useGrowthQuery();
+  const current = growth.data?.current;
+  const changes = growth.data?.recentExpChanges ?? [];
+
+  return (
+    <div className="relative flex min-w-0 w-fit flex-row flex-nowrap items-center gap-3" data-testid="growth-shell">
+      <PanelFrame title="Current Growth" depth={1}>
+        <div className="space-y-2 px-3">
+          {growth.loading && !growth.data ? <InfoCard>Loading Growth...</InfoCard> : null}
+          {growth.error ? <><p role="alert" className="text-xs text-red-400">{growth.error}</p><button type="button" onClick={() => void growth.retry()}>Retry</button></> : null}
+          {current ? <>
+            <GoldRow>Level: {current.level}</GoldRow>
+            <GoldRow>EXP: {current.exp}</GoldRow>
+            {CORE_STATS.map(([label, key]) => <GoldRow key={key}>{label}: {current[key]}</GoldRow>)}
+            {Object.entries(current.extraStats).map(([name, value]) => <GoldRow key={name}>{name}: {value}</GoldRow>)}
+          </> : null}
+        </div>
+      </PanelFrame>
+
+      <PanelFrame title="Recent EXP Changes" depth={0}>
+        <div className="space-y-3 px-3">
+          {growth.data && changes.length === 0 ? <InfoCard>No recent EXP changes.</InfoCard> : null}
+          {changes.map((change) => (
+            <InfoCard key={change.changeId} label={`Change #${change.changeId}`}>
+              <div>Requested EXP: {change.requestedExp}</div>
+              <div>Applied EXP: {change.appliedExp}</div>
+              <div>Leftover EXP: {change.leftoverExp}</div>
+              <div>Level: {change.beforeLevel} → {change.afterLevel}</div>
+              <div>Total EXP: {change.beforeTotalExp} → {change.afterTotalExp}</div>
+              <div>Occurred: {change.occurredAt}</div>
+              <div>Source Type: {change.sourceType ?? "—"}</div>
+              <div>Source ID: {change.sourceId ?? "—"}</div>
+            </InfoCard>
+          ))}
+        </div>
+      </PanelFrame>
+    </div>
+  );
+}

--- a/features/player/GrowthShell.tsx
+++ b/features/player/GrowthShell.tsx
@@ -24,6 +24,7 @@ export default function GrowthShell() {
             <GoldRow>Level: {current.level}</GoldRow>
             <GoldRow>EXP: {current.exp}</GoldRow>
             {CORE_STATS.map(([label, key]) => <GoldRow key={key}>{label}: {current[key]}</GoldRow>)}
+            {Object.keys(current.extraStats).length === 0 ? <InfoCard>No extra stats.</InfoCard> : null}
             {Object.entries(current.extraStats).map(([name, value]) => <GoldRow key={name}>{name}: {value}</GoldRow>)}
           </> : null}
         </div>
@@ -40,8 +41,10 @@ export default function GrowthShell() {
               <div>Level: {change.beforeLevel} → {change.afterLevel}</div>
               <div>Total EXP: {change.beforeTotalExp} → {change.afterTotalExp}</div>
               <div>Occurred: {change.occurredAt}</div>
-              <div>Source Type: {change.sourceType ?? "—"}</div>
-              <div>Source ID: {change.sourceId ?? "—"}</div>
+              {change.sourceType === null ? <div>Source unavailable.</div> : <>
+                <div>Source Type: {change.sourceType}</div>
+                {change.sourceId === null ? null : <div>Source ID: {change.sourceId}</div>}
+              </>}
             </InfoCard>
           ))}
         </div>

--- a/features/player/api.test.ts
+++ b/features/player/api.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { HobbyCatalogInfo, PlayerAchievementInfo, PlayerCertificationInfo, PlayerHobbyInfo, PlayerInfo, PlayerTitleInfo } from "@/shared/api/types";
+import type { HobbyCatalogInfo, PlayerAchievementInfo, PlayerCertificationInfo, PlayerGrowthOverview, PlayerHobbyInfo, PlayerInfo, PlayerTitleInfo } from "@/shared/api/types";
 import {
   deletePlayerCertificationApi,
   deletePlayerHobbyApi,
@@ -10,6 +10,7 @@ import {
   getPlayerCertificationsApi,
   getCurrentPlayerApi,
   getHobbyCatalogApi,
+  getPlayerGrowthApi,
   getPlayerHobbiesApi,
   getPlayerTitlesApi,
   registerPlayerCertificationApi,
@@ -18,7 +19,7 @@ import {
   setRepresentativeTitleApi,
   updatePlayerHobbyApi,
 } from "./api";
-import { achievementMock, certificationMock, hobbyMock, resetCertificationMock, resetHobbyMock, resetTitleMock, titleMock } from "./mock";
+import { achievementMock, certificationMock, EMPTY_PLAYER_GROWTH, growthMock, hobbyMock, MOCK_PLAYER_GROWTH, resetCertificationMock, resetHobbyMock, resetTitleMock, titleMock } from "./mock";
 
 const client = vi.hoisted(() => ({ apiDelete: vi.fn(), apiGet: vi.fn(), apiPatch: vi.fn(), apiPost: vi.fn() }));
 
@@ -32,6 +33,26 @@ const achievement: PlayerAchievementInfo = {
   descMd: "Completed the first step.",
   acquiredAt: "2026-08-14T00:00:00Z",
 };
+
+describe("Current Player Growth API를 사용할 때", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("envelope-aware client의 exact path와 exact mock shape를 사용한다", async () => {
+    client.apiGet.mockResolvedValue(MOCK_PLAYER_GROWTH);
+
+    expect(await getPlayerGrowthApi()).toEqual(MOCK_PLAYER_GROWTH);
+    expect(client.apiGet).toHaveBeenCalledWith("/api/v1/players/growth");
+    expect(client.apiGet.mock.calls.flat().join(" ")).not.toMatch(/playerId|userId|\/players\/me\/growth/);
+
+    const mock = growthMock.overview();
+    expect(mock).toEqual(MOCK_PLAYER_GROWTH satisfies PlayerGrowthOverview);
+    expect(mock.recentExpChanges).toHaveLength(2);
+    expect(mock.recentExpChanges[0]).toMatchObject({ beforeLevel: 77, afterLevel: 78, requestedExp: 500, appliedExp: 400, leftoverExp: 100 });
+    expect(mock.recentExpChanges[1]).toMatchObject({ sourceType: null, sourceId: null });
+    expect(EMPTY_PLAYER_GROWTH.recentExpChanges).toEqual([]);
+    expect(mock.current).not.toHaveProperty("nextLevelExp");
+  });
+});
 
 describe("Current Player Achievement API를 사용할 때", () => {
   beforeEach(() => vi.clearAllMocks());

--- a/features/player/api.ts
+++ b/features/player/api.ts
@@ -6,13 +6,14 @@ import type {
   PlayerHobbyInfo,
   PlayerHobbyMutationRequest,
   PlayerHobbyMutationResult,
+  PlayerGrowthOverview,
   PlayerAchievementInfo,
   PlayerCertificationDatesRequest,
   PlayerCertificationInfo,
   PlayerCertificationMutationResult,
   PlayerTitleInfo,
 } from "@/shared/api/types";
-import { achievementMock, certificationMock, hobbyMock, titleMock } from "./mock";
+import { achievementMock, certificationMock, growthMock, hobbyMock, titleMock } from "./mock";
 
 export type RegisterPlayerRequest = { name: string; gender: string };
 export type CreatedPlayerWithToken = {
@@ -27,6 +28,10 @@ export async function registerPlayerApi(body: RegisterPlayerRequest): Promise<Cr
     return { id, accessToken: `mock-player-access-${id}`, refreshToken: `mock-player-refresh-${id}` };
   }
   return apiPost<CreatedPlayerWithToken>("/api/v1/players/register", body);
+}
+
+export function getPlayerGrowthApi(): Promise<PlayerGrowthOverview> {
+  return USE_MOCK ? Promise.resolve(growthMock.overview()) : apiGet<PlayerGrowthOverview>("/api/v1/players/growth");
 }
 
 export async function getPlayerAchievementsApi(): Promise<PlayerAchievementInfo[]> {

--- a/features/player/mock.ts
+++ b/features/player/mock.ts
@@ -9,9 +9,34 @@ import type {
   PlayerHobbyInfo,
   PlayerHobbyMutationRequest,
   PlayerHobbyMutationResult,
+  PlayerGrowthOverview,
   PlayerInfo,
   PlayerTitleInfo,
 } from "@/shared/api/types";
+
+export const MOCK_PLAYER_GROWTH = {
+  current: {
+    level: 78,
+    exp: 7842,
+    str: 342,
+    agi: 287,
+    dex: 256,
+    intel: 145,
+    vit: 310,
+    luc: 89,
+    extraStats: { "Critical Rate": 24, "Movement Speed": 112 },
+    representativeTitleId: 1,
+  },
+  recentExpChanges: [
+    { changeId: 52, requestedExp: 500, appliedExp: 400, leftoverExp: 100, beforeLevel: 77, afterLevel: 78, beforeTotalExp: 77442, afterTotalExp: 77842, occurredAt: "2026-08-14T09:00:00Z", sourceType: "QUEST", sourceId: 31 },
+    { changeId: 51, requestedExp: 150, appliedExp: 150, leftoverExp: 0, beforeLevel: 77, afterLevel: 77, beforeTotalExp: 77292, afterTotalExp: 77442, occurredAt: "2026-08-13T09:00:00Z", sourceType: null, sourceId: null },
+  ],
+} satisfies PlayerGrowthOverview;
+
+export const EMPTY_PLAYER_GROWTH = {
+  ...MOCK_PLAYER_GROWTH,
+  recentExpChanges: [],
+} satisfies PlayerGrowthOverview;
 
 export const MOCK_CHARACTER_SHEET: CharacterSheet = {
   player: {
@@ -124,6 +149,10 @@ export const MOCK_ACHIEVEMENTS: PlayerAchievementInfo[] = [
 function copy<T>(value: T): T {
   return structuredClone(value);
 }
+
+export const growthMock = {
+  overview: (): PlayerGrowthOverview => copy(MOCK_PLAYER_GROWTH),
+};
 
 export const achievementMock = {
   list: (): PlayerAchievementInfo[] => copy(MOCK_ACHIEVEMENTS),

--- a/features/player/useGrowthQuery.test.tsx
+++ b/features/player/useGrowthQuery.test.tsx
@@ -1,0 +1,28 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { EMPTY_PLAYER_GROWTH, MOCK_PLAYER_GROWTH } from "./mock";
+import { useGrowthQuery } from "./useGrowthQuery";
+
+const api = vi.hoisted(() => ({ getPlayerGrowthApi: vi.fn() }));
+vi.mock("./api", () => api);
+
+describe("Current Player Growth read state를 관리할 때", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("initial load와 error/retry를 feature state 안에서 유지한다", async () => {
+    api.getPlayerGrowthApi.mockResolvedValueOnce(MOCK_PLAYER_GROWTH);
+    const first = renderHook(() => useGrowthQuery());
+    await waitFor(() => expect(first.result.current.data).toEqual(MOCK_PLAYER_GROWTH));
+    expect(first.result.current.error).toBeNull();
+    first.unmount();
+
+    api.getPlayerGrowthApi.mockRejectedValueOnce(new Error("growth failed")).mockResolvedValueOnce(EMPTY_PLAYER_GROWTH);
+    const retry = renderHook(() => useGrowthQuery());
+    await waitFor(() => expect(retry.result.current.error).toBe("growth failed"));
+    await act(async () => { await retry.result.current.retry(); });
+    expect(retry.result.current.data).toEqual(EMPTY_PLAYER_GROWTH);
+    expect(retry.result.current.loading).toBe(false);
+    expect(retry.result.current.error).toBeNull();
+  });
+});

--- a/features/player/useGrowthQuery.ts
+++ b/features/player/useGrowthQuery.ts
@@ -1,0 +1,31 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+import type { PlayerGrowthOverview } from "@/shared/api/types";
+import { getPlayerGrowthApi } from "./api";
+
+export function useGrowthQuery() {
+  const [data, setData] = useState<PlayerGrowthOverview | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const retry = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const next = await getPlayerGrowthApi();
+      setData(next);
+      return next;
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "Unable to load Growth.");
+      return undefined;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { void retry(); }, [retry]);
+
+  return { data, loading, error, retry };
+}

--- a/shared/api/types/character.ts
+++ b/shared/api/types/character.ts
@@ -120,3 +120,31 @@ export interface PlayerTitleInfo {
   descMd: string;
   acquiredAt: string;
 }
+
+export interface PlayerGrowthOverview {
+  current: {
+    level: number;
+    exp: number;
+    str: number;
+    agi: number;
+    dex: number;
+    intel: number;
+    vit: number;
+    luc: number;
+    extraStats: Record<string, number>;
+    representativeTitleId: number | null;
+  };
+  recentExpChanges: Array<{
+    changeId: number;
+    requestedExp: number;
+    appliedExp: number;
+    leftoverExp: number;
+    beforeLevel: number;
+    afterLevel: number;
+    beforeTotalExp: number;
+    afterTotalExp: number;
+    occurredAt: string;
+    sourceType: string | null;
+    sourceId: number | null;
+  }>;
+}


### PR DESCRIPTION
### Purpose

Add a real Player Growth surface backed by the canonical Current Player Growth read model.

Closes #34

### Delivered

- Growth Player submenu
- real `/api/v1/players/growth`
- current level and EXP
- six canonical stats
- dynamic extra stats
- bounded recent EXP history
- nullable source metadata
- feature-owned loading/error/retry
- backend-parity Growth mock
- focused routing/contract coverage

### Growth Semantics

The UI preserves:

```text
requestedExp
appliedExp
leftoverExp
before/after level
before/after total EXP
occurredAt
nullable sourceType/sourceId
```

### No Fabricated Formula

The backend does not expose next-level required EXP.

This PR does not invent:

```text
next-level threshold
level percentage
progress denominator
```

### Ownership

Current Player identity remains authentication-owned.

No player/user identity is sent.

### Scope

No:

- Growth mutation
- stat allocation
- Role stat radar
- source entity enrichment
- history pagination beyond backend recent 20
- Skill redesign

### Validation

Focused coverage verifies the exact transport, Growth routing, canonical stat/EXP rendering, nullable source metadata, and absence of fabricated level-threshold semantics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a **Growth** section to the player menu.
  * Added a growth overview displaying level, experience, core and additional stats.
  * Added recent experience history with levels, amounts, timestamps, and sources.
  * Added loading, empty-state, error, and retry handling for growth data.
* **Bug Fixes**
  * Unsupported projections and unavailable sources are now excluded from growth history.
  * Growth data is fetched only once during initial loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->