### PR TITLE
[Notification] Verify real backend contract and future-type fallback

### DIFF
--- a/features/notification/NotificationBell.test.tsx
+++ b/features/notification/NotificationBell.test.tsx
@@ -8,6 +8,7 @@ const state = vi.hoisted(() => ({
   inbox: [
     { id: 2, type: "SYSTEM_NOTICE" as const, title: "Unread", body: "Canonical body", occurredAt: "2026-08-18T12:34:56Z", read: false },
     { id: 1, type: "MAIL_RECEIVED" as const, title: "Read", body: "Older body", occurredAt: "2026-08-17T11:22:33Z", read: true },
+    { id: 0, type: "FUTURE_ANNOUNCEMENT", title: "Future title", body: "Future body", occurredAt: "2026-08-16T10:20:30Z", read: true },
   ],
   inboxLoaded: false,
   inboxLoading: false,
@@ -45,6 +46,9 @@ describe("NotificationBell canonical surface", () => {
     expect(screen.getByRole("button", { name: "모두 읽음" })).toBeEnabled();
     expect(screen.getByRole("button", { name: "Load older" })).toBeInTheDocument();
     expect(screen.queryByText(/전체 삭제|clear|delete/i)).not.toBeInTheDocument();
+    expect(screen.getByText("Future title")).toBeInTheDocument();
+    expect(screen.getByText("Future body")).toBeInTheDocument();
+    expect(screen.getByLabelText("Notification")).toHaveTextContent("!");
 
     fireEvent.click(screen.getByRole("button", { name: "Mark read" }));
     expect(state.markRead).toHaveBeenCalledWith(2);

--- a/features/notification/NotificationBell.test.tsx
+++ b/features/notification/NotificationBell.test.tsx
@@ -48,7 +48,7 @@ describe("NotificationBell canonical surface", () => {
     expect(screen.queryByText(/전체 삭제|clear|delete/i)).not.toBeInTheDocument();
     expect(screen.getByText("Future title")).toBeInTheDocument();
     expect(screen.getByText("Future body")).toBeInTheDocument();
-    expect(screen.getByLabelText("Notification")).toHaveTextContent("!");
+    expect(screen.getByRole("img", { name: "Notification" })).toHaveTextContent("!");
 
     fireEvent.click(screen.getByRole("button", { name: "Mark read" }));
     expect(state.markRead).toHaveBeenCalledWith(2);

--- a/features/notification/NotificationBell.tsx
+++ b/features/notification/NotificationBell.tsx
@@ -6,15 +6,20 @@ import { useEffect, useRef, useState } from "react";
 import type { NotificationInfo, NotificationType } from "@/shared/api/types";
 import { useNotifications } from "./useNotifications";
 
-const TYPE_META: Record<NotificationType, { color: string; icon: string }> = {
-  MAIL_RECEIVED: { color: "rgba(74,158,255,0.85)", icon: "✉" },
-  QUEST_PROGRESS: { color: "rgba(218,178,55,0.9)", icon: "⚔" },
-  QUEST_COMPLETED: { color: "rgba(218,178,55,0.9)", icon: "✓" },
-  QUEST_REWARD_READY: { color: "rgba(248,197,78,1)", icon: "★" },
-  LISTING_SOLD: { color: "rgba(74,222,128,0.85)", icon: "◆" },
-  ACHIEVEMENT_UNLOCK: { color: "rgba(248,197,78,1)", icon: "★" },
-  SYSTEM_NOTICE: { color: "rgba(160,160,180,0.6)", icon: "!" },
+const TYPE_META: Record<NotificationType, { color: string; icon: string; label: string }> = {
+  MAIL_RECEIVED: { color: "rgba(74,158,255,0.85)", icon: "✉", label: "Mail received" },
+  QUEST_PROGRESS: { color: "rgba(218,178,55,0.9)", icon: "⚔", label: "Quest progress" },
+  QUEST_COMPLETED: { color: "rgba(218,178,55,0.9)", icon: "✓", label: "Quest completed" },
+  QUEST_REWARD_READY: { color: "rgba(248,197,78,1)", icon: "★", label: "Quest reward ready" },
+  LISTING_SOLD: { color: "rgba(74,222,128,0.85)", icon: "◆", label: "Listing sold" },
+  ACHIEVEMENT_UNLOCK: { color: "rgba(248,197,78,1)", icon: "★", label: "Achievement unlocked" },
+  SYSTEM_NOTICE: { color: "rgba(160,160,180,0.6)", icon: "!", label: "System notice" },
 };
+const UNKNOWN_TYPE_META = { color: "rgba(160,160,180,0.6)", icon: "!", label: "Notification" };
+
+function isKnownNotificationType(type: string): type is NotificationType {
+  return Object.prototype.hasOwnProperty.call(TYPE_META, type);
+}
 
 export function NotificationTimestamp({ occurredAt }: { occurredAt: string }) {
   const label = occurredAt.replace("T", " ").replace(/:\d{2}(?:\.\d+)?Z$/, " UTC");
@@ -26,7 +31,7 @@ function NotificationRow({ notification, pending, onMarkRead }: {
   pending: boolean;
   onMarkRead: (id: number) => void;
 }) {
-  const meta = TYPE_META[notification.type];
+  const meta = isKnownNotificationType(notification.type) ? TYPE_META[notification.type] : UNKNOWN_TYPE_META;
   return (
     <motion.article
       initial={{ opacity: 0, x: -6 }}
@@ -40,7 +45,7 @@ function NotificationRow({ notification, pending, onMarkRead }: {
         background: notification.read ? "transparent" : "rgba(218,178,55,0.04)",
       }}
     >
-      <span style={{ width: 22, height: 22, borderRadius: "50%", border: `1.5px solid ${meta.color}`, display: "flex", alignItems: "center", justifyContent: "center", fontSize: 10, color: meta.color, flexShrink: 0, marginTop: 1 }}>{meta.icon}</span>
+      <span aria-label={meta.label} title={meta.label} style={{ width: 22, height: 22, borderRadius: "50%", border: `1.5px solid ${meta.color}`, display: "flex", alignItems: "center", justifyContent: "center", fontSize: 10, color: meta.color, flexShrink: 0, marginTop: 1 }}>{meta.icon}</span>
       <div style={{ flex: 1, minWidth: 0 }}>
         <strong style={{ display: "block", fontSize: 11, fontWeight: notification.read ? 400 : 600, color: notification.read ? "rgba(185,172,140,0.75)" : "rgba(235,218,175,0.95)", lineHeight: 1.35, overflow: "hidden", textOverflow: "ellipsis" }}>{notification.title}</strong>
         <p style={{ fontSize: 10, color: "rgba(160,148,115,0.7)", marginTop: 2, lineHeight: 1.3 }}>{notification.body}</p>

--- a/features/notification/NotificationBell.tsx
+++ b/features/notification/NotificationBell.tsx
@@ -45,7 +45,7 @@ function NotificationRow({ notification, pending, onMarkRead }: {
         background: notification.read ? "transparent" : "rgba(218,178,55,0.04)",
       }}
     >
-      <span aria-label={meta.label} title={meta.label} style={{ width: 22, height: 22, borderRadius: "50%", border: `1.5px solid ${meta.color}`, display: "flex", alignItems: "center", justifyContent: "center", fontSize: 10, color: meta.color, flexShrink: 0, marginTop: 1 }}>{meta.icon}</span>
+      <span role="img" aria-label={meta.label} title={meta.label} style={{ width: 22, height: 22, borderRadius: "50%", border: `1.5px solid ${meta.color}`, display: "flex", alignItems: "center", justifyContent: "center", fontSize: 10, color: meta.color, flexShrink: 0, marginTop: 1 }}>{meta.icon}</span>
       <div style={{ flex: 1, minWidth: 0 }}>
         <strong style={{ display: "block", fontSize: 11, fontWeight: notification.read ? 400 : 600, color: notification.read ? "rgba(185,172,140,0.75)" : "rgba(235,218,175,0.95)", lineHeight: 1.35, overflow: "hidden", textOverflow: "ellipsis" }}>{notification.title}</strong>
         <p style={{ fontSize: 10, color: "rgba(160,148,115,0.7)", marginTop: 2, lineHeight: 1.3 }}>{notification.body}</p>

--- a/features/notification/api.test.ts
+++ b/features/notification/api.test.ts
@@ -8,16 +8,25 @@ vi.mock("@/shared/api/client", () => ({ USE_MOCK: false, ...client }));
 describe("Notification API contract", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    client.apiGet.mockResolvedValue({});
-    client.apiPost.mockResolvedValue({});
   });
 
-  it("uses canonical inbox, unread, and read command routes", async () => {
-    await getNotificationsApi();
-    await getNotificationsApi(81, 20);
-    await getUnreadCountApi();
-    await markNotificationReadApi(91);
-    await markAllNotificationsReadApi();
+  it("passes through Backend #293 DTOs on USE_MOCK=false and sends no identity body", async () => {
+    const backendPage = {
+      notifications: [{ id: 91, type: "FUTURE_NOTICE", title: "Future", body: "Preserve me", occurredAt: "2026-08-21T10:00:00Z", read: false }],
+      hasMore: true,
+      nextCursor: 91,
+    };
+    client.apiGet
+      .mockResolvedValueOnce(backendPage)
+      .mockResolvedValueOnce({ notifications: [], hasMore: false, nextCursor: null })
+      .mockResolvedValueOnce({ unreadCount: 3 });
+    client.apiPost.mockResolvedValueOnce(undefined).mockResolvedValueOnce({ markedCount: 4 });
+
+    const inbox = await getNotificationsApi();
+    const older = await getNotificationsApi(81, 20);
+    const unread = await getUnreadCountApi();
+    const markedOne = await markNotificationReadApi(91);
+    const markedAll = await markAllNotificationsReadApi();
 
     expect(client.apiGet.mock.calls).toEqual([
       ["/api/v1/notifications?size=20"],
@@ -25,8 +34,17 @@ describe("Notification API contract", () => {
       ["/api/v1/notifications/unread-count"],
     ]);
     expect(client.apiPost.mock.calls).toEqual([
-      ["/api/v1/notifications/91/read", {}],
-      ["/api/v1/notifications/read-all", {}],
+      ["/api/v1/notifications/91/read", undefined],
+      ["/api/v1/notifications/read-all", undefined],
     ]);
+    expect(inbox).toEqual(backendPage);
+    expect(Object.keys(inbox.notifications[0])).toEqual(["id", "type", "title", "body", "occurredAt", "read"]);
+    expect(inbox.notifications[0]).not.toHaveProperty("playerId");
+    expect(inbox.notifications[0]).not.toHaveProperty("userId");
+    expect(older).toEqual({ notifications: [], hasMore: false, nextCursor: null });
+    expect(unread).toEqual({ unreadCount: 3 });
+    expect(markedOne).toBeUndefined();
+    expect(markedAll).toEqual({ markedCount: 4 });
+    expect([...client.apiGet.mock.calls, ...client.apiPost.mock.calls].flat().join(" ")).not.toMatch(/token|playerId|userId/);
   });
 });

--- a/features/notification/api.ts
+++ b/features/notification/api.ts
@@ -18,9 +18,9 @@ export function markNotificationReadApi(id: number): Promise<void> {
     notificationMock.markRead(id);
     return Promise.resolve();
   }
-  return apiPost<void>(`/api/v1/notifications/${id}/read`, {});
+  return apiPost<void>(`/api/v1/notifications/${id}/read`, undefined);
 }
 
 export function markAllNotificationsReadApi(): Promise<MarkAllRead> {
-  return USE_MOCK ? Promise.resolve(notificationMock.markAllRead()) : apiPost<MarkAllRead>("/api/v1/notifications/read-all", {});
+  return USE_MOCK ? Promise.resolve(notificationMock.markAllRead()) : apiPost<MarkAllRead>("/api/v1/notifications/read-all", undefined);
 }

--- a/shared/api/types/notifications.ts
+++ b/shared/api/types/notifications.ts
@@ -9,7 +9,7 @@ export type NotificationType =
 
 export interface NotificationInfo {
   id: number;
-  type: NotificationType;
+  type: string;
   title: string;
   body: string;
   occurredAt: string;


### PR DESCRIPTION
## Purpose

Verify the canonical Notification frontend against the real Backend Stage 1 contract and close the remaining future-type compatibility gap.

Closes #46

## Delivered

- real-mode Backend #293 contract verification
- Notification transport/DTO alignment where required
- runtime-safe unknown/future notification type fallback
- preserved backend unread-count authority
- preserved explicit mark-one/mark-all semantics
- focused Notification contract coverage

## Canonical API

```text
GET  /api/v1/notifications?cursor=&size=20
GET  /api/v1/notifications/unread-count
POST /api/v1/notifications/{id}/read
POST /api/v1/notifications/read-all
```

## Forward Compatibility

Unknown future Notification types render through a generic fallback without:

- crashing
- dropping title/body
- inventing deep links

## Scope

No:

- realtime/SSE/WebSocket
- source-domain adapters
- deep links
- delete/clear
- visual redesign
- theme work
- Economy changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added descriptive labels and tooltips to notification icons, improving accessibility and clarity.
  * Added support for displaying additional notification types, including future announcements.
* **Bug Fixes**
  * Notifications with unrecognized types now display safely with a neutral fallback icon instead of causing an error.
  * Improved notification read operations for more reliable behavior.
* **Tests**
  * Expanded coverage for notification content, indicators, pagination, unread counts, and read actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->