### PR TITLE
[Theme] Add canonical dual-theme runtime foundation

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -4,12 +4,14 @@
   --background: #ffffff;
   --foreground: #171717;
   --drift: 14px;
+
   color-scheme: light;
 }
 
 :root[data-theme="astral"] {
   --background: #0a0a0a;
   --foreground: #ededed;
+
   color-scheme: dark;
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -3,20 +3,14 @@
 :root {
   --background: #ffffff;
   --foreground: #171717;
+  --drift: 14px;
+  color-scheme: light;
 }
 
-@theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
+:root[data-theme="astral"] {
+  --background: #0a0a0a;
+  --foreground: #ededed;
+  color-scheme: dark;
 }
 
 body {
@@ -142,11 +136,6 @@ body {
    다크 패널 인풋 — 플레이스홀더 & 브라우저 기본값 덮어쓰기
 ═══════════════════════════════════════════════════ */
 
-/* 전체 color-scheme dark → 브라우저 UI(스크롤바, form)를 다크 모드로 */
-:root {
-  color-scheme: dark;
-}
-
 /* SAO 인풋 플레이스홀더 */
 input::placeholder,
 textarea::placeholder {
@@ -155,7 +144,7 @@ textarea::placeholder {
 
 /* select 요소 다크 */
 select {
-  color-scheme: dark;
+  color-scheme: inherit;
 }
 
 /* SAO 텍스트 글로우 — 선택 상태, 타이틀 강조 */

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 
 import { AuthProvider } from "@/features/auth/AuthContext";
+import { ThemeProvider } from "@/features/theme/ThemeProvider";
+import { THEME_BOOTSTRAP_SCRIPT } from "@/features/theme/theme";
 import { ToastProvider } from "@/context/ToastContext";
 
 import "./globals.css";
@@ -27,10 +29,13 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="ko">
+    <html lang="ko" data-theme="warm-beige" suppressHydrationWarning>
+      <head><script dangerouslySetInnerHTML={{ __html: THEME_BOOTSTRAP_SCRIPT }} /></head>
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
         <AuthProvider>
-          <ToastProvider>{children}</ToastProvider>
+          <ThemeProvider>
+            <ToastProvider>{children}</ToastProvider>
+          </ThemeProvider>
         </AuthProvider>
       </body>
     </html>

--- a/features/system/settings/SettingsShell.test.tsx
+++ b/features/system/settings/SettingsShell.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { UserSettingsResponse } from "@/shared/api/types";
+import { ThemeProvider } from "@/features/theme/ThemeProvider";
 import SettingsShell from "./SettingsShell";
 
 const api = vi.hoisted(() => ({ getSettingsApi: vi.fn(), updateSettingsApi: vi.fn() }));
@@ -13,19 +14,21 @@ const canonical: UserSettingsResponse = {
   userId: 7,
   volume: 70,
   uiLayoutJson: "layout",
-  flagsJson: JSON.stringify({ graphicsQuality: "HIGH", inputPreset: "ADVANCED", uiScale: 125 }),
+  flagsJson: JSON.stringify({ graphicsQuality: "HIGH", inputPreset: "ADVANCED", uiScale: 125, futureFlag: "keep" }),
   updatedAt: "2026-08-18T00:00:00Z",
 };
 
 describe("System Options surface save timing", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    localStorage.clear();
+    vi.stubGlobal("matchMedia", vi.fn(() => ({ matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn() })));
     api.getSettingsApi.mockResolvedValue(canonical);
   });
 
   it("keeps the failed draft open and closes only after a successful canonical response", async () => {
     api.updateSettingsApi.mockRejectedValueOnce(new Error("save failed")).mockResolvedValueOnce({ ...canonical, volume: 25 });
-    render(<SettingsShell />);
+    render(<ThemeProvider><SettingsShell /></ThemeProvider>);
     expect(await screen.findByText("Master Volume: 70%")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "설정 편집" }));
     fireEvent.change(screen.getByRole("spinbutton", { name: "Master Volume" }), { target: { value: "25" } });
@@ -38,5 +41,22 @@ describe("System Options surface save timing", () => {
     await waitFor(() => expect(screen.queryByRole("spinbutton", { name: "Master Volume" })).not.toBeInTheDocument());
     expect(screen.getByText("Master Volume: 25%")).toBeInTheDocument();
     expect(toast.showToast).toHaveBeenCalledTimes(1);
+  });
+
+  it("applies theme selection immediately and keeps it applied when focused persistence fails", async () => {
+    api.updateSettingsApi.mockRejectedValueOnce(new Error("theme save failed"));
+    render(<ThemeProvider><SettingsShell /></ThemeProvider>);
+    expect(await screen.findByText("Master Volume: 70%")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByRole("combobox", { name: "Theme" }), { target: { value: "ASTRAL" } });
+    expect(document.documentElement.dataset.theme).toBe("astral");
+    expect(localStorage.getItem("lifeasgame.themePreference")).toBe("ASTRAL");
+    expect(await screen.findByText("theme save failed")).toBeInTheDocument();
+    expect(screen.getByRole("combobox", { name: "Theme" })).toHaveValue("ASTRAL");
+    expect(screen.queryByRole("button", { name: /apply/i })).not.toBeInTheDocument();
+
+    const request = api.updateSettingsApi.mock.calls[0][0];
+    expect(request).toEqual({ flagsJson: expect.any(String) });
+    expect(JSON.parse(request.flagsJson)).toMatchObject({ themePreference: "ASTRAL", futureFlag: "keep" });
   });
 });

--- a/features/system/settings/SettingsShell.tsx
+++ b/features/system/settings/SettingsShell.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 
 import { useToast } from "@/context/ToastContext";
-import type { GraphicsQuality, InputPreset, SettingsView, UiScale, VoiceChatMode } from "@/shared/api/types";
+import type { GraphicsQuality, InputPreset, SettingsView, ThemePreference, UiScale, VoiceChatMode } from "@/shared/api/types";
 import { INPUT_STYLE, SAO } from "@/shared/design/tokens";
 import { PanelFrame } from "@/widgets/right-panels/ui/PanelFrame";
 import { GoldRow, InfoCard } from "@/widgets/right-panels/ui/Rows";
@@ -34,6 +34,7 @@ const isUiScale = (value: number): value is UiScale => UI_SCALES.some((scale) =>
 const isGraphicsQuality = (value: string): value is GraphicsQuality => ["LOW", "MEDIUM", "HIGH", "ULTRA"].includes(value);
 const isVoiceChat = (value: string): value is VoiceChatMode => ["OFF", "TEAM_ONLY", "ALL"].includes(value);
 const isInputPreset = (value: string): value is InputPreset => ["STANDARD", "ADVANCED", "CUSTOM"].includes(value);
+const isThemePreference = (value: string): value is ThemePreference => ["SYSTEM", "ASTRAL", "WARM_BEIGE"].includes(value);
 
 function summaryRows(settings: SettingsView) {
   return [
@@ -94,6 +95,26 @@ export default function SettingsShell() {
           </div>
         ) : null}
 
+        {!settings.error && settings.canonical ? (
+          <section aria-label="Appearance">
+            <label style={fieldLabel}>
+              Theme
+              <select
+                aria-label="Theme"
+                value={settings.themePreference}
+                disabled={settings.themeSaving || settings.saving}
+                onChange={(event) => { if (isThemePreference(event.target.value)) void settings.setThemePreference(event.target.value); }}
+                style={INPUT_STYLE}
+              >
+                <option value="SYSTEM">System</option>
+                <option value="ASTRAL">Astral</option>
+                <option value="WARM_BEIGE">Warm Beige</option>
+              </select>
+            </label>
+            {settings.themeSaveError ? <p role="alert" className="mt-1 text-xs" style={{ color: SAO.color.action.red }}>{settings.themeSaveError}</p> : null}
+          </section>
+        ) : null}
+
         {!settings.error && settings.canonical && !editing ? (
           <>
             <InfoCard>Graphics, audio, controls, and gameplay preferences.</InfoCard>
@@ -129,8 +150,8 @@ export default function SettingsShell() {
             ))}
             {settings.saveError ? <p role="alert" className="text-xs" style={{ color: SAO.color.action.red }}>{settings.saveError}</p> : null}
             <div className="flex gap-2">
-              <button type="submit" disabled={!settings.dirty || settings.saving} style={{ ...actionBtnStyle, flex: 1 }}>{settings.saving ? "Saving..." : "Save Settings"}</button>
-              <button type="button" disabled={settings.saving} style={secondaryButton} onClick={() => { settings.cancel(); setEditing(false); }}>Cancel</button>
+              <button type="submit" disabled={!settings.dirty || settings.saving || settings.themeSaving} style={{ ...actionBtnStyle, flex: 1 }}>{settings.saving ? "Saving..." : "Save Settings"}</button>
+              <button type="button" disabled={settings.saving || settings.themeSaving} style={secondaryButton} onClick={() => { settings.cancel(); setEditing(false); }}>Cancel</button>
             </div>
           </form>
         ) : null}

--- a/features/system/settings/model.test.ts
+++ b/features/system/settings/model.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import type { UserSettingsResponse } from "@/shared/api/types";
 import { SYSTEM_OPTIONS_FORM_FIELDS } from "../model";
-import { buildSettingsPatch, parseUserSettings, SettingsParseError } from "./model";
+import { buildSettingsPatch, buildThemeSettingsPatch, parseUserSettings, SettingsParseError } from "./model";
 
 const transport = (flagsJson: string | null): UserSettingsResponse => ({
   userId: 7,
@@ -40,5 +40,16 @@ describe("Settings flags parser and merger", () => {
   it("offers only canonical UI scales and includes Advanced input", () => {
     expect(SYSTEM_OPTIONS_FORM_FIELDS.find(({ key }) => key === "uiScale")?.options?.map(({ value }) => value)).toEqual(["75", "100", "125", "150"]);
     expect(SYSTEM_OPTIONS_FORM_FIELDS.find(({ key }) => key === "inputPreset")?.options?.map(({ value }) => value)).toContain("ADVANCED");
+  });
+
+  it("falls back unknown theme safely and changes it only through the focused theme patch", () => {
+    const canonical = parseUserSettings(transport(JSON.stringify({ themePreference: "FUTURE_THEME", futureFlag: "keep" })));
+    expect(canonical.view.themePreference).toBe("WARM_BEIGE");
+
+    const ordinaryFlags = JSON.parse(buildSettingsPatch(canonical, { ...canonical.view, volume: 55 }).flagsJson!);
+    expect(ordinaryFlags).toMatchObject({ themePreference: "FUTURE_THEME", futureFlag: "keep" });
+
+    const themeFlags = JSON.parse(buildThemeSettingsPatch(canonical, "ASTRAL").flagsJson!);
+    expect(themeFlags).toMatchObject({ themePreference: "ASTRAL", futureFlag: "keep" });
   });
 });

--- a/features/system/settings/model.ts
+++ b/features/system/settings/model.ts
@@ -4,11 +4,13 @@ import type {
   ParsedUserSettings,
   SettingsFlags,
   SettingsView,
+  ThemePreference,
   UiScale,
   UpdateUserSettingsRequest,
   UserSettingsResponse,
   VoiceChatMode,
 } from "@/shared/api/types";
+import { DEFAULT_THEME_PREFERENCE, parseThemePreference } from "@/features/theme/theme";
 
 export const DEFAULT_SETTINGS_FLAGS: SettingsFlags = {
   graphicsQuality: "HIGH",
@@ -21,6 +23,7 @@ export const DEFAULT_SETTINGS_FLAGS: SettingsFlags = {
   notifications: true,
   emailAlerts: false,
   language: "ko",
+  themePreference: DEFAULT_THEME_PREFERENCE,
 };
 
 const GRAPHICS_QUALITIES: GraphicsQuality[] = ["LOW", "MEDIUM", "HIGH", "ULTRA"];
@@ -76,6 +79,7 @@ export function parseUserSettings(transport: UserSettingsResponse): ParsedUserSe
     notifications: booleanValue(rawFlags.notifications, DEFAULT_SETTINGS_FLAGS.notifications),
     emailAlerts: booleanValue(rawFlags.emailAlerts, DEFAULT_SETTINGS_FLAGS.emailAlerts),
     language: stringValue(rawFlags.language, DEFAULT_SETTINGS_FLAGS.language),
+    themePreference: parseThemePreference(rawFlags.themePreference) ?? DEFAULT_SETTINGS_FLAGS.themePreference,
   };
   return { transport, rawFlags, view };
 }
@@ -83,5 +87,11 @@ export function parseUserSettings(transport: UserSettingsResponse): ParsedUserSe
 export function buildSettingsPatch(canonical: ParsedUserSettings, draft: SettingsView): UpdateUserSettingsRequest {
   const flagsJson = { ...canonical.rawFlags, ...draft } as Record<string, unknown>;
   delete flagsJson.volume;
+  if (Object.prototype.hasOwnProperty.call(canonical.rawFlags, "themePreference")) flagsJson.themePreference = canonical.rawFlags.themePreference;
+  else delete flagsJson.themePreference;
   return { volume: draft.volume, flagsJson: JSON.stringify(flagsJson) };
+}
+
+export function buildThemeSettingsPatch(canonical: ParsedUserSettings, themePreference: ThemePreference): UpdateUserSettingsRequest {
+  return { flagsJson: JSON.stringify({ ...canonical.rawFlags, themePreference }) };
 }

--- a/features/system/settings/useSettings.test.tsx
+++ b/features/system/settings/useSettings.test.tsx
@@ -92,8 +92,12 @@ describe("feature-owned Settings state", () => {
 
   it("preserves a valid local preference when server flags omit themePreference", async () => {
     localStorage.setItem(THEME_STORAGE_KEY, "ASTRAL");
+    let finishLoad!: (settings: UserSettingsResponse) => void;
+    api.getSettingsApi.mockReturnValue(new Promise((resolve) => { finishLoad = resolve; }));
     const { result } = renderHook(() => useSettings(), { wrapper });
 
+    await waitFor(() => expect(document.documentElement.dataset.theme).toBe("astral"));
+    await act(async () => { finishLoad(response()); });
     await waitFor(() => expect(result.current.canonical).not.toBeNull());
     expect(result.current.themePreference).toBe("ASTRAL");
     expect(result.current.canonical?.view.themePreference).toBe("ASTRAL");

--- a/features/system/settings/useSettings.test.tsx
+++ b/features/system/settings/useSettings.test.tsx
@@ -1,11 +1,16 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { ThemeProvider } from "@/features/theme/ThemeProvider";
+import { THEME_STORAGE_KEY } from "@/features/theme/theme";
 import type { UserSettingsResponse } from "@/shared/api/types";
 import { useSettings } from "./useSettings";
 
 const api = vi.hoisted(() => ({ getSettingsApi: vi.fn(), updateSettingsApi: vi.fn() }));
 vi.mock("@/lib/api/endpoints/settings.api", () => api);
+
+const wrapper = ({ children }: { children: ReactNode }) => <ThemeProvider>{children}</ThemeProvider>;
 
 const response = (overrides: Partial<UserSettingsResponse> = {}): UserSettingsResponse => ({
   userId: 7,
@@ -19,12 +24,14 @@ const response = (overrides: Partial<UserSettingsResponse> = {}): UserSettingsRe
 describe("feature-owned Settings state", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    localStorage.clear();
+    vi.stubGlobal("matchMedia", vi.fn(() => ({ matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn() })));
     api.getSettingsApi.mockResolvedValue(response());
   });
 
   it("protects invalid flags, exposes retry, and never PATCHes without safe canonical state", async () => {
     api.getSettingsApi.mockResolvedValueOnce(response({ flagsJson: "[]" })).mockResolvedValueOnce(response());
-    const { result } = renderHook(() => useSettings());
+    const { result } = renderHook(() => useSettings(), { wrapper });
     await waitFor(() => expect(result.current.error).toMatch(/cannot be edited safely/i));
 
     await act(async () => { expect(await result.current.save()).toBe(false); });
@@ -41,7 +48,7 @@ describe("feature-owned Settings state", () => {
       flagsJson: JSON.stringify({ graphicsQuality: "LOW", futureFlag: "preserve", serverFlag: true }),
       updatedAt: "2026-08-18T01:00:00Z",
     }));
-    const { result } = renderHook(() => useSettings());
+    const { result } = renderHook(() => useSettings(), { wrapper });
     await waitFor(() => expect(result.current.canonical).not.toBeNull());
     act(() => result.current.updateDraft({ volume: 65, graphicsQuality: "LOW" }));
 
@@ -58,7 +65,7 @@ describe("feature-owned Settings state", () => {
 
   it("keeps the previous canonical state and edited draft after save failure, then cancel restores canonical", async () => {
     api.updateSettingsApi.mockRejectedValue(new Error("save failed"));
-    const { result } = renderHook(() => useSettings());
+    const { result } = renderHook(() => useSettings(), { wrapper });
     await waitFor(() => expect(result.current.canonical).not.toBeNull());
     act(() => result.current.updateDraft({ volume: 25 }));
 
@@ -70,5 +77,26 @@ describe("feature-owned Settings state", () => {
     act(() => result.current.cancel());
     expect(result.current.draft?.volume).toBe(70);
     expect(result.current.saveError).toBeNull();
+  });
+
+  it("lets a supported server theme override the local bootstrap cache after Settings loads", async () => {
+    localStorage.setItem(THEME_STORAGE_KEY, "ASTRAL");
+    api.getSettingsApi.mockResolvedValue(response({ flagsJson: JSON.stringify({ themePreference: "WARM_BEIGE", futureFlag: "preserve" }) }));
+    const { result } = renderHook(() => useSettings(), { wrapper });
+
+    await waitFor(() => expect(result.current.canonical).not.toBeNull());
+    expect(result.current.themePreference).toBe("WARM_BEIGE");
+    expect(document.documentElement.dataset.theme).toBe("warm-beige");
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe("WARM_BEIGE");
+  });
+
+  it("preserves a valid local preference when server flags omit themePreference", async () => {
+    localStorage.setItem(THEME_STORAGE_KEY, "ASTRAL");
+    const { result } = renderHook(() => useSettings(), { wrapper });
+
+    await waitFor(() => expect(result.current.canonical).not.toBeNull());
+    expect(result.current.themePreference).toBe("ASTRAL");
+    expect(result.current.canonical?.view.themePreference).toBe("ASTRAL");
+    expect(document.documentElement.dataset.theme).toBe("astral");
   });
 });

--- a/features/system/settings/useSettings.ts
+++ b/features/system/settings/useSettings.ts
@@ -10,11 +10,11 @@ import { buildSettingsPatch, buildThemeSettingsPatch, parseUserSettings } from "
 
 const message = (caught: unknown, fallback: string) => caught instanceof Error ? caught.message : fallback;
 
-function withTheme(parsed: ParsedUserSettings, fallback: ThemePreference) {
+function withTheme(parsed: ParsedUserSettings, localPreferenceWhenServerKeyMissing: ThemePreference) {
   const supplied = Object.prototype.hasOwnProperty.call(parsed.rawFlags, "themePreference");
   const preference = supplied
     ? parseThemePreference(parsed.rawFlags.themePreference) ?? DEFAULT_THEME_PREFERENCE
-    : fallback;
+    : localPreferenceWhenServerKeyMissing;
   return { ...parsed, view: { ...parsed.view, themePreference: preference } };
 }
 
@@ -31,7 +31,10 @@ export function useSettings() {
   const saveLocked = useRef(false);
   const themeSaveLocked = useRef(false);
   const themePreferenceRef = useRef(runtimePreference);
-  themePreferenceRef.current = runtimePreference;
+
+  useEffect(() => {
+    themePreferenceRef.current = runtimePreference;
+  }, [runtimePreference]);
 
   const load = useCallback(async () => {
     setLoading(true);

--- a/features/system/settings/useSettings.ts
+++ b/features/system/settings/useSettings.ts
@@ -2,26 +2,43 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import type { ParsedUserSettings, SettingsView } from "@/shared/api/types";
+import type { ParsedUserSettings, SettingsView, ThemePreference } from "@/shared/api/types";
+import { useTheme } from "@/features/theme/ThemeProvider";
+import { DEFAULT_THEME_PREFERENCE, parseThemePreference } from "@/features/theme/theme";
 import { getSettingsApi, updateSettingsApi } from "@/lib/api/endpoints/settings.api";
-import { buildSettingsPatch, parseUserSettings } from "./model";
+import { buildSettingsPatch, buildThemeSettingsPatch, parseUserSettings } from "./model";
 
 const message = (caught: unknown, fallback: string) => caught instanceof Error ? caught.message : fallback;
 
+function withTheme(parsed: ParsedUserSettings, fallback: ThemePreference) {
+  const supplied = Object.prototype.hasOwnProperty.call(parsed.rawFlags, "themePreference");
+  const preference = supplied
+    ? parseThemePreference(parsed.rawFlags.themePreference) ?? DEFAULT_THEME_PREFERENCE
+    : fallback;
+  return { ...parsed, view: { ...parsed.view, themePreference: preference } };
+}
+
 export function useSettings() {
+  const { preference: runtimePreference, setPreference: setRuntimePreference } = useTheme();
   const [canonical, setCanonical] = useState<ParsedUserSettings | null>(null);
   const [draft, setDraft] = useState<SettingsView | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
+  const [themeSaving, setThemeSaving] = useState(false);
+  const [themeSaveError, setThemeSaveError] = useState<string | null>(null);
   const saveLocked = useRef(false);
+  const themeSaveLocked = useRef(false);
+  const themePreferenceRef = useRef(runtimePreference);
+  themePreferenceRef.current = runtimePreference;
 
   const load = useCallback(async () => {
     setLoading(true);
     setError(null);
     try {
-      const parsed = parseUserSettings(await getSettingsApi());
+      const parsed = withTheme(parseUserSettings(await getSettingsApi()), themePreferenceRef.current);
+      setRuntimePreference(parsed.view.themePreference);
       setCanonical(parsed);
       setDraft(parsed.view);
       setSaveError(null);
@@ -30,7 +47,7 @@ export function useSettings() {
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [setRuntimePreference]);
 
   useEffect(() => { void load(); }, [load]);
 
@@ -45,7 +62,7 @@ export function useSettings() {
   };
 
   const save = async () => {
-    if (!canonical || !draft || saveLocked.current) return false;
+    if (!canonical || !draft || saveLocked.current || themeSaveLocked.current) return false;
     if (!Number.isInteger(draft.volume) || draft.volume < 0 || draft.volume > 100) {
       setSaveError("Master Volume must be a whole number from 0 to 100.");
       return false;
@@ -54,9 +71,9 @@ export function useSettings() {
     setSaving(true);
     setSaveError(null);
     try {
-      const parsed = parseUserSettings(await updateSettingsApi(buildSettingsPatch(canonical, draft)));
+      const parsed = withTheme(parseUserSettings(await updateSettingsApi(buildSettingsPatch(canonical, draft))), themePreferenceRef.current);
       setCanonical(parsed);
-      setDraft(parsed.view);
+      setDraft({ ...parsed.view, themePreference: themePreferenceRef.current });
       return true;
     } catch (caught) {
       setSaveError(message(caught, "Unable to save Settings."));
@@ -67,6 +84,46 @@ export function useSettings() {
     }
   };
 
-  const dirty = Boolean(canonical && draft && JSON.stringify(canonical.view) !== JSON.stringify(draft));
-  return { loading, error, retry: load, canonical, draft, dirty, saving, saveError, updateDraft, save, cancel };
+  const setThemePreference = async (preference: ThemePreference) => {
+    if (themeSaveLocked.current || saveLocked.current) return false;
+    setRuntimePreference(preference);
+    setDraft((current) => current ? { ...current, themePreference: preference } : current);
+    setThemeSaveError(null);
+    if (!canonical) return false;
+    themeSaveLocked.current = true;
+    setThemeSaving(true);
+    try {
+      const parsed = withTheme(parseUserSettings(await updateSettingsApi(buildThemeSettingsPatch(canonical, preference))), preference);
+      setRuntimePreference(parsed.view.themePreference);
+      setCanonical(parsed);
+      setDraft((current) => current ? { ...current, themePreference: parsed.view.themePreference } : parsed.view);
+      return true;
+    } catch (caught) {
+      setThemeSaveError(message(caught, "Unable to save theme preference."));
+      return false;
+    } finally {
+      themeSaveLocked.current = false;
+      setThemeSaving(false);
+    }
+  };
+
+  const dirty = Boolean(canonical && draft
+    && JSON.stringify({ ...canonical.view, themePreference: undefined }) !== JSON.stringify({ ...draft, themePreference: undefined }));
+  return {
+    loading,
+    error,
+    retry: load,
+    canonical,
+    draft,
+    dirty,
+    saving,
+    saveError,
+    updateDraft,
+    save,
+    cancel,
+    themePreference: runtimePreference,
+    themeSaving,
+    themeSaveError,
+    setThemePreference,
+  };
 }

--- a/features/theme/ThemeProvider.test.tsx
+++ b/features/theme/ThemeProvider.test.tsx
@@ -73,4 +73,18 @@ describe("dual theme runtime", () => {
     expect(document.documentElement.dataset.theme).toBe("astral");
     expect(screen.getByRole("textbox", { name: "Representative draft" })).toHaveValue("still here");
   });
+
+  it("falls back safely when obtaining localStorage throws", () => {
+    const storage = vi.spyOn(window, "localStorage", "get").mockImplementation(() => {
+      throw new Error("storage unavailable");
+    });
+
+    try {
+      render(<ThemeProvider><Harness /></ThemeProvider>);
+      expect(screen.getByText("WARM_BEIGE:warm-beige")).toBeInTheDocument();
+      expect(document.documentElement.dataset.theme).toBe("warm-beige");
+    } finally {
+      storage.mockRestore();
+    }
+  });
 });

--- a/features/theme/ThemeProvider.test.tsx
+++ b/features/theme/ThemeProvider.test.tsx
@@ -1,0 +1,76 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { useState } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ThemeProvider, useTheme } from "./ThemeProvider";
+import { DEFAULT_THEME_PREFERENCE, THEME_STORAGE_KEY, readStoredThemePreference, resolveTheme } from "./theme";
+
+let dark = false;
+const listeners = new Set<() => void>();
+const media = {
+  get matches() { return dark; },
+  media: "(prefers-color-scheme: dark)",
+  onchange: null,
+  addEventListener: (_type: string, listener: () => void) => listeners.add(listener),
+  removeEventListener: (_type: string, listener: () => void) => listeners.delete(listener),
+  addListener: () => {},
+  removeListener: () => {},
+  dispatchEvent: () => true,
+};
+
+function Harness() {
+  const theme = useTheme();
+  const [draft, setDraft] = useState("kept");
+  return (
+    <div>
+      <output>{theme.preference}:{theme.effectiveTheme}</output>
+      <input aria-label="Representative draft" value={draft} onChange={(event) => setDraft(event.target.value)} />
+      <button type="button" onClick={() => theme.setPreference("SYSTEM")}>System</button>
+      <button type="button" onClick={() => theme.setPreference("ASTRAL")}>Astral</button>
+      <button type="button" onClick={() => theme.setPreference("WARM_BEIGE")}>Warm Beige</button>
+    </div>
+  );
+}
+
+describe("dual theme runtime", () => {
+  beforeEach(() => {
+    dark = false;
+    listeners.clear();
+    localStorage.clear();
+    delete document.documentElement.dataset.theme;
+    vi.stubGlobal("matchMedia", vi.fn(() => media));
+  });
+
+  it("resolves defaults, SYSTEM, explicit, and unknown preferences safely", () => {
+    expect(DEFAULT_THEME_PREFERENCE).toBe("WARM_BEIGE");
+    expect(resolveTheme(undefined)).toBe("warm-beige");
+    expect(resolveTheme("SYSTEM", false)).toBe("warm-beige");
+    expect(resolveTheme("SYSTEM", true)).toBe("astral");
+    expect(resolveTheme("ASTRAL", false)).toBe("astral");
+    expect(resolveTheme("WARM_BEIGE", true)).toBe("warm-beige");
+    expect(resolveTheme("FUTURE_THEME", true)).toBe("warm-beige");
+    expect(readStoredThemePreference({ getItem: () => "FUTURE_THEME" })).toBe("WARM_BEIGE");
+  });
+
+  it("bootstraps local preference, follows OS only for SYSTEM, persists, and never remounts child state", async () => {
+    dark = true;
+    localStorage.setItem(THEME_STORAGE_KEY, "SYSTEM");
+    render(<ThemeProvider><Harness /></ThemeProvider>);
+
+    await waitFor(() => expect(screen.getByText("SYSTEM:astral")).toBeInTheDocument());
+    expect(document.documentElement.dataset.theme).toBe("astral");
+    fireEvent.change(screen.getByRole("textbox", { name: "Representative draft" }), { target: { value: "still here" } });
+
+    dark = false;
+    act(() => listeners.forEach((listener) => listener()));
+    await waitFor(() => expect(screen.getByText("SYSTEM:warm-beige")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole("button", { name: "Astral" }));
+    expect(document.documentElement.dataset.theme).toBe("astral");
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe("ASTRAL");
+    dark = false;
+    act(() => listeners.forEach((listener) => listener()));
+    expect(document.documentElement.dataset.theme).toBe("astral");
+    expect(screen.getByRole("textbox", { name: "Representative draft" })).toHaveValue("still here");
+  });
+});

--- a/features/theme/ThemeProvider.tsx
+++ b/features/theme/ThemeProvider.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { createContext, useCallback, useContext, useEffect, useLayoutEffect, useMemo, useState } from "react";
+
+import type { EffectiveTheme, ThemePreference } from "./theme";
+import { DEFAULT_THEME_PREFERENCE, THEME_STORAGE_KEY, readStoredThemePreference, resolveTheme } from "./theme";
+
+type ThemeContextValue = {
+  preference: ThemePreference;
+  effectiveTheme: EffectiveTheme;
+  setPreference: (preference: ThemePreference) => void;
+};
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+function systemDark() {
+  return typeof window.matchMedia === "function" && window.matchMedia("(prefers-color-scheme: dark)").matches;
+}
+
+function applyRoot(preference: ThemePreference): EffectiveTheme {
+  const effective = resolveTheme(preference, systemDark());
+  document.documentElement.dataset.theme = effective;
+  return effective;
+}
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [preference, setPreferenceState] = useState<ThemePreference>(DEFAULT_THEME_PREFERENCE);
+  const [effectiveTheme, setEffectiveTheme] = useState<EffectiveTheme>("warm-beige");
+
+  const setPreference = useCallback((next: ThemePreference) => {
+    try { localStorage.setItem(THEME_STORAGE_KEY, next); } catch { /* local cache is best-effort */ }
+    setPreferenceState(next);
+    setEffectiveTheme(applyRoot(next));
+  }, []);
+
+  useLayoutEffect(() => {
+    const stored = readStoredThemePreference(localStorage);
+    setPreferenceState(stored);
+    setEffectiveTheme(applyRoot(stored));
+  }, []);
+
+  useEffect(() => {
+    if (preference !== "SYSTEM" || typeof window.matchMedia !== "function") return;
+    const media = window.matchMedia("(prefers-color-scheme: dark)");
+    const update = () => setEffectiveTheme(applyRoot("SYSTEM"));
+    media.addEventListener("change", update);
+    return () => media.removeEventListener("change", update);
+  }, [preference]);
+
+  const value = useMemo(() => ({ preference, effectiveTheme, setPreference }), [preference, effectiveTheme, setPreference]);
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+  if (!context) throw new Error("useTheme must be used within ThemeProvider");
+  return context;
+}

--- a/features/theme/ThemeProvider.tsx
+++ b/features/theme/ThemeProvider.tsx
@@ -34,7 +34,8 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   useLayoutEffect(() => {
-    const stored = readStoredThemePreference(localStorage);
+    let stored = DEFAULT_THEME_PREFERENCE;
+    try { stored = readStoredThemePreference(localStorage); } catch { /* local cache is best-effort */ }
     setPreferenceState(stored);
     setEffectiveTheme(applyRoot(stored));
   }, []);

--- a/features/theme/theme.ts
+++ b/features/theme/theme.ts
@@ -1,0 +1,27 @@
+import type { ThemePreference } from "@/shared/api/types";
+
+export type { ThemePreference } from "@/shared/api/types";
+export type EffectiveTheme = "astral" | "warm-beige";
+
+export const THEME_STORAGE_KEY = "lifeasgame.themePreference";
+export const DEFAULT_THEME_PREFERENCE: ThemePreference = "WARM_BEIGE";
+
+export function parseThemePreference(value: unknown): ThemePreference | null {
+  return value === "SYSTEM" || value === "ASTRAL" || value === "WARM_BEIGE" ? value : null;
+}
+
+export function resolveTheme(preference: unknown, systemDark = false): EffectiveTheme {
+  const supported = parseThemePreference(preference) ?? DEFAULT_THEME_PREFERENCE;
+  if (supported === "SYSTEM") return systemDark ? "astral" : "warm-beige";
+  return supported === "ASTRAL" ? "astral" : "warm-beige";
+}
+
+export function readStoredThemePreference(storage?: Pick<Storage, "getItem">): ThemePreference {
+  try {
+    return parseThemePreference(storage?.getItem(THEME_STORAGE_KEY)) ?? DEFAULT_THEME_PREFERENCE;
+  } catch {
+    return DEFAULT_THEME_PREFERENCE;
+  }
+}
+
+export const THEME_BOOTSTRAP_SCRIPT = `(()=>{try{const p=localStorage.getItem("${THEME_STORAGE_KEY}");const dark=p==="SYSTEM"&&typeof matchMedia==="function"&&matchMedia("(prefers-color-scheme: dark)").matches;document.documentElement.dataset.theme=p==="ASTRAL"||dark?"astral":"warm-beige"}catch{document.documentElement.dataset.theme="warm-beige"}})()`;

--- a/lib/api/mock/settings.mock.ts
+++ b/lib/api/mock/settings.mock.ts
@@ -15,6 +15,7 @@ const initialSettings: UserSettingsResponse = {
     notifications: true,
     emailAlerts: false,
     language: "ko",
+    themePreference: "WARM_BEIGE",
     futureFlag: "preserved",
   }),
   updatedAt: "2026-05-01T12:00:00Z",

--- a/shared/api/types/settings.ts
+++ b/shared/api/types/settings.ts
@@ -2,6 +2,7 @@ export type GraphicsQuality = "LOW" | "MEDIUM" | "HIGH" | "ULTRA";
 export type VoiceChatMode = "OFF" | "TEAM_ONLY" | "ALL";
 export type UiScale = 75 | 100 | 125 | 150;
 export type InputPreset = "STANDARD" | "ADVANCED" | "CUSTOM";
+export type ThemePreference = "SYSTEM" | "ASTRAL" | "WARM_BEIGE";
 
 export interface SettingsFlags {
   graphicsQuality: GraphicsQuality;
@@ -14,6 +15,7 @@ export interface SettingsFlags {
   notifications: boolean;
   emailAlerts: boolean;
   language: string;
+  themePreference: ThemePreference;
 }
 
 export interface SettingsView extends SettingsFlags {


### PR DESCRIPTION
## Purpose

Add the Frontend runtime foundation for the locked First Completion Dual Theme contract without starting the final visual redesign pass.

Closes #48

## Delivered

- canonical theme preference model:
  - `SYSTEM`
  - `ASTRAL`
  - `WARM_BEIGE`
- effective runtime theme model:
  - `astral`
  - `warm-beige`
- Warm Beige default
- SYSTEM light/dark resolution
- pre-paint local bootstrap
- root theme marker
- anonymous local preference persistence
- logged-in UserSettings canonical synchronization
- Settings > Appearance immediate theme switching
- unknown/future preference fallback
- focused theme/runtime coverage

## Canonical Theme Contract

```text
default = WARM_BEIGE

SYSTEM:
OS dark  -> ASTRAL
OS light -> WARM_BEIGE

unknown/future preference
-> WARM_BEIGE fallback
```

Explicit `ASTRAL` and `WARM_BEIGE` preferences ignore later OS theme changes.

`SYSTEM` continues to follow OS light/dark changes.

## Runtime Architecture

Theme runtime is owned by a single frontend theme boundary.

The implementation:

- resolves preference to an effective theme
- applies one root theme marker
- uses token/root-marker switching instead of feature duplication
- avoids using theme as a React key
- preserves current navigation and UI state while switching

Theme changes do not intentionally reset:

- route
- panel/drawer depth
- scroll
- form/input state
- chat draft
- selected item

## Persistence

Anonymous users:

- use local preference
- fall back to Warm Beige

Logged-in users:

- use local preference as pre-paint bootstrap/cache
- use server UserSettings as canonical once loaded
- preserve unrelated unknown `flagsJson` keys
- keep local/effective theme when server persistence fails

Logout does not force-reset the local theme.

## Settings UX

Settings > Appearance exposes:

- System
- Astral
- Warm Beige

Theme switching applies immediately.

There is no separate Apply action for theme.

Existing non-theme Settings save/cancel behavior is not broadly redesigned.

## Forward Compatibility

Unsupported future theme preference values:

- do not crash the app
- resolve safely to Warm Beige
- are not written back as if they were supported

## Visual Boundary

This PR establishes runtime, persistence, root-marker, and semantic token plumbing only.

It does not claim final Astral/Warm Beige visual fidelity.

It does not:

- invent final palette values
- broadly restyle existing screens
- duplicate components per theme
- create theme-specific feature trees

The final visual pass will consume the approved Visual Designer artifacts separately.

## Scope Boundaries

This PR does not implement:

- final dual-theme visual polish
- broad component restyling
- Economy changes
- Notification changes
- responsive overhaul
- backend schema/API changes
- additional themes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added theme selection in Settings with System, Astral, and Warm Beige options.
  - Themes apply immediately, persist across sessions, and respond to system appearance changes.
  - Added dark Astral and light Warm Beige visual themes.
  - Theme choices remain visible and report errors if saving other settings fails.

- **Bug Fixes**
  - Improved color handling for controls such as dropdowns across themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->