### PR TITLE
[System] Align Current User Settings with canonical PATCH contract

### DIFF
--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -68,6 +68,7 @@ vi.mock("@/shared/ui/AmbientOverlay", () => ({ default: () => null }));
 vi.mock("@/shared/ui/SaoAlert", () => ({ default: () => null }));
 vi.mock("@/shared/ui/NotificationBell", () => ({ NotificationBell: () => null }));
 vi.mock("@/features/social/ConnectionsDrawer", () => ({ default: () => <div data-testid="connections-utility" /> }));
+vi.mock("@/features/system/settings/SettingsShell", () => ({ default: () => <div data-testid="settings-shell">Canonical Settings</div> }));
 
 describe("Home shell에서 feature surface를 routing할 때", () => {
   beforeEach(() => {
@@ -246,6 +247,16 @@ describe("Home shell에서 feature surface를 routing할 때", () => {
       fireEvent.click(screen.getByRole("button", { name: "Gear" }));
       expect(screen.queryByTestId("inventory-shell")).not.toBeInTheDocument();
       expect(screen.getByTestId("gear-shell")).toBeInTheDocument();
+    });
+  });
+
+  describe("인증된 user가 System Options를 선택하면", () => {
+    it("page-owned form 대신 feature-owned Settings shell로 routing한다", () => {
+      render(<Home />);
+      fireEvent.click(screen.getByRole("button", { name: "System" }));
+      fireEvent.click(screen.getByRole("button", { name: "Options" }));
+
+      expect(screen.getByTestId("settings-shell")).toHaveTextContent("Canonical Settings");
     });
   });
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -25,6 +25,7 @@ import TitleShell from "@/features/player/TitleShell";
 import HobbyShell from "@/features/player/HobbyShell";
 import GrowthShell from "@/features/player/GrowthShell";
 import ConnectionsDrawer from "@/features/social/ConnectionsDrawer";
+import SettingsShell from "@/features/system/settings/SettingsShell";
 import { useRoles } from "@/features/role/useRoles";
 import { usePanScroll } from "@/shared/hooks/usePanScroll";
 import { MOCK_CHARACTER_SHEET } from "@/features/player/mock";
@@ -57,9 +58,7 @@ import {
   MARKET_WALLET_SUMMARY_LIST,
 } from "@/features/market/model";
 import { SKILLS_LISTS } from "@/features/skills/model";
-import { SYSTEM_PANEL_ROWS, SYSTEM_OPTIONS_FORM_FIELDS } from "@/features/system/model";
-import { getSettingsApi, updateSettingsApi } from "@/lib/api/endpoints/settings.api";
-import type { GameSettings } from "@/shared/api/types";
+import { SYSTEM_PANEL_ROWS } from "@/features/system/model";
 import { bringToFrontStable } from "@/shared/lib/reorder";
 import { UI_CONSTS } from "@/shared/lib/uiConsts";
 import { useToast } from "@/context/ToastContext";
@@ -121,8 +120,6 @@ function buildPanels(
   selectedSubByMain: Record<MainNavId, string | null>,
   selectedMarketShopSectionId: string | null,
   selectedDetailByKey: Record<DetailSelectionKey, string | null>,
-  editingItemId: string | null,
-  hasActiveForm: boolean,
 ): { panelStack: PanelStackItem[]; socialContext: SocialContextData | null } {
   const mainItems = SUBMENUS_BY_MAIN[selectedMain];
   const selectedMainSub = selectedSubForMain(selectedMain, selectedSubByMain);
@@ -359,15 +356,6 @@ function buildPanels(
   const systemPanel = SYSTEM_PANEL_ROWS[selectedMainSub as keyof typeof SYSTEM_PANEL_ROWS];
 
   if (selectedMainSub === "options") {
-    if (hasActiveForm) return { panelStack, socialContext: null };
-    panelStack.push({
-      id: "system-options-placeholder",
-      kind: "placeholder",
-      title: "Options",
-      description: systemPanel?.description ?? "Game settings and preferences.",
-      rows: systemPanel?.rows ?? [],
-      primaryActionLabel: "설정 편집",
-    });
     return { panelStack, socialContext: null };
   }
 
@@ -453,8 +441,6 @@ export default function Home() {
         selectedSubByMain,
         selectedMarketShopSectionId,
         selectedDetailByKey,
-        editingItemId,
-        Boolean(activeFormPanel),
       )
       : { panelStack: [], socialContext: null },
     [
@@ -462,8 +448,6 @@ export default function Home() {
       selectedSubByMain,
       selectedMarketShopSectionId,
       selectedDetailByKey,
-      editingItemId,
-      activeFormPanel,
     ],
   );
 
@@ -611,33 +595,6 @@ export default function Home() {
     const panel = basePanelStack[panelIndex];
     if (!panel) return;
 
-    // Placeholder primary action — system options edit button
-    if (panel.kind === "placeholder" && panel.id === "system-options-placeholder") {
-      getSettingsApi().then((settings) => {
-        const p = settings.parsed;
-        openForm(
-          "system-options",
-          "System Options",
-          SYSTEM_OPTIONS_FORM_FIELDS,
-          "설정 저장",
-          {
-            volume: String(p.volume ?? 78),
-            graphicsQuality: p.graphicsQuality ?? "HIGH",
-            voiceChat: p.voiceChat ?? "TEAM_ONLY",
-            uiScale: String(p.uiScale ?? 100),
-            inputPreset: p.inputPreset ?? "STANDARD",
-            showDamageNumbers: String(p.showDamageNumbers ?? true),
-            showParticles: String(p.showParticles ?? true),
-            showOnlineStatus: String(p.showOnlineStatus ?? true),
-            notifications: String(p.notifications ?? true),
-            emailAlerts: String(p.emailAlerts ?? false),
-            language: p.language ?? "ko",
-          },
-        );
-      });
-      return;
-    }
-
     if (panel.kind !== "list") return;
     const route = panel.context.route;
     const sub = selectedSubByMain[panel.context.main];
@@ -750,29 +707,6 @@ export default function Home() {
 
   // Called when form panel submit is confirmed
   const handlePanelFormSubmit = (formKey: string, values: Record<string, string>) => {
-    if (formKey === "system-options") {
-      const settings: Partial<GameSettings> = {
-        volume: Number(values.volume),
-        graphicsQuality: values.graphicsQuality as GameSettings["graphicsQuality"],
-        voiceChat: values.voiceChat as GameSettings["voiceChat"],
-        uiScale: Number(values.uiScale) as GameSettings["uiScale"],
-        inputPreset: values.inputPreset as GameSettings["inputPreset"],
-        showDamageNumbers: values.showDamageNumbers === "true",
-        showParticles: values.showParticles === "true",
-        showOnlineStatus: values.showOnlineStatus === "true",
-        notifications: values.notifications === "true",
-        emailAlerts: values.emailAlerts === "true",
-        language: values.language,
-      };
-      updateSettingsApi(settings).then(() => {
-        showToast({ variant: "success", title: "설정 저장됨", body: "System options updated." });
-      }).catch(() => {
-        showToast({ variant: "error", title: "저장 실패", body: "다시 시도해주세요." });
-      });
-      setActiveFormPanel(null);
-      return;
-    }
-
     if (formKey === "listing-create") {
       const itemInstanceId = Number(values._itemInstanceId);
       const itemId = Number(values._itemId);
@@ -1008,6 +942,11 @@ export default function Home() {
             <div className="flex w-fit items-center gap-3">
               <RightPanels selectedMain="lifelog" panelStack={panelStack.slice(0, 1)} panelStackKey="lifelog-media-menu" onPanelItemSelect={handlePanelItemSelect} />
               <MediaShell />
+            </div>
+          ) : selectedMain === "system" && selectedSubByMain.system === "options" ? (
+            <div className="flex w-fit items-center gap-3">
+              <RightPanels selectedMain="system" panelStack={panelStack.slice(0, 1)} panelStackKey="system-settings-menu" onPanelItemSelect={handlePanelItemSelect} />
+              <SettingsShell />
             </div>
           ) : (
             <RightPanels

--- a/features/system/model.ts
+++ b/features/system/model.ts
@@ -6,13 +6,7 @@ export const SYSTEM_PANEL_ROWS: Record<Exclude<SystemSubId, "logout">, {
 }> = {
   options: {
     description: "Graphics, audio, controls, and gameplay preferences.",
-    rows: [
-      "Master Volume: 78%",
-      "Graphics Quality: High",
-      "Voice Chat: Team Only",
-      "UI Scale: 100%",
-      "Input Preset: Standard",
-    ],
+    rows: [],
   },
   help: {
     description: "Quick guides, FAQ, and support routes.",
@@ -57,8 +51,8 @@ export const SYSTEM_OPTIONS_FORM_FIELDS: FormFieldSpec[] = [
   {
     key: "uiScale",
     label: "UI Scale (%)",
-    type: "number",
-    placeholder: "75 ~ 150",
+    type: "select",
+    options: [75, 100, 125, 150].map((value) => ({ value: String(value), label: `${value}%` })),
   },
   {
     key: "inputPreset",

--- a/features/system/settings/SettingsShell.test.tsx
+++ b/features/system/settings/SettingsShell.test.tsx
@@ -1,0 +1,42 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { UserSettingsResponse } from "@/shared/api/types";
+import SettingsShell from "./SettingsShell";
+
+const api = vi.hoisted(() => ({ getSettingsApi: vi.fn(), updateSettingsApi: vi.fn() }));
+const toast = vi.hoisted(() => ({ showToast: vi.fn() }));
+vi.mock("@/lib/api/endpoints/settings.api", () => api);
+vi.mock("@/context/ToastContext", () => ({ useToast: () => toast }));
+
+const canonical: UserSettingsResponse = {
+  userId: 7,
+  volume: 70,
+  uiLayoutJson: "layout",
+  flagsJson: JSON.stringify({ graphicsQuality: "HIGH", inputPreset: "ADVANCED", uiScale: 125 }),
+  updatedAt: "2026-08-18T00:00:00Z",
+};
+
+describe("System Options surface save timing", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api.getSettingsApi.mockResolvedValue(canonical);
+  });
+
+  it("keeps the failed draft open and closes only after a successful canonical response", async () => {
+    api.updateSettingsApi.mockRejectedValueOnce(new Error("save failed")).mockResolvedValueOnce({ ...canonical, volume: 25 });
+    render(<SettingsShell />);
+    expect(await screen.findByText("Master Volume: 70%")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "설정 편집" }));
+    fireEvent.change(screen.getByRole("spinbutton", { name: "Master Volume" }), { target: { value: "25" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save Settings" }));
+
+    expect(await screen.findByText("save failed")).toBeInTheDocument();
+    expect(screen.getByRole("spinbutton", { name: "Master Volume" })).toHaveValue(25);
+
+    fireEvent.click(screen.getByRole("button", { name: "Save Settings" }));
+    await waitFor(() => expect(screen.queryByRole("spinbutton", { name: "Master Volume" })).not.toBeInTheDocument());
+    expect(screen.getByText("Master Volume: 25%")).toBeInTheDocument();
+    expect(toast.showToast).toHaveBeenCalledTimes(1);
+  });
+});

--- a/features/system/settings/SettingsShell.tsx
+++ b/features/system/settings/SettingsShell.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { useState } from "react";
+
+import { useToast } from "@/context/ToastContext";
+import type { GraphicsQuality, InputPreset, SettingsView, UiScale, VoiceChatMode } from "@/shared/api/types";
+import { INPUT_STYLE, SAO } from "@/shared/design/tokens";
+import { PanelFrame } from "@/widgets/right-panels/ui/PanelFrame";
+import { GoldRow, InfoCard } from "@/widgets/right-panels/ui/Rows";
+import { actionBtnStyle } from "@/widgets/right-panels/ui/styles";
+import { SYSTEM_OPTIONS_FORM_FIELDS } from "../model";
+import { useSettings } from "./useSettings";
+
+const secondaryButton = {
+  border: `1px solid ${SAO.color.border.panel}`,
+  background: SAO.color.bg.inset,
+  color: SAO.color.text.secondary,
+  borderRadius: SAO.radius.panel,
+  padding: "7px 10px",
+  fontSize: "0.68rem",
+  letterSpacing: "0.08em",
+} as const;
+
+const fieldLabel = {
+  display: "block",
+  fontSize: "0.62rem",
+  letterSpacing: "0.14em",
+  color: SAO.color.text.label,
+  textTransform: "uppercase",
+} as const;
+
+const UI_SCALES = [75, 100, 125, 150] as const;
+const isUiScale = (value: number): value is UiScale => UI_SCALES.some((scale) => scale === value);
+const isGraphicsQuality = (value: string): value is GraphicsQuality => ["LOW", "MEDIUM", "HIGH", "ULTRA"].includes(value);
+const isVoiceChat = (value: string): value is VoiceChatMode => ["OFF", "TEAM_ONLY", "ALL"].includes(value);
+const isInputPreset = (value: string): value is InputPreset => ["STANDARD", "ADVANCED", "CUSTOM"].includes(value);
+
+function summaryRows(settings: SettingsView) {
+  return [
+    `Master Volume: ${settings.volume}%`,
+    `Graphics Quality: ${settings.graphicsQuality}`,
+    `Voice Chat: ${settings.voiceChat}`,
+    `UI Scale: ${settings.uiScale}%`,
+    `Input Preset: ${settings.inputPreset}`,
+    `Damage Numbers: ${settings.showDamageNumbers ? "On" : "Off"}`,
+    `Particle Effects: ${settings.showParticles ? "On" : "Off"}`,
+    `Show Online Status: ${settings.showOnlineStatus ? "On" : "Off"}`,
+    `Notifications: ${settings.notifications ? "On" : "Off"}`,
+    `Email Alerts: ${settings.emailAlerts ? "On" : "Off"}`,
+    `Language: ${settings.language}`,
+  ];
+}
+
+export default function SettingsShell() {
+  const settings = useSettings();
+  const { showToast } = useToast();
+  const [editing, setEditing] = useState(false);
+  const draft = settings.draft;
+
+  const change = (key: string, value: string) => {
+    if (key === "volume") return settings.updateDraft({ volume: Number(value) });
+    if (key === "uiScale") {
+      const scale = Number(value);
+      if (isUiScale(scale)) settings.updateDraft({ uiScale: scale });
+      return;
+    }
+    if (key === "graphicsQuality" && isGraphicsQuality(value)) return settings.updateDraft({ graphicsQuality: value });
+    if (key === "voiceChat" && isVoiceChat(value)) return settings.updateDraft({ voiceChat: value });
+    if (key === "inputPreset" && isInputPreset(value)) return settings.updateDraft({ inputPreset: value });
+    if (key === "showDamageNumbers") return settings.updateDraft({ showDamageNumbers: value === "true" });
+    if (key === "showParticles") return settings.updateDraft({ showParticles: value === "true" });
+    if (key === "showOnlineStatus") return settings.updateDraft({ showOnlineStatus: value === "true" });
+    if (key === "notifications") return settings.updateDraft({ notifications: value === "true" });
+    if (key === "emailAlerts") return settings.updateDraft({ emailAlerts: value === "true" });
+    if (key === "language") settings.updateDraft({ language: value });
+  };
+
+  const submit = async (event: React.SubmitEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (await settings.save()) {
+      setEditing(false);
+      showToast({ variant: "success", title: "설정 저장됨", body: "System options updated." });
+    }
+  };
+
+  return (
+    <PanelFrame title="System Options" depth={1}>
+      <div className="space-y-3 px-3" data-testid="settings-shell">
+        {settings.loading && !settings.canonical ? <InfoCard>Loading Settings...</InfoCard> : null}
+        {settings.error ? (
+          <div className="space-y-2">
+            <p role="alert" className="text-xs" style={{ color: SAO.color.action.red }}>{settings.error}</p>
+            <button type="button" style={secondaryButton} onClick={() => void settings.retry()}>Retry</button>
+          </div>
+        ) : null}
+
+        {!settings.error && settings.canonical && !editing ? (
+          <>
+            <InfoCard>Graphics, audio, controls, and gameplay preferences.</InfoCard>
+            <div className="space-y-1.5">
+              {summaryRows(settings.canonical.view).map((row) => <GoldRow key={row}>{row}</GoldRow>)}
+            </div>
+            <button type="button" style={actionBtnStyle} onClick={() => setEditing(true)}>설정 편집</button>
+          </>
+        ) : null}
+
+        {!settings.error && editing && draft ? (
+          <form className="space-y-3" onSubmit={submit}>
+            {SYSTEM_OPTIONS_FORM_FIELDS.map((field) => (
+              <label key={field.key} style={fieldLabel}>
+                {field.label}
+                {field.type === "select" ? (
+                  <select title={field.label} value={String(draft[field.key as keyof SettingsView])} onChange={(event) => change(field.key, event.target.value)} style={INPUT_STYLE}>
+                    {field.options?.map((option) => <option key={option.value} value={option.value}>{option.label}</option>)}
+                  </select>
+                ) : (
+                  <input
+                    aria-label={field.label}
+                    type="number"
+                    min={0}
+                    max={100}
+                    step={1}
+                    value={draft.volume}
+                    onChange={(event) => change(field.key, event.target.value)}
+                    style={INPUT_STYLE}
+                  />
+                )}
+              </label>
+            ))}
+            {settings.saveError ? <p role="alert" className="text-xs" style={{ color: SAO.color.action.red }}>{settings.saveError}</p> : null}
+            <div className="flex gap-2">
+              <button type="submit" disabled={!settings.dirty || settings.saving} style={{ ...actionBtnStyle, flex: 1 }}>{settings.saving ? "Saving..." : "Save Settings"}</button>
+              <button type="button" disabled={settings.saving} style={secondaryButton} onClick={() => { settings.cancel(); setEditing(false); }}>Cancel</button>
+            </div>
+          </form>
+        ) : null}
+      </div>
+    </PanelFrame>
+  );
+}

--- a/features/system/settings/model.test.ts
+++ b/features/system/settings/model.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import type { UserSettingsResponse } from "@/shared/api/types";
+import { SYSTEM_OPTIONS_FORM_FIELDS } from "../model";
+import { buildSettingsPatch, parseUserSettings, SettingsParseError } from "./model";
+
+const transport = (flagsJson: string | null): UserSettingsResponse => ({
+  userId: 7,
+  volume: 72,
+  uiLayoutJson: JSON.stringify({ untouched: true }),
+  flagsJson,
+  updatedAt: "2026-08-18T00:00:00Z",
+});
+
+describe("Settings flags parser and merger", () => {
+  it("defaults only missing known flags and preserves unknown keys without duplicating volume", () => {
+    const canonical = parseUserSettings(transport(JSON.stringify({
+      inputPreset: "ADVANCED",
+      uiScale: 125,
+      futureFlag: { enabled: true },
+      volume: 12,
+    })));
+    const request = buildSettingsPatch(canonical, { ...canonical.view, volume: 44, graphicsQuality: "LOW" });
+    const flags = JSON.parse(request.flagsJson!);
+
+    expect(canonical.view).toEqual(expect.objectContaining({ volume: 72, inputPreset: "ADVANCED", uiScale: 125, voiceChat: "TEAM_ONLY" }));
+    expect(request).not.toHaveProperty("uiLayoutJson");
+    expect(request.volume).toBe(44);
+    expect(flags).toEqual(expect.objectContaining({ futureFlag: { enabled: true }, graphicsQuality: "LOW", inputPreset: "ADVANCED" }));
+    expect(flags).not.toHaveProperty("volume");
+  });
+
+  it("accepts null as empty flags but rejects malformed and non-object flags", () => {
+    expect(parseUserSettings(transport(null)).view.uiScale).toBe(100);
+    expect(() => parseUserSettings(transport("{"))).toThrow(SettingsParseError);
+    expect(() => parseUserSettings(transport("[]"))).toThrow(SettingsParseError);
+    expect(() => parseUserSettings(transport("null"))).toThrow(SettingsParseError);
+  });
+
+  it("offers only canonical UI scales and includes Advanced input", () => {
+    expect(SYSTEM_OPTIONS_FORM_FIELDS.find(({ key }) => key === "uiScale")?.options?.map(({ value }) => value)).toEqual(["75", "100", "125", "150"]);
+    expect(SYSTEM_OPTIONS_FORM_FIELDS.find(({ key }) => key === "inputPreset")?.options?.map(({ value }) => value)).toContain("ADVANCED");
+  });
+});

--- a/features/system/settings/model.ts
+++ b/features/system/settings/model.ts
@@ -1,0 +1,87 @@
+import type {
+  GraphicsQuality,
+  InputPreset,
+  ParsedUserSettings,
+  SettingsFlags,
+  SettingsView,
+  UiScale,
+  UpdateUserSettingsRequest,
+  UserSettingsResponse,
+  VoiceChatMode,
+} from "@/shared/api/types";
+
+export const DEFAULT_SETTINGS_FLAGS: SettingsFlags = {
+  graphicsQuality: "HIGH",
+  voiceChat: "TEAM_ONLY",
+  uiScale: 100,
+  inputPreset: "STANDARD",
+  showDamageNumbers: true,
+  showParticles: true,
+  showOnlineStatus: true,
+  notifications: true,
+  emailAlerts: false,
+  language: "ko",
+};
+
+const GRAPHICS_QUALITIES: GraphicsQuality[] = ["LOW", "MEDIUM", "HIGH", "ULTRA"];
+const VOICE_CHAT_MODES: VoiceChatMode[] = ["OFF", "TEAM_ONLY", "ALL"];
+const UI_SCALES: UiScale[] = [75, 100, 125, 150];
+const INPUT_PRESETS: InputPreset[] = ["STANDARD", "ADVANCED", "CUSTOM"];
+
+export class SettingsParseError extends Error {
+  constructor(message = "Settings flags are invalid and cannot be edited safely.") {
+    super(message);
+    this.name = "SettingsParseError";
+  }
+}
+
+function enumValue<T extends string | number>(raw: unknown, fallback: T, allowed: T[]): T {
+  if (raw === undefined) return fallback;
+  if (allowed.includes(raw as T)) return raw as T;
+  throw new SettingsParseError();
+}
+
+function booleanValue(raw: unknown, fallback: boolean): boolean {
+  if (raw === undefined) return fallback;
+  if (typeof raw === "boolean") return raw;
+  throw new SettingsParseError();
+}
+
+function stringValue(raw: unknown, fallback: string): string {
+  if (raw === undefined) return fallback;
+  if (typeof raw === "string") return raw;
+  throw new SettingsParseError();
+}
+
+export function parseUserSettings(transport: UserSettingsResponse): ParsedUserSettings {
+  let parsed: unknown = {};
+  try {
+    parsed = transport.flagsJson === null ? {} : JSON.parse(transport.flagsJson);
+  } catch {
+    throw new SettingsParseError();
+  }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) throw new SettingsParseError();
+  if (!Number.isInteger(transport.volume) || transport.volume < 0 || transport.volume > 100) throw new SettingsParseError("Settings volume is invalid.");
+
+  const rawFlags = parsed as Record<string, unknown>;
+  const view: SettingsView = {
+    volume: transport.volume,
+    graphicsQuality: enumValue(rawFlags.graphicsQuality, DEFAULT_SETTINGS_FLAGS.graphicsQuality, GRAPHICS_QUALITIES),
+    voiceChat: enumValue(rawFlags.voiceChat, DEFAULT_SETTINGS_FLAGS.voiceChat, VOICE_CHAT_MODES),
+    uiScale: enumValue(rawFlags.uiScale, DEFAULT_SETTINGS_FLAGS.uiScale, UI_SCALES),
+    inputPreset: enumValue(rawFlags.inputPreset, DEFAULT_SETTINGS_FLAGS.inputPreset, INPUT_PRESETS),
+    showDamageNumbers: booleanValue(rawFlags.showDamageNumbers, DEFAULT_SETTINGS_FLAGS.showDamageNumbers),
+    showParticles: booleanValue(rawFlags.showParticles, DEFAULT_SETTINGS_FLAGS.showParticles),
+    showOnlineStatus: booleanValue(rawFlags.showOnlineStatus, DEFAULT_SETTINGS_FLAGS.showOnlineStatus),
+    notifications: booleanValue(rawFlags.notifications, DEFAULT_SETTINGS_FLAGS.notifications),
+    emailAlerts: booleanValue(rawFlags.emailAlerts, DEFAULT_SETTINGS_FLAGS.emailAlerts),
+    language: stringValue(rawFlags.language, DEFAULT_SETTINGS_FLAGS.language),
+  };
+  return { transport, rawFlags, view };
+}
+
+export function buildSettingsPatch(canonical: ParsedUserSettings, draft: SettingsView): UpdateUserSettingsRequest {
+  const flagsJson = { ...canonical.rawFlags, ...draft } as Record<string, unknown>;
+  delete flagsJson.volume;
+  return { volume: draft.volume, flagsJson: JSON.stringify(flagsJson) };
+}

--- a/features/system/settings/useSettings.test.tsx
+++ b/features/system/settings/useSettings.test.tsx
@@ -1,0 +1,74 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { UserSettingsResponse } from "@/shared/api/types";
+import { useSettings } from "./useSettings";
+
+const api = vi.hoisted(() => ({ getSettingsApi: vi.fn(), updateSettingsApi: vi.fn() }));
+vi.mock("@/lib/api/endpoints/settings.api", () => api);
+
+const response = (overrides: Partial<UserSettingsResponse> = {}): UserSettingsResponse => ({
+  userId: 7,
+  volume: 70,
+  uiLayoutJson: "layout-owned-elsewhere",
+  flagsJson: JSON.stringify({ graphicsQuality: "HIGH", futureFlag: "preserve" }),
+  updatedAt: "2026-08-18T00:00:00Z",
+  ...overrides,
+});
+
+describe("feature-owned Settings state", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api.getSettingsApi.mockResolvedValue(response());
+  });
+
+  it("protects invalid flags, exposes retry, and never PATCHes without safe canonical state", async () => {
+    api.getSettingsApi.mockResolvedValueOnce(response({ flagsJson: "[]" })).mockResolvedValueOnce(response());
+    const { result } = renderHook(() => useSettings());
+    await waitFor(() => expect(result.current.error).toMatch(/cannot be edited safely/i));
+
+    await act(async () => { expect(await result.current.save()).toBe(false); });
+    expect(api.updateSettingsApi).not.toHaveBeenCalled();
+
+    await act(async () => { await result.current.retry(); });
+    expect(result.current.canonical?.view.volume).toBe(70);
+    expect(result.current.draft).toEqual(result.current.canonical?.view);
+  });
+
+  it("uses the successful response as canonical and clears dirty state", async () => {
+    api.updateSettingsApi.mockResolvedValue(response({
+      volume: 66,
+      flagsJson: JSON.stringify({ graphicsQuality: "LOW", futureFlag: "preserve", serverFlag: true }),
+      updatedAt: "2026-08-18T01:00:00Z",
+    }));
+    const { result } = renderHook(() => useSettings());
+    await waitFor(() => expect(result.current.canonical).not.toBeNull());
+    act(() => result.current.updateDraft({ volume: 65, graphicsQuality: "LOW" }));
+
+    await act(async () => { expect(await result.current.save()).toBe(true); });
+
+    expect(result.current.canonical?.view.volume).toBe(66);
+    expect(result.current.canonical?.rawFlags.serverFlag).toBe(true);
+    expect(result.current.draft).toEqual(result.current.canonical?.view);
+    expect(result.current.dirty).toBe(false);
+    const request = api.updateSettingsApi.mock.calls[0][0];
+    expect(request).not.toHaveProperty("uiLayoutJson");
+    expect(JSON.parse(request.flagsJson)).not.toHaveProperty("volume");
+  });
+
+  it("keeps the previous canonical state and edited draft after save failure, then cancel restores canonical", async () => {
+    api.updateSettingsApi.mockRejectedValue(new Error("save failed"));
+    const { result } = renderHook(() => useSettings());
+    await waitFor(() => expect(result.current.canonical).not.toBeNull());
+    act(() => result.current.updateDraft({ volume: 25 }));
+
+    await act(async () => { expect(await result.current.save()).toBe(false); });
+    expect(result.current.canonical?.view.volume).toBe(70);
+    expect(result.current.draft?.volume).toBe(25);
+    expect(result.current.saveError).toBe("save failed");
+
+    act(() => result.current.cancel());
+    expect(result.current.draft?.volume).toBe(70);
+    expect(result.current.saveError).toBeNull();
+  });
+});

--- a/features/system/settings/useSettings.ts
+++ b/features/system/settings/useSettings.ts
@@ -1,0 +1,72 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import type { ParsedUserSettings, SettingsView } from "@/shared/api/types";
+import { getSettingsApi, updateSettingsApi } from "@/lib/api/endpoints/settings.api";
+import { buildSettingsPatch, parseUserSettings } from "./model";
+
+const message = (caught: unknown, fallback: string) => caught instanceof Error ? caught.message : fallback;
+
+export function useSettings() {
+  const [canonical, setCanonical] = useState<ParsedUserSettings | null>(null);
+  const [draft, setDraft] = useState<SettingsView | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const saveLocked = useRef(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const parsed = parseUserSettings(await getSettingsApi());
+      setCanonical(parsed);
+      setDraft(parsed.view);
+      setSaveError(null);
+    } catch (caught) {
+      setError(message(caught, "Unable to load Settings."));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { void load(); }, [load]);
+
+  const updateDraft = (changes: Partial<SettingsView>) => {
+    setDraft((current) => current ? { ...current, ...changes } : current);
+    setSaveError(null);
+  };
+
+  const cancel = () => {
+    setDraft(canonical?.view ?? null);
+    setSaveError(null);
+  };
+
+  const save = async () => {
+    if (!canonical || !draft || saveLocked.current) return false;
+    if (!Number.isInteger(draft.volume) || draft.volume < 0 || draft.volume > 100) {
+      setSaveError("Master Volume must be a whole number from 0 to 100.");
+      return false;
+    }
+    saveLocked.current = true;
+    setSaving(true);
+    setSaveError(null);
+    try {
+      const parsed = parseUserSettings(await updateSettingsApi(buildSettingsPatch(canonical, draft)));
+      setCanonical(parsed);
+      setDraft(parsed.view);
+      return true;
+    } catch (caught) {
+      setSaveError(message(caught, "Unable to save Settings."));
+      return false;
+    } finally {
+      saveLocked.current = false;
+      setSaving(false);
+    }
+  };
+
+  const dirty = Boolean(canonical && draft && JSON.stringify(canonical.view) !== JSON.stringify(draft));
+  return { loading, error, retry: load, canonical, draft, dirty, saving, saveError, updateDraft, save, cancel };
+}

--- a/lib/api/endpoints/settings.api.test.ts
+++ b/lib/api/endpoints/settings.api.test.ts
@@ -1,0 +1,25 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getSettingsApi, updateSettingsApi } from "./settings.api";
+
+const client = vi.hoisted(() => ({ apiGet: vi.fn(), apiPatch: vi.fn(), apiPost: vi.fn() }));
+
+vi.mock("../client", () => ({ USE_MOCK: false, ...client }));
+
+describe("Current User Settings API contract", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    client.apiGet.mockResolvedValue({});
+    client.apiPatch.mockResolvedValue({});
+  });
+
+  it("uses canonical GET and PATCH with the supplied transport body", async () => {
+    const request = { volume: 64, flagsJson: JSON.stringify({ graphicsQuality: "LOW" }) };
+    await getSettingsApi();
+    await updateSettingsApi(request);
+
+    expect(client.apiGet).toHaveBeenCalledWith("/api/v1/users/me/settings");
+    expect(client.apiPatch).toHaveBeenCalledWith("/api/v1/users/me/settings", request);
+    expect(client.apiPost).not.toHaveBeenCalled();
+  });
+});

--- a/lib/api/endpoints/settings.api.ts
+++ b/lib/api/endpoints/settings.api.ts
@@ -1,45 +1,11 @@
-import { USE_MOCK, apiGet, apiPost } from "../client";
-import { MOCK_USER_SETTINGS } from "../mock/settings.mock";
-import type { GameSettings, UserSettingsResponse } from "@/shared/api/types";
+import { USE_MOCK, apiGet, apiPatch } from "../client";
+import { settingsMock } from "../mock/settings.mock";
+import type { UpdateUserSettingsRequest, UserSettingsResponse } from "@/shared/api/types";
 
 export async function getSettingsApi(): Promise<UserSettingsResponse> {
-  if (USE_MOCK) return MOCK_USER_SETTINGS;
-  const raw = await apiGet<{
-    userId: number;
-    volume: number;
-    uiLayoutJson: string | null;
-    flagsJson: string | null;
-    updatedAt: string;
-  }>("/api/v1/users/me/settings");
-  return {
-    ...raw,
-    parsed: raw.flagsJson ? (JSON.parse(raw.flagsJson) as GameSettings) : ({} as GameSettings),
-  };
+  return USE_MOCK ? settingsMock.get() : apiGet<UserSettingsResponse>("/api/v1/users/me/settings");
 }
 
-export async function updateSettingsApi(settings: Partial<GameSettings>): Promise<UserSettingsResponse> {
-  if (USE_MOCK) {
-    const merged = { ...MOCK_USER_SETTINGS.parsed, ...settings };
-    return {
-      ...MOCK_USER_SETTINGS,
-      volume: settings.volume ?? MOCK_USER_SETTINGS.volume,
-      flagsJson: JSON.stringify(merged),
-      parsed: merged,
-      updatedAt: new Date().toISOString(),
-    };
-  }
-  const raw = await apiPost<{
-    userId: number;
-    volume: number;
-    uiLayoutJson: string | null;
-    flagsJson: string | null;
-    updatedAt: string;
-  }>("/api/v1/users/me/settings", {
-    volume: settings.volume,
-    flagsJson: JSON.stringify(settings),
-  });
-  return {
-    ...raw,
-    parsed: raw.flagsJson ? (JSON.parse(raw.flagsJson) as GameSettings) : ({} as GameSettings),
-  };
+export async function updateSettingsApi(request: UpdateUserSettingsRequest): Promise<UserSettingsResponse> {
+  return USE_MOCK ? settingsMock.patch(request) : apiPatch<UserSettingsResponse>("/api/v1/users/me/settings", request);
 }

--- a/lib/api/endpoints/user.api.ts
+++ b/lib/api/endpoints/user.api.ts
@@ -1,20 +1,10 @@
 import { USE_MOCK, apiGet, apiPut } from "../client";
-import { MOCK_USER_INFO, MOCK_USER_SETTINGS } from "../mock/user.mock";
-import type { UserInfo, UserSettings } from "../types";
+import { MOCK_USER_INFO } from "../mock/user.mock";
+import type { UserInfo } from "../types";
 
 export async function getUserInfoApi(): Promise<UserInfo> {
   if (USE_MOCK) return MOCK_USER_INFO;
   return apiGet<UserInfo>("/api/v1/users/me");
-}
-
-export async function getUserSettingsApi(): Promise<UserSettings> {
-  if (USE_MOCK) return MOCK_USER_SETTINGS;
-  return apiGet<UserSettings>("/api/v1/users/me/settings");
-}
-
-export async function updateUserSettingsApi(settings: Partial<UserSettings>): Promise<UserSettings> {
-  if (USE_MOCK) return { ...MOCK_USER_SETTINGS, ...settings };
-  return apiPut<UserSettings>("/api/v1/users/me/settings", settings);
 }
 
 export async function updateNicknameApi(nickname: string): Promise<void> {

--- a/lib/api/mock/settings.mock.test.ts
+++ b/lib/api/mock/settings.mock.test.ts
@@ -1,0 +1,17 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { settingsMock } from "./settings.mock";
+
+describe("mutable Settings mock authority", () => {
+  beforeEach(() => settingsMock.reset());
+
+  it("persists supplied PATCH fields into later GET and preserves omitted or null fields", () => {
+    const before = settingsMock.get();
+    const flagsJson = JSON.stringify({ notifications: false, futureFlag: "kept" });
+    settingsMock.patch({ volume: 31, flagsJson });
+    settingsMock.patch({ volume: null, uiLayoutJson: null });
+    const after = settingsMock.get();
+
+    expect(after).toEqual(expect.objectContaining({ userId: before.userId, volume: 31, flagsJson, uiLayoutJson: before.uiLayoutJson }));
+  });
+});

--- a/lib/api/mock/settings.mock.ts
+++ b/lib/api/mock/settings.mock.ts
@@ -1,24 +1,38 @@
-import type { GameSettings, UserSettingsResponse } from "@/shared/api/types";
+import type { UpdateUserSettingsRequest, UserSettingsResponse } from "@/shared/api/types";
 
-export const DEFAULT_SETTINGS: GameSettings = {
-  volume: 78,
-  graphicsQuality: "HIGH",
-  voiceChat: "TEAM_ONLY",
-  uiScale: 100,
-  inputPreset: "STANDARD",
-  showDamageNumbers: true,
-  showParticles: true,
-  showOnlineStatus: true,
-  notifications: true,
-  emailAlerts: false,
-  language: "ko",
-};
-
-export const MOCK_USER_SETTINGS: UserSettingsResponse = {
+const initialSettings: UserSettingsResponse = {
   userId: 6,
   volume: 78,
-  uiLayoutJson: null,
-  flagsJson: JSON.stringify(DEFAULT_SETTINGS),
+  uiLayoutJson: JSON.stringify({ panel: "classic" }),
+  flagsJson: JSON.stringify({
+    graphicsQuality: "HIGH",
+    voiceChat: "TEAM_ONLY",
+    uiScale: 100,
+    inputPreset: "STANDARD",
+    showDamageNumbers: true,
+    showParticles: true,
+    showOnlineStatus: true,
+    notifications: true,
+    emailAlerts: false,
+    language: "ko",
+    futureFlag: "preserved",
+  }),
   updatedAt: "2026-05-01T12:00:00Z",
-  parsed: DEFAULT_SETTINGS,
+};
+
+let settings = { ...initialSettings };
+
+export const settingsMock = {
+  reset() { settings = { ...initialSettings }; },
+  get(): UserSettingsResponse { return { ...settings }; },
+  patch(request: UpdateUserSettingsRequest): UserSettingsResponse {
+    settings = {
+      ...settings,
+      ...(request.volume == null ? {} : { volume: request.volume }),
+      ...(request.uiLayoutJson == null ? {} : { uiLayoutJson: request.uiLayoutJson }),
+      ...(request.flagsJson == null ? {} : { flagsJson: request.flagsJson }),
+      updatedAt: new Date().toISOString(),
+    };
+    return { ...settings };
+  },
 };

--- a/lib/api/mock/user.mock.ts
+++ b/lib/api/mock/user.mock.ts
@@ -1,4 +1,4 @@
-import type { UserInfo, UserSettings } from "../types";
+import type { UserInfo } from "../types";
 
 export const MOCK_USER_INFO: UserInfo = {
   user: {
@@ -18,15 +18,6 @@ export const MOCK_USER_INFO: UserInfo = {
       pendingRewards: 2,
     },
   },
-};
-
-export const MOCK_USER_SETTINGS: UserSettings = {
-  notifications: true,
-  emailAlerts: false,
-  publicProfile: true,
-  showOnlineStatus: true,
-  language: "ko",
-  uiScale: 100,
 };
 
 export const MOCK_ADMIN_USERS: Array<{

--- a/shared/api/types/settings.ts
+++ b/shared/api/types/settings.ts
@@ -1,10 +1,9 @@
 export type GraphicsQuality = "LOW" | "MEDIUM" | "HIGH" | "ULTRA";
 export type VoiceChatMode = "OFF" | "TEAM_ONLY" | "ALL";
 export type UiScale = 75 | 100 | 125 | 150;
-export type InputPreset = "STANDARD" | "CUSTOM";
+export type InputPreset = "STANDARD" | "ADVANCED" | "CUSTOM";
 
-export interface GameSettings {
-  volume: number;
+export interface SettingsFlags {
   graphicsQuality: GraphicsQuality;
   voiceChat: VoiceChatMode;
   uiScale: UiScale;
@@ -17,11 +16,26 @@ export interface GameSettings {
   language: string;
 }
 
+export interface SettingsView extends SettingsFlags {
+  volume: number;
+}
+
 export interface UserSettingsResponse {
   userId: number;
   volume: number;
   uiLayoutJson: string | null;
   flagsJson: string | null;
   updatedAt: string;
-  parsed: GameSettings;
+}
+
+export interface UpdateUserSettingsRequest {
+  volume?: number | null;
+  uiLayoutJson?: string | null;
+  flagsJson?: string | null;
+}
+
+export interface ParsedUserSettings {
+  transport: UserSettingsResponse;
+  rawFlags: Record<string, unknown>;
+  view: SettingsView;
 }

--- a/shared/api/types/user.ts
+++ b/shared/api/types/user.ts
@@ -10,12 +10,3 @@ export interface UserInfo {
     badges: { notifications: number; pendingRewards: number };
   };
 }
-
-export interface UserSettings {
-  notifications: boolean;
-  emailAlerts: boolean;
-  publicProfile: boolean;
-  showOnlineStatus: boolean;
-  language: string;
-  uiScale: number;
-}


### PR DESCRIPTION
### Purpose

Make System Options a canonical Current User Settings feature backed by the real backend contract.

Closes #40

### Delivered

- real Current User Settings feature ownership
- canonical GET settings
- canonical PATCH settings
- response-authoritative save flow
- top-level volume authority
- forward-compatible flagsJson preservation
- parse-failure protection
- discrete UI-scale contract
- InputPreset type alignment
- mutable Settings mock authority
- focused Settings contract/state coverage

### Canonical API

```text
GET   /api/v1/users/me/settings
PATCH /api/v1/users/me/settings
```

### Identity

Current User identity remains authentication-owned.

No userId/playerId is sent in update requests.

### Settings Semantics

```text
volume
```

is persisted through the dedicated backend field.

`flagsJson` contains Settings flags only and preserves unknown existing keys.

`uiLayoutJson` is not edited by System Options and is preserved by omission.

### State Authority

The successful PATCH response becomes canonical Settings state.

Failed saves preserve the edit draft and previous canonical state.

### Structural Cleanup

Settings query/mutation ownership no longer lives in `app/page.tsx`.

Hard-coded Options rows are no longer treated as server truth.

### Scope

No:

- full visual redesign
- theme system
- graphics-engine implementation
- voice-chat implementation
- notification inbox
- backend changes
- uiLayout editing

### Validation

Focused tests cover GET/PATCH transport, flags preservation, type constraints, retry/save state, and mock persistence.