### PR TITLE
[Theme] Apply approved v7 dual-theme tokens and shared visual foundation

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -82,6 +82,13 @@
   --lag-state-disabled: var(--lag-disabled);
   --lag-state-pending: var(--lag-amber);
   --lag-state-read-only: var(--lag-meta);
+  --lag-control-bg: color-mix(in srgb, var(--lag-panel-2) 76%, var(--lag-border));
+  --lag-control-hover-bg: color-mix(in srgb, var(--lag-focus) 12%, var(--lag-control-bg));
+  --lag-control-border: color-mix(in srgb, var(--lag-border) 76%, var(--lag-text));
+  --lag-control-text: var(--lag-text);
+  --lag-selected-surface: color-mix(in srgb, var(--lag-state-selected) 14%, var(--lag-panel));
+  --lag-muted-surface: color-mix(in srgb, var(--lag-panel-2) 82%, var(--lag-border));
+  --lag-raised-surface: color-mix(in srgb, var(--lag-panel) 88%, var(--lag-border));
   --background: var(--lag-ambient);
   --foreground: var(--lag-text);
   --drift: 14px;
@@ -134,7 +141,11 @@ body {
 .lag-button-secondary,
 .lag-panel-card,
 .lag-theme-option,
-.lag-theme-preview {
+.lag-theme-preview,
+.lag-left-context,
+.lag-utility-button,
+.lag-utility-drawer,
+.lag-notification-dropdown {
   transition:
     background-color var(--lag-motion-normal) ease,
     border-color var(--lag-motion-normal) ease,
@@ -172,7 +183,7 @@ body {
 .lag-row,
 .lag-info-card,
 .lag-home-card {
-  background-color: var(--lag-paper);
+  background-color: var(--lag-muted-surface);
   border: 1px solid var(--lag-divider);
   color: var(--lag-text);
 }
@@ -218,10 +229,10 @@ body {
 }
 
 .lag-button-secondary {
-  background-color: var(--lag-paper);
-  border: 1px solid var(--lag-border);
+  background-color: var(--lag-control-bg);
+  border: 1px solid var(--lag-control-border);
   border-radius: var(--lag-radius-sm);
-  color: var(--lag-text-2);
+  color: var(--lag-control-text);
 }
 
 .lag-button-primary {
@@ -234,10 +245,147 @@ body {
 .lag-settings-control {
   width: 100%;
   padding: var(--lag-space-2) var(--lag-space-3);
-  background-color: var(--lag-paper);
-  border: 1px solid var(--lag-border);
+  background-color: var(--lag-control-bg);
+  border: 1px solid var(--lag-control-border);
   border-radius: var(--lag-radius-sm);
   color: var(--lag-text);
+}
+
+.lag-button-secondary:hover,
+.lag-settings-control:hover,
+.lag-utility-button:hover {
+  background-color: var(--lag-control-hover-bg);
+  border-color: var(--lag-focus);
+}
+
+.lag-left-context,
+.lag-utility-drawer,
+.lag-notification-dropdown {
+  background: var(--lag-raised-surface);
+  border: 1px solid var(--lag-border);
+  box-shadow: 0 18px 44px color-mix(in srgb, var(--lag-shadow) 28%, transparent);
+  color: var(--lag-text);
+}
+
+.lag-left-context {
+  flex: 0 0 auto;
+  border-radius: var(--lag-radius-md);
+  backdrop-filter: blur(16px);
+}
+
+.lag-left-context-grid {
+  background-image:
+    linear-gradient(color-mix(in srgb, var(--lag-divider) 40%, transparent) 1px, transparent 1px),
+    linear-gradient(90deg, color-mix(in srgb, var(--lag-divider) 40%, transparent) 1px, transparent 1px);
+  background-size: 22px 22px;
+}
+
+.lag-panel-rail {
+  display: flex;
+  width: fit-content;
+  min-width: max-content;
+  height: min(680px, calc(100svh - 120px));
+  min-height: 420px;
+  align-items: center;
+  gap: var(--lag-space-3);
+}
+
+.lag-panel-stage,
+.lag-panel-frame {
+  flex: 0 0 auto;
+}
+
+.lag-panel-frame {
+  width: min(344px, calc(100vw - 32px)) !important;
+  max-height: calc(100svh - 140px);
+}
+
+.lag-panel-body {
+  max-height: min(62vh, 560px) !important;
+  overflow-y: auto;
+}
+
+.lag-panel-title,
+.lag-utility-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.lag-orb-column {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--lag-space-2);
+}
+
+.lag-utility-cluster {
+  position: relative;
+  display: flex;
+  width: 100%;
+  justify-content: center;
+  gap: 4px;
+}
+
+.lag-utility-button {
+  display: inline-flex;
+  width: 32px;
+  height: 32px;
+  flex: 0 0 32px;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  border: 1px solid var(--lag-control-border);
+  border-radius: 9999px;
+  background: var(--lag-control-bg);
+  color: var(--lag-control-text);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+}
+
+.lag-utility-drawer {
+  border-radius: var(--lag-radius-md);
+}
+
+.lag-utility-row {
+  background: var(--lag-muted-surface);
+  border-color: var(--lag-divider);
+  color: var(--lag-text);
+}
+
+.lag-role-control {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 8px 12px;
+  border: 1px solid var(--lag-control-border);
+  border-radius: var(--lag-radius-sm);
+  outline: none;
+  background: var(--lag-control-bg);
+  color: var(--lag-control-text);
+  font-size: 0.875rem;
+  letter-spacing: 0.04em;
+}
+
+.lag-role-control:hover {
+  background: var(--lag-control-hover-bg);
+}
+
+.lag-orb-label {
+  transition: color var(--lag-motion-normal) ease;
+}
+
+@media (min-width: 768px) and (max-width: 1199px) {
+  .lag-app-shell {
+    min-width: max-content;
+    align-items: center;
+  }
+
+  .lag-left-context {
+    width: clamp(344px, 42vw, 500px) !important;
+  }
 }
 
 .lag-settings-shell .lag-panel-frame {
@@ -335,12 +483,16 @@ body {
 
 @media (max-width: 767px) {
   .lag-app-shell {
-    display: block !important;
-    min-width: 0 !important;
-    padding: var(--lag-space-6) var(--lag-space-4) 112px !important;
+    display: flex !important;
+    width: max-content;
+    min-width: 100% !important;
+    align-items: center;
+    gap: var(--lag-space-3) !important;
+    padding: var(--lag-space-4) var(--lag-space-4) 140px !important;
   }
 
   .lag-orb-column {
+    display: block;
     position: fixed !important;
     right: var(--lag-space-4);
     bottom: var(--lag-space-4);
@@ -388,12 +540,16 @@ body {
   }
 
   .lag-utility-cluster {
-    top: -56px !important;
+    position: absolute;
+    top: auto !important;
     right: 0 !important;
+    bottom: calc(100% + var(--lag-space-2));
   }
 
   .lag-workspace {
-    min-width: 0 !important;
+    width: fit-content;
+    min-width: calc(100vw - 32px) !important;
+    flex: 0 0 auto;
     padding: 0;
     background-color: transparent;
     border: 0;
@@ -423,8 +579,52 @@ body {
   }
 
   .lag-panel-frame {
-    width: 100% !important;
-    max-width: none;
+    width: clamp(280px, calc(100vw - 32px), 344px) !important;
+    max-height: calc(100svh - 156px);
+  }
+
+  .lag-panel-rail {
+    height: calc(100svh - 156px);
+    min-height: 420px;
+  }
+
+  .lag-panel-body {
+    max-height: calc(100svh - 230px) !important;
+  }
+
+  .lag-left-context {
+    width: clamp(280px, calc(100vw - 32px), 344px) !important;
+    min-height: 420px !important;
+    height: calc(100svh - 156px) !important;
+  }
+
+  .lag-utility-drawer {
+    top: var(--lag-space-4) !important;
+    right: var(--lag-space-4) !important;
+    bottom: 112px;
+    width: calc(100vw - 32px) !important;
+    height: auto !important;
+    max-height: calc(100svh - 128px) !important;
+  }
+
+  .lag-notification-dropdown {
+    position: fixed !important;
+    top: auto !important;
+    right: var(--lag-space-4) !important;
+    bottom: 112px;
+    width: calc(100vw - 32px) !important;
+  }
+
+  .lag-chat-layout {
+    grid-template-columns: minmax(0, 1fr) !important;
+    grid-template-rows: minmax(96px, 32%) minmax(0, 1fr);
+  }
+
+  .lag-chat-channels {
+    border-right: 0;
+    border-bottom: 1px solid var(--lag-divider);
+    padding-right: 0;
+    padding-bottom: var(--lag-space-3);
   }
 }
 
@@ -442,7 +642,16 @@ body {
   .lag-button-secondary,
   .lag-panel-card,
   .lag-theme-option,
-  .lag-theme-preview {
+  .lag-theme-preview,
+  .lag-orb-label,
+  .lag-left-context,
+  .lag-utility-button,
+  .lag-utility-drawer,
+  .lag-notification-dropdown {
+    transition-duration: 0s;
+  }
+
+  .sao-card-shimmer:hover::after {
     transition-duration: 0s;
   }
 }
@@ -567,7 +776,7 @@ body {
 /* SAO 인풋 플레이스홀더 */
 input::placeholder,
 textarea::placeholder {
-  color: rgba(90,128,178,0.42) !important;
+  color: var(--lag-meta) !important;
 }
 
 /* select 요소 다크 */

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,17 +1,95 @@
 @import "tailwindcss";
 
+:root,
+:root[data-theme="warm-beige"],
+[data-lag-preview-theme="warm-beige"] {
+  --lag-ambient: #EDE6DA;
+  --lag-ambient-2: #F3ECE1;
+  --lag-shell: #E6DDD0;
+  --lag-nav: #E9E0D4;
+  --lag-workspace: #F5EFE5;
+  --lag-panel: #FBF7F0;
+  --lag-panel-2: #F8F1E7;
+  --lag-personal: #FFF9F1;
+  --lag-paper: #FFFDF8;
+  --lag-text: #302C29;
+  --lag-text-2: #6C6259;
+  --lag-meta: #8E8174;
+  --lag-border: #CBBDAA;
+  --lag-divider: #DDD1C1;
+  --lag-shadow: #A9967D;
+  --lag-focus: #5B9295;
+  --lag-cyan: #67A6A7;
+  --lag-violet: #82709B;
+  --lag-lav: #A89BC0;
+  --lag-amber: #C49245;
+  --lag-success: #6F8E69;
+  --lag-warning: #C07B44;
+  --lag-error: #B8615E;
+  --lag-disabled: #B9AEA0;
+  --lag-grain: #E4D8C8;
+}
+
+:root[data-theme="astral"],
+[data-lag-preview-theme="astral"] {
+  --lag-ambient: #07111F;
+  --lag-ambient-2: #0A1626;
+  --lag-shell: #0D1725;
+  --lag-nav: #0B1523;
+  --lag-workspace: #111C2A;
+  --lag-panel: #162337;
+  --lag-panel-2: #1A2A40;
+  --lag-personal: #1B2B42;
+  --lag-paper: #203048;
+  --lag-text: #F4F7FB;
+  --lag-text-2: #AAB8C8;
+  --lag-meta: #7F91A5;
+  --lag-border: #2B3E55;
+  --lag-divider: #22344A;
+  --lag-shadow: #02060D;
+  --lag-focus: #54D4DE;
+  --lag-cyan: #54D4DE;
+  --lag-violet: #8B72D8;
+  --lag-lav: #A99AE3;
+  --lag-amber: #D9A456;
+  --lag-success: #63A783;
+  --lag-warning: #D69A56;
+  --lag-error: #D86D72;
+  --lag-disabled: #536171;
+  --lag-grain: #142034;
+}
+
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  --lag-space-1: 4px;
+  --lag-space-2: 8px;
+  --lag-space-3: 12px;
+  --lag-space-4: 16px;
+  --lag-space-6: 24px;
+  --lag-space-8: 32px;
+  --lag-radius-sm: 12px;
+  --lag-radius-md: 16px;
+  --lag-radius-lg: 22px;
+  --lag-radius-xl: 28px;
+  --lag-motion-fast: 120ms;
+  --lag-motion-normal: 180ms;
+  --lag-motion-panel: 240ms;
+  --lag-state-success: var(--lag-success);
+  --lag-state-warning: var(--lag-warning);
+  --lag-state-error: var(--lag-error);
+  --lag-state-info: var(--lag-focus);
+  --lag-state-focus: var(--lag-focus);
+  --lag-state-selected: var(--lag-violet);
+  --lag-state-disabled: var(--lag-disabled);
+  --lag-state-pending: var(--lag-amber);
+  --lag-state-read-only: var(--lag-meta);
+  --background: var(--lag-ambient);
+  --foreground: var(--lag-text);
   --drift: 14px;
 
   color-scheme: light;
 }
 
 :root[data-theme="astral"] {
-  --background: #0a0a0a;
-  --foreground: #ededed;
-
   color-scheme: dark;
 }
 
@@ -19,6 +97,354 @@ body {
   background: var(--background);
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
+}
+
+:where(button, input, select, textarea):focus-visible {
+  outline: 2px solid var(--lag-state-focus);
+  outline-offset: 2px;
+}
+
+:where(button, input, select, textarea):disabled {
+  cursor: not-allowed;
+  opacity: 0.62;
+}
+
+.lag-app-surface {
+  background-color: var(--lag-ambient);
+  background-image:
+    linear-gradient(color-mix(in srgb, var(--lag-divider) 32%, transparent) 1px, transparent 1px),
+    linear-gradient(90deg, color-mix(in srgb, var(--lag-divider) 32%, transparent) 1px, transparent 1px),
+    radial-gradient(ellipse at 16% 22%, color-mix(in srgb, var(--lag-cyan) 13%, transparent), transparent 48%),
+    radial-gradient(ellipse at 84% 14%, color-mix(in srgb, var(--lag-amber) 9%, transparent), transparent 38%),
+    linear-gradient(180deg, var(--lag-ambient), var(--lag-ambient-2));
+  background-size: 44px 44px, 44px 44px, 100% 100%, 100% 100%, 100% 100%;
+  color: var(--lag-text);
+}
+
+.lag-app-surface,
+.lag-orb-nav,
+.lag-workspace,
+.lag-panel-frame,
+.lag-row,
+.lag-info-card,
+.lag-home-surface,
+.lag-home-card,
+.lag-settings-control,
+.lag-button-primary,
+.lag-button-secondary,
+.lag-panel-card,
+.lag-theme-option,
+.lag-theme-preview {
+  transition:
+    background-color var(--lag-motion-normal) ease,
+    border-color var(--lag-motion-normal) ease,
+    box-shadow var(--lag-motion-normal) ease,
+    color var(--lag-motion-normal) ease;
+}
+
+.lag-orb-nav {
+  background-color: color-mix(in srgb, var(--lag-nav) 96%, transparent);
+  border: 1px solid var(--lag-border);
+  border-radius: var(--lag-radius-xl);
+  box-shadow: 0 18px 44px color-mix(in srgb, var(--lag-shadow) 28%, transparent);
+}
+
+.lag-workspace {
+  padding: var(--lag-space-6);
+  background-color: color-mix(in srgb, var(--lag-workspace) 94%, transparent);
+  border: 1px solid var(--lag-border);
+  border-radius: var(--lag-radius-lg);
+}
+
+.lag-panel-frame {
+  background-color: var(--lag-panel);
+  border: 1px solid var(--lag-border);
+  border-radius: var(--lag-radius-md);
+  box-shadow: 0 18px 40px color-mix(in srgb, var(--lag-shadow) 24%, transparent);
+  color: var(--lag-text);
+}
+
+.lag-panel-header {
+  background-color: var(--lag-panel-2);
+  border-bottom: 1px solid var(--lag-divider);
+}
+
+.lag-row,
+.lag-info-card,
+.lag-home-card {
+  background-color: var(--lag-paper);
+  border: 1px solid var(--lag-divider);
+  color: var(--lag-text);
+}
+
+.lag-row,
+.lag-info-card {
+  border-radius: var(--lag-radius-sm);
+}
+
+.lag-home {
+  min-width: 0;
+}
+
+.lag-home-surface {
+  background-color: var(--lag-panel);
+  border: 1px solid var(--lag-border);
+  border-radius: var(--lag-radius-md);
+  box-shadow: 0 14px 32px color-mix(in srgb, var(--lag-shadow) 16%, transparent);
+}
+
+.lag-home-hero {
+  border-left: 4px solid var(--lag-cyan);
+}
+
+.lag-home-card {
+  border-radius: var(--lag-radius-sm);
+}
+
+.lag-home-card:hover {
+  border-color: var(--lag-focus);
+}
+
+.lag-text-primary {
+  color: var(--lag-text);
+}
+
+.lag-text-secondary {
+  color: var(--lag-text-2);
+}
+
+.lag-text-meta {
+  color: var(--lag-text-2);
+}
+
+.lag-button-secondary {
+  background-color: var(--lag-paper);
+  border: 1px solid var(--lag-border);
+  border-radius: var(--lag-radius-sm);
+  color: var(--lag-text-2);
+}
+
+.lag-button-primary {
+  background-color: var(--lag-panel-2);
+  border: 1px solid var(--lag-focus);
+  border-radius: var(--lag-radius-sm);
+  color: var(--lag-text);
+}
+
+.lag-settings-control {
+  width: 100%;
+  padding: var(--lag-space-2) var(--lag-space-3);
+  background-color: var(--lag-paper);
+  border: 1px solid var(--lag-border);
+  border-radius: var(--lag-radius-sm);
+  color: var(--lag-text);
+}
+
+.lag-settings-shell .lag-panel-frame {
+  width: min(560px, calc(100vw - 32px)) !important;
+}
+
+.lag-settings-label {
+  color: var(--lag-text-2);
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.lag-theme-picker {
+  display: grid;
+  gap: var(--lag-space-3);
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.lag-theme-option {
+  position: relative;
+  display: grid;
+  min-height: 132px;
+  gap: var(--lag-space-2);
+  padding: var(--lag-space-4);
+  background-color: var(--lag-panel-2);
+  border: 1px solid var(--lag-border);
+  border-radius: var(--lag-radius-md);
+  color: var(--lag-text);
+  cursor: pointer;
+}
+
+.lag-theme-option:has(input:checked) {
+  background-color: color-mix(in srgb, var(--lag-focus) 9%, var(--lag-panel));
+  border: 2px solid var(--lag-focus);
+  padding: calc(var(--lag-space-4) - 1px);
+}
+
+.lag-theme-option-system {
+  min-height: 72px;
+  grid-column: 1 / -1;
+}
+
+.lag-theme-option input {
+  position: absolute;
+  top: var(--lag-space-4);
+  right: var(--lag-space-4);
+  accent-color: var(--lag-focus);
+}
+
+.lag-theme-option:has(input:disabled) {
+  cursor: not-allowed;
+  opacity: 0.62;
+}
+
+.lag-theme-swatches {
+  display: flex;
+  gap: var(--lag-space-2);
+  margin-top: auto;
+}
+
+.lag-theme-swatch {
+  width: 22px;
+  height: 22px;
+  border: 1px solid var(--lag-border);
+  border-radius: 50%;
+}
+
+.lag-theme-swatch:nth-child(1) { background-color: var(--lag-ambient); }
+.lag-theme-swatch:nth-child(2) { background-color: var(--lag-panel); }
+.lag-theme-swatch:nth-child(3) { background-color: var(--lag-cyan); }
+.lag-theme-swatch:nth-child(4) { background-color: var(--lag-violet); }
+.lag-theme-swatch:nth-child(5) { background-color: var(--lag-amber); }
+
+.lag-theme-preview {
+  display: grid;
+  min-height: 112px;
+  place-items: center;
+  background-color: var(--lag-workspace);
+  border: 1px solid var(--lag-border);
+  border-radius: var(--lag-radius-md);
+  color: var(--lag-text);
+}
+
+.lag-state-error {
+  padding-left: var(--lag-space-2);
+  color: var(--lag-text);
+  border-left: 3px solid var(--lag-state-error);
+}
+
+.lag-state-success {
+  color: var(--lag-state-success);
+}
+
+@media (max-width: 767px) {
+  .lag-app-shell {
+    display: block !important;
+    min-width: 0 !important;
+    padding: var(--lag-space-6) var(--lag-space-4) 112px !important;
+  }
+
+  .lag-orb-column {
+    position: fixed !important;
+    right: var(--lag-space-4);
+    bottom: var(--lag-space-4);
+    left: var(--lag-space-4);
+    z-index: 500000;
+    width: auto !important;
+  }
+
+  .lag-orb-nav {
+    width: 100% !important;
+    height: 76px !important;
+    padding: 0 var(--lag-space-2) !important;
+  }
+
+  .lag-orb-scroll {
+    width: 100%;
+    height: auto !important;
+    overflow-x: auto !important;
+    overflow-y: hidden !important;
+  }
+
+  .lag-orb-track {
+    min-width: max-content;
+    flex-direction: row !important;
+    gap: var(--lag-space-4) !important;
+    padding: var(--lag-space-2) !important;
+  }
+
+  .lag-orb-item {
+    min-height: 48px !important;
+  }
+
+  .lag-orb-icon,
+  .lag-orb-icon > img {
+    width: 42px !important;
+    height: 42px !important;
+  }
+
+  .lag-orb-icon span {
+    font-size: 10px !important;
+  }
+
+  .lag-orb-label {
+    display: none !important;
+  }
+
+  .lag-utility-cluster {
+    top: -56px !important;
+    right: 0 !important;
+  }
+
+  .lag-workspace {
+    min-width: 0 !important;
+    padding: 0;
+    background-color: transparent;
+    border: 0;
+    border-radius: 0;
+    overflow: visible !important;
+  }
+
+  .lag-home-grid,
+  .lag-theme-picker {
+    grid-template-columns: 1fr;
+  }
+
+  .lag-theme-option-system {
+    grid-column: auto;
+  }
+
+  .lag-settings-route {
+    width: 100% !important;
+  }
+
+  .lag-settings-shell {
+    width: 100%;
+  }
+
+  .lag-settings-route > :first-child {
+    display: none;
+  }
+
+  .lag-panel-frame {
+    width: 100% !important;
+    max-width: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .lag-app-surface,
+  .lag-orb-nav,
+  .lag-workspace,
+  .lag-panel-frame,
+  .lag-row,
+  .lag-info-card,
+  .lag-home-surface,
+  .lag-home-card,
+  .lag-settings-control,
+  .lag-button-primary,
+  .lag-button-secondary,
+  .lag-panel-card,
+  .lag-theme-option,
+  .lag-theme-preview {
+    transition-duration: 0s;
+  }
 }
 
 /* ═══════════════════════════════════════════════════
@@ -115,8 +541,8 @@ body {
   background: linear-gradient(
     105deg,
     transparent 30%,
-    rgba(120, 200, 255, 0.09) 48%,
-    rgba(200, 230, 255, 0.06) 52%,
+    color-mix(in srgb, var(--lag-focus) 9%, transparent) 48%,
+    color-mix(in srgb, var(--lag-cyan) 6%, transparent) 52%,
     transparent 70%
   );
   pointer-events: none;
@@ -173,6 +599,11 @@ select {
 #sao-particles,
 #sao-particles canvas {
   pointer-events: none !important;
+}
+
+:root[data-theme="warm-beige"] #sao-particles,
+:root[data-theme="warm-beige"] .lag-ambient-overlay {
+  display: none;
 }
 
 /* ═══════════════════════════════════════════════════

--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -1,4 +1,6 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { readFileSync } from "node:fs";
+import { useState } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { MainNavId, PanelStackItem } from "@/entities/nav";
@@ -40,7 +42,12 @@ vi.mock("@/features/lifelog/ExerciseShell", () => ({ default: () => <div data-te
 vi.mock("@/features/lifelog/MediaShell", () => ({ default: () => <div data-testid="media-shell">Media Shell</div> }));
 vi.mock("@/features/player/AchievementShell", () => ({ default: () => <div data-testid="achievement-shell">Achievement Shell</div> }));
 vi.mock("@/features/player/CertificationShell", () => ({ default: () => <div data-testid="certification-shell">Certification Shell</div> }));
-vi.mock("@/features/player/TitleShell", () => ({ default: () => <div data-testid="title-shell">Title Shell</div> }));
+vi.mock("@/features/player/TitleShell", () => ({
+  default: function MockTitleShell() {
+    const [detail, setDetail] = useState(false);
+    return <div data-testid="title-shell">Title Shell<button type="button" onClick={() => setDetail(true)}>Select Mock Title</button>{detail ? <span>Mock Title Detail</span> : null}</div>;
+  },
+}));
 vi.mock("@/features/player/HobbyShell", () => ({ default: () => <div data-testid="hobby-shell">Hobby Shell</div> }));
 vi.mock("@/features/inventory/InventoryShell", () => ({ default: ({ surface }: { surface: string }) => <div data-testid="inventory-shell">Inventory · {surface}</div> }));
 vi.mock("@/features/inventory/GearShell", () => ({ default: () => <div data-testid="gear-shell">Gear Shell</div> }));
@@ -82,6 +89,18 @@ describe("Home shell에서 feature surface를 routing할 때", () => {
         { changeId: 1, requestedExp: 10, appliedExp: 10, leftoverExp: 0, beforeLevel: 7, afterLevel: 7, beforeTotalExp: 752, afterTotalExp: 762, occurredAt: "2026-08-13T09:00:00Z", sourceType: null, sourceId: 999 },
       ],
     });
+  });
+
+  it("utility와 responsive stage geometry를 shared layout/camera contract로 묶는다", () => {
+    const page = readFileSync("app/page.tsx", "utf8");
+    const css = readFileSync("app/globals.css", "utf8");
+
+    expect(page).toContain("useStageCamera(viewportRef, workspaceRef");
+    expect(page).not.toContain("right: -14");
+    expect(css).toContain(".lag-panel-rail");
+    expect(css).toContain("flex: 0 0 auto");
+    expect(css).toContain("width: clamp(280px, calc(100vw - 32px), 344px)");
+    expect(css).toContain("text-overflow: ellipsis");
   });
 
   describe("인증된 player가 처음 진입하면", () => {
@@ -220,6 +239,19 @@ describe("Home shell에서 feature surface를 routing할 때", () => {
 
       expect(screen.getByTestId("title-shell")).toBeInTheDocument();
       expect(screen.queryByRole("button", { name: "Combat" })).not.toBeInTheDocument();
+    });
+
+    it("다른 Player submenu로 전환했다 돌아오면 이전 detail state를 복원하지 않는다", () => {
+      render(<Home />);
+
+      fireEvent.click(screen.getByRole("button", { name: "Player" }));
+      fireEvent.click(screen.getByRole("button", { name: "Title" }));
+      fireEvent.click(screen.getByRole("button", { name: "Select Mock Title" }));
+      expect(screen.getByText("Mock Title Detail")).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole("button", { name: "Growth" }));
+      fireEvent.click(screen.getByRole("button", { name: "Title" }));
+      expect(screen.queryByText("Mock Title Detail")).not.toBeInTheDocument();
     });
   });
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -753,27 +753,10 @@ export default function Home() {
   return (
     <div
       ref={viewportRef}
-      className="h-screen overflow-auto"
-      style={{
-        /* SAO 가상공간 배경 — 파란 격자 + 방사형 빛 + 깊이감 */
-        background: [
-          /* 파란 격자 — 홀로그램 바닥 */
-          "linear-gradient(rgba(82,127,214,0.042) 1px, transparent 1px)",
-          "linear-gradient(90deg, rgba(82,127,214,0.042) 1px, transparent 1px)",
-          /* 좌상단 파란 빛 */
-          "radial-gradient(ellipse at 16% 22%, rgba(82,127,214,0.22) 0%, transparent 48%)",
-          /* 우상단 골드 빛 */
-          "radial-gradient(ellipse at 84% 14%, rgba(247,191,78,0.09) 0%, transparent 38%)",
-          /* 중앙 하단 보조 파란 빛 */
-          "radial-gradient(ellipse at 50% 88%, rgba(60,100,200,0.10) 0%, transparent 44%)",
-          /* 기본 다크 그라데이션 */
-          "linear-gradient(180deg, #06080d 0%, #08090f 40%, #090b11 100%)",
-        ].join(", "),
-        backgroundSize: "44px 44px, 44px 44px, 100% 100%, 100% 100%, 100% 100%, 100% 100%",
-      }}
+      className="lag-app-surface h-screen overflow-auto"
     >
       <main
-        className="mx-auto flex w-full min-w-max items-center"
+        className="lag-app-shell mx-auto flex w-full min-w-max items-center"
         style={{
           minHeight: "100vh",
           gap: UI_CONSTS.layout.columnGap,
@@ -798,8 +781,8 @@ export default function Home() {
           zIndex={getSurfaceZIndex("left-context", SURFACE_GROUP_BASE_Z.left)}
         />
 
-        <div className="shrink-0" style={{ width: UI_CONSTS.layout.centerWidth, position: "relative" }}>
-          <div className="flex items-center gap-2" style={{ position: "absolute", top: 0, right: -14, zIndex: getSurfaceZIndex("orb-nav", SURFACE_GROUP_BASE_Z.nav) + 1 }}>
+        <div className="lag-orb-column shrink-0" style={{ width: UI_CONSTS.layout.centerWidth, position: "relative" }}>
+          <div className="lag-utility-cluster flex items-center gap-2" style={{ position: "absolute", top: 0, right: -14, zIndex: getSurfaceZIndex("orb-nav", SURFACE_GROUP_BASE_Z.nav) + 1 }}>
             <SocialUtilityHub />
             <NotificationBell />
           </div>
@@ -812,7 +795,7 @@ export default function Home() {
           />
         </div>
 
-        <div className="scrollbar-hide min-w-0 flex-1 overflow-x-auto" style={{ minWidth: UI_CONSTS.layout.rightMinWidth }}>
+        <div className="lag-workspace scrollbar-hide min-w-0 flex-1 overflow-x-auto" style={{ minWidth: UI_CONSTS.layout.rightMinWidth }}>
           {selectedMain === null ? (
             <HomeShell
               onOpenJournal={() => {
@@ -944,7 +927,7 @@ export default function Home() {
               <MediaShell />
             </div>
           ) : selectedMain === "system" && selectedSubByMain.system === "options" ? (
-            <div className="flex w-fit items-center gap-3">
+            <div className="lag-settings-route flex w-fit items-center gap-3">
               <RightPanels selectedMain="system" panelStack={panelStack.slice(0, 1)} panelStackKey="system-settings-menu" onPanelItemSelect={handlePanelItemSelect} />
               <SettingsShell />
             </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -28,6 +28,7 @@ import SocialUtilityHub from "@/features/social/SocialUtilityHub";
 import SettingsShell from "@/features/system/settings/SettingsShell";
 import { useRoles } from "@/features/role/useRoles";
 import { usePanScroll } from "@/shared/hooks/usePanScroll";
+import { useStageCamera } from "@/shared/hooks/useStageCamera";
 import { MOCK_CHARACTER_SHEET } from "@/features/player/mock";
 import {
   DEFAULT_SUB_SELECTIONS,
@@ -376,6 +377,7 @@ export default function Home() {
   const playerInfo = MOCK_CHARACTER_SHEET.player;
 
   const viewportRef = useRef<HTMLDivElement>(null);
+  const workspaceRef = useRef<HTMLDivElement>(null);
   const formOpenCountRef = useRef(0);
   usePanScroll(viewportRef);
 
@@ -481,6 +483,7 @@ export default function Home() {
     setSelectedDetailByKey(createDefaultDetailSelections());
     setActiveFormPanel(null);
     setEditingItemId(null);
+    setSelectedRoleId(null);
   };
 
   const handleMainSelect = (nextMain: MainNavId) => {
@@ -737,16 +740,7 @@ export default function Home() {
   const leftContextMode =
     selectedMain === "player" ? "player" : selectedMain === "role" ? "role" : selectedMain === "social" ? "social" : "hidden";
 
-  // Auto-scroll viewport right when panel stack grows (new panel added)
-  const prevPanelLengthRef = useRef(0);
-  useEffect(() => {
-    if (panelStack.length > prevPanelLengthRef.current) {
-      requestAnimationFrame(() => {
-        viewportRef.current?.scrollTo({ left: viewportRef.current.scrollWidth, behavior: "smooth" });
-      });
-    }
-    prevPanelLengthRef.current = panelStack.length;
-  }, [panelStack.length]);
+  useStageCamera(viewportRef, workspaceRef, selectedMain ?? "home");
 
   if (isLoading || !isAuthenticated || !playerId) return null;
 
@@ -782,7 +776,7 @@ export default function Home() {
         />
 
         <div className="lag-orb-column shrink-0" style={{ width: UI_CONSTS.layout.centerWidth, position: "relative" }}>
-          <div className="lag-utility-cluster flex items-center gap-2" style={{ position: "absolute", top: 0, right: -14, zIndex: getSurfaceZIndex("orb-nav", SURFACE_GROUP_BASE_Z.nav) + 1 }}>
+          <div className="lag-utility-cluster" style={{ zIndex: getSurfaceZIndex("orb-nav", SURFACE_GROUP_BASE_Z.nav) + 1 }}>
             <SocialUtilityHub />
             <NotificationBell />
           </div>
@@ -795,7 +789,7 @@ export default function Home() {
           />
         </div>
 
-        <div className="lag-workspace scrollbar-hide min-w-0 flex-1 overflow-x-auto" style={{ minWidth: UI_CONSTS.layout.rightMinWidth }}>
+        <div ref={workspaceRef} className="lag-workspace scrollbar-hide min-w-0 flex-1 overflow-x-auto" style={{ minWidth: UI_CONSTS.layout.rightMinWidth }}>
           {selectedMain === null ? (
             <HomeShell
               onOpenJournal={() => {
@@ -878,7 +872,7 @@ export default function Home() {
               />
             </div>
           ) : selectedMain === "quests" ? (
-            <JourneyShell initialSurface={(selectedSubByMain.quests as QuestsSubId | null) ?? "current"} />
+            <JourneyShell initialSurface={selectedSubByMain.quests as QuestsSubId | null} />
           ) : selectedMain === "inventory" && selectedSubByMain.inventory ? (
             <div className="flex w-fit items-center gap-3">
               <RightPanels

--- a/features/home/HomeShell.tsx
+++ b/features/home/HomeShell.tsx
@@ -2,7 +2,6 @@
 
 import type { ReactNode } from "react";
 
-import { SAO } from "@/shared/design/tokens";
 import type { HomeJournalEntry } from "./model";
 import { useHomeQuery } from "./useHomeQuery";
 
@@ -15,16 +14,12 @@ type HomeShellProps = {
 };
 
 const buttonStyle = {
-  border: `1px solid ${SAO.color.border.panel}`,
-  background: SAO.color.bg.inset,
-  color: SAO.color.text.primary,
-  borderRadius: SAO.radius.panel,
+  borderRadius: "var(--lag-radius-sm)",
 } as const;
 
 const retryStyle = {
   ...buttonStyle,
   padding: "7px 12px",
-  color: SAO.color.text.secondary,
   fontSize: "0.72rem",
 } as const;
 
@@ -35,10 +30,10 @@ function WorldSection({ title, actionLabel, onOpen, children }: {
   children: ReactNode;
 }) {
   return (
-    <section className="min-w-0 space-y-3 rounded-md border p-4" style={{ background: SAO.color.bg.panel, borderColor: SAO.color.border.panel }}>
+    <section className="lag-home-surface min-w-0 space-y-3 p-4">
       <div className="flex items-center justify-between gap-3">
-        <h2 className="text-sm font-semibold tracking-[0.12em]" style={{ color: SAO.color.text.primary }}>{title}</h2>
-        {onOpen ? <button type="button" style={retryStyle} onClick={onOpen}>{actionLabel}</button> : null}
+        <h2 className="lag-text-primary text-sm font-semibold tracking-[0.12em]">{title}</h2>
+        {onOpen ? <button type="button" className="lag-button-secondary" style={retryStyle} onClick={onOpen}>{actionLabel}</button> : null}
       </div>
       {children}
     </section>
@@ -46,11 +41,11 @@ function WorldSection({ title, actionLabel, onOpen, children }: {
 }
 
 function Empty({ children }: { children: ReactNode }) {
-  return <p className="text-sm" style={{ color: SAO.color.text.label }}>{children}</p>;
+  return <p className="lag-text-meta text-sm">{children}</p>;
 }
 
 function Meta({ children }: { children: ReactNode }) {
-  return <p className="text-xs" style={{ color: SAO.color.text.label }}>{children}</p>;
+  return <p className="lag-text-meta text-xs">{children}</p>;
 }
 
 function journalPreview(entry: HomeJournalEntry) {
@@ -93,9 +88,9 @@ function journalPreview(entry: HomeJournalEntry) {
 
 function HomeError({ message, retry }: { message: string; retry: () => void }) {
   return (
-    <div className="flex items-center justify-between gap-4 rounded-md border p-4" style={{ background: SAO.color.bg.panel, borderColor: SAO.color.action.red }}>
-      <p role="alert" className="text-sm" style={{ color: SAO.color.action.red }}>{message}</p>
-      <button type="button" style={retryStyle} onClick={retry}>Retry</button>
+    <div className="lag-home-surface flex items-center justify-between gap-4 border-l-4 p-4" style={{ borderLeftColor: "var(--lag-state-error)" }}>
+      <p role="alert" className="lag-state-error text-sm">Error: {message}</p>
+      <button type="button" className="lag-button-secondary" style={retryStyle} onClick={retry}>Retry</button>
     </div>
   );
 }
@@ -116,16 +111,16 @@ export default function HomeShell({
   if (!data) return null;
 
   return (
-    <div className="w-[min(980px,calc(100vw-180px))] min-w-[720px] space-y-4" data-testid="home-shell">
-      <header className="rounded-md border px-5 py-4" style={{ background: SAO.color.bg.panel, borderColor: SAO.color.border.gold }}>
-        <p className="text-xs tracking-[0.18em]" style={{ color: SAO.color.text.label }}>AUTHENTICATED WORLD</p>
-        <h1 className="mt-1 text-xl font-semibold" style={{ color: SAO.color.text.primary }}>Home</h1>
+    <div className="lag-home w-full max-w-[1200px] space-y-4" data-testid="home-shell">
+      <header className="lag-home-surface lag-home-hero px-5 py-4">
+        <p className="lag-text-meta text-xs tracking-[0.18em]">AUTHENTICATED WORLD</p>
+        <h1 className="lag-text-primary mt-1 text-xl font-semibold">Home</h1>
         <Meta>Generated <time dateTime={data.generatedAt}>{data.generatedAt}</time>{home.loading ? " · Refreshing" : ""}</Meta>
       </header>
 
       {home.error ? <HomeError message={home.error} retry={() => void home.reload()} /> : null}
 
-      <div className="grid grid-cols-2 gap-4">
+      <div className="lag-home-grid grid grid-cols-2 gap-4">
         <WorldSection title="Recent Journal" actionLabel="Open Journal" onOpen={onOpenJournal}>
           {data.recentJournal.length === 0 ? <Empty>No recent Journal entries.</Empty> : (
             <div className="space-y-2">
@@ -139,7 +134,7 @@ export default function HomeShell({
                   entry.roleEventId === null ? null : `Event #${entry.roleEventId}`,
                 ].filter((value): value is string => value !== null);
                 return (
-                  <button key={entry.lifeLogId} type="button" className="block w-full p-3 text-left" style={buttonStyle} onClick={onOpenJournal}>
+                  <button key={entry.lifeLogId} type="button" className="lag-home-card block w-full p-3 text-left" style={buttonStyle} onClick={onOpenJournal}>
                     <p className="text-sm font-semibold">{preview.title}</p>
                     <Meta>{preview.detail.filter((value): value is string => value !== null).join(" · ")}</Meta>
                     <Meta>{metadata.join(" · ")}</Meta>
@@ -155,10 +150,10 @@ export default function HomeShell({
           {data.recentAchievements.length === 0 ? <Empty>No recent Achievements.</Empty> : (
             <div className="space-y-2">
               {data.recentAchievements.map((achievement) => (
-                <button key={achievement.achievementId} type="button" className="block w-full p-3 text-left" style={buttonStyle} onClick={onOpenAchievements}>
+                <button key={achievement.achievementId} type="button" className="lag-home-card block w-full p-3 text-left" style={buttonStyle} onClick={onOpenAchievements}>
                   <p className="text-sm font-semibold">{achievement.name}</p>
                   <Meta>{achievement.category}</Meta>
-                  <p className="line-clamp-2 text-xs" style={{ color: SAO.color.text.secondary }}>{achievement.descMd}</p>
+                  <p className="lag-text-secondary line-clamp-2 text-xs">{achievement.descMd}</p>
                   <Meta><time dateTime={achievement.acquiredAt}>{achievement.acquiredAt}</time></Meta>
                 </button>
               ))}
@@ -166,15 +161,15 @@ export default function HomeShell({
           )}
         </WorldSection>
 
-        <section className="min-w-0 space-y-4 rounded-md border p-4" style={{ background: SAO.color.bg.panel, borderColor: SAO.color.border.panel }}>
-          <h2 className="text-sm font-semibold tracking-[0.12em]" style={{ color: SAO.color.text.primary }}>Current Journey</h2>
+        <section className="lag-home-surface min-w-0 space-y-4 p-4">
+          <h2 className="lag-text-primary text-sm font-semibold tracking-[0.12em]">Current Journey</h2>
           <div className="space-y-2">
             <div className="flex items-center justify-between gap-3">
-              <h3 className="text-xs font-semibold" style={{ color: SAO.color.text.secondary }}>Current Quests</h3>
-              <button type="button" style={retryStyle} onClick={onOpenCurrentQuests}>Open Quests</button>
+              <h3 className="lag-text-secondary text-xs font-semibold">Current Quests</h3>
+              <button type="button" className="lag-button-secondary" style={retryStyle} onClick={onOpenCurrentQuests}>Open Quests</button>
             </div>
             {data.journey.currentQuests.length === 0 ? <Empty>No current Quests.</Empty> : data.journey.currentQuests.map((quest) => (
-              <button key={quest.acceptanceId} type="button" className="block w-full p-3 text-left" style={buttonStyle} onClick={onOpenCurrentQuests}>
+              <button key={quest.acceptanceId} type="button" className="lag-home-card block w-full p-3 text-left" style={buttonStyle} onClick={onOpenCurrentQuests}>
                 <p className="text-sm font-semibold">{quest.title}</p>
                 <Meta>{quest.status} · {quest.progressValue} / {quest.targetValue}</Meta>
                 <Meta>Accepted <time dateTime={quest.acceptedAt}>{quest.acceptedAt}</time></Meta>
@@ -184,11 +179,11 @@ export default function HomeShell({
           </div>
           <div className="space-y-2">
             <div className="flex items-center justify-between gap-3">
-              <h3 className="text-xs font-semibold" style={{ color: SAO.color.text.secondary }}>Selected Routes</h3>
-              <button type="button" style={retryStyle} onClick={onOpenRoutes}>Open Routes</button>
+              <h3 className="lag-text-secondary text-xs font-semibold">Selected Routes</h3>
+              <button type="button" className="lag-button-secondary" style={retryStyle} onClick={onOpenRoutes}>Open Routes</button>
             </div>
             {data.journey.selectedRoutes.length === 0 ? <Empty>No selected Routes.</Empty> : data.journey.selectedRoutes.map((route) => (
-              <button key={route.routeId} type="button" className="block w-full p-3 text-left" style={buttonStyle} onClick={onOpenRoutes}>
+              <button key={route.routeId} type="button" className="lag-home-card block w-full p-3 text-left" style={buttonStyle} onClick={onOpenRoutes}>
                 <p className="text-sm font-semibold">{route.title}</p>
                 <Meta>{route.status}{route.currentStepId === null ? "" : ` · Current Step #${route.currentStepId}`}</Meta>
                 <Meta>Selected <time dateTime={route.selectedAt}>{route.selectedAt}</time></Meta>
@@ -208,7 +203,7 @@ export default function HomeShell({
           {data.roleActivity30d.assignedRecords === 0 ? <Empty>No assigned Role activity.</Empty> : (
             <div className="space-y-2">
               {data.roleActivity30d.roles.map((role) => (
-                <button key={role.roleId} type="button" className="block w-full p-3 text-left" style={buttonStyle} onClick={() => onOpenRole(role.roleId)}>
+                <button key={role.roleId} type="button" className="lag-home-card block w-full p-3 text-left" style={buttonStyle} onClick={() => onOpenRole(role.roleId)}>
                   <p className="text-sm font-semibold">{role.roleName ?? `Role #${role.roleId}`}</p>
                   <Meta>{role.recordCount} records · {percent.format(role.share)}</Meta>
                 </button>

--- a/features/notification/NotificationBell.test.tsx
+++ b/features/notification/NotificationBell.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react";
+import { readFileSync } from "node:fs";
 import { renderToStaticMarkup } from "react-dom/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -63,5 +64,14 @@ describe("NotificationBell canonical surface", () => {
     expect(first).toBe(second);
     expect(first).toContain("2026-08-18 12:34 UTC");
     expect(now).not.toHaveBeenCalled();
+  });
+
+  it("uses dual-theme semantic surfaces without the fixed dark/gold container", () => {
+    const source = readFileSync("features/notification/NotificationBell.tsx", "utf8");
+
+    expect(source).toContain("lag-utility-button");
+    expect(source).toContain("lag-notification-dropdown");
+    expect(source).toContain("var(--lag-control-bg)");
+    expect(source).not.toMatch(/rgba\(|#[0-9a-fA-F]{3,8}/);
   });
 });

--- a/features/notification/NotificationBell.tsx
+++ b/features/notification/NotificationBell.tsx
@@ -7,15 +7,15 @@ import type { NotificationInfo, NotificationType } from "@/shared/api/types";
 import { useNotifications } from "./useNotifications";
 
 const TYPE_META: Record<NotificationType, { color: string; icon: string; label: string }> = {
-  MAIL_RECEIVED: { color: "rgba(74,158,255,0.85)", icon: "✉", label: "Mail received" },
-  QUEST_PROGRESS: { color: "rgba(218,178,55,0.9)", icon: "⚔", label: "Quest progress" },
-  QUEST_COMPLETED: { color: "rgba(218,178,55,0.9)", icon: "✓", label: "Quest completed" },
-  QUEST_REWARD_READY: { color: "rgba(248,197,78,1)", icon: "★", label: "Quest reward ready" },
-  LISTING_SOLD: { color: "rgba(74,222,128,0.85)", icon: "◆", label: "Listing sold" },
-  ACHIEVEMENT_UNLOCK: { color: "rgba(248,197,78,1)", icon: "★", label: "Achievement unlocked" },
-  SYSTEM_NOTICE: { color: "rgba(160,160,180,0.6)", icon: "!", label: "System notice" },
+  MAIL_RECEIVED: { color: "var(--lag-state-info)", icon: "✉", label: "Mail received" },
+  QUEST_PROGRESS: { color: "var(--lag-state-pending)", icon: "⚔", label: "Quest progress" },
+  QUEST_COMPLETED: { color: "var(--lag-state-success)", icon: "✓", label: "Quest completed" },
+  QUEST_REWARD_READY: { color: "var(--lag-amber)", icon: "★", label: "Quest reward ready" },
+  LISTING_SOLD: { color: "var(--lag-state-success)", icon: "◆", label: "Listing sold" },
+  ACHIEVEMENT_UNLOCK: { color: "var(--lag-state-selected)", icon: "★", label: "Achievement unlocked" },
+  SYSTEM_NOTICE: { color: "var(--lag-text-2)", icon: "!", label: "System notice" },
 };
-const UNKNOWN_TYPE_META = { color: "rgba(160,160,180,0.6)", icon: "!", label: "Notification" };
+const UNKNOWN_TYPE_META = { color: "var(--lag-text-2)", icon: "!", label: "Notification" };
 
 function isKnownNotificationType(type: string): type is NotificationType {
   return Object.prototype.hasOwnProperty.call(TYPE_META, type);
@@ -41,17 +41,17 @@ function NotificationRow({ notification, pending, onMarkRead }: {
         alignItems: "flex-start",
         gap: 10,
         padding: "9px 14px",
-        borderBottom: "1px solid rgba(200,165,50,0.08)",
-        background: notification.read ? "transparent" : "rgba(218,178,55,0.04)",
+        borderBottom: "1px solid var(--lag-divider)",
+        background: notification.read ? "transparent" : "var(--lag-selected-surface)",
       }}
     >
       <span role="img" aria-label={meta.label} title={meta.label} style={{ width: 22, height: 22, borderRadius: "50%", border: `1.5px solid ${meta.color}`, display: "flex", alignItems: "center", justifyContent: "center", fontSize: 10, color: meta.color, flexShrink: 0, marginTop: 1 }}>{meta.icon}</span>
       <div style={{ flex: 1, minWidth: 0 }}>
-        <strong style={{ display: "block", fontSize: 11, fontWeight: notification.read ? 400 : 600, color: notification.read ? "rgba(185,172,140,0.75)" : "rgba(235,218,175,0.95)", lineHeight: 1.35, overflow: "hidden", textOverflow: "ellipsis" }}>{notification.title}</strong>
-        <p style={{ fontSize: 10, color: "rgba(160,148,115,0.7)", marginTop: 2, lineHeight: 1.3 }}>{notification.body}</p>
-        <div style={{ marginTop: 4, fontSize: 9, color: "rgba(140,128,100,0.55)" }}><NotificationTimestamp occurredAt={notification.occurredAt} /></div>
+        <strong style={{ display: "block", fontSize: 11, fontWeight: notification.read ? 400 : 600, color: notification.read ? "var(--lag-text-2)" : "var(--lag-text)", lineHeight: 1.35, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{notification.title}</strong>
+        <p style={{ fontSize: 10, color: "var(--lag-text-2)", marginTop: 2, lineHeight: 1.3 }}>{notification.body}</p>
+        <div style={{ marginTop: 4, fontSize: 9, color: "var(--lag-meta)" }}><NotificationTimestamp occurredAt={notification.occurredAt} /></div>
       </div>
-      {!notification.read ? <button type="button" disabled={pending} onClick={() => onMarkRead(notification.id)} style={{ border: "1px solid rgba(200,165,50,0.24)", background: "rgba(218,178,55,0.07)", color: "rgba(190,175,138,0.88)", borderRadius: 4, padding: "3px 6px", fontSize: 9, cursor: pending ? "default" : "pointer", opacity: pending ? 0.5 : 1 }}>{pending ? "Saving..." : "Mark read"}</button> : null}
+      {!notification.read ? <button type="button" className="lag-button-secondary" disabled={pending} onClick={() => onMarkRead(notification.id)} style={{ padding: "3px 6px", fontSize: 9, cursor: pending ? "default" : "pointer", opacity: pending ? 0.5 : 1 }}>{pending ? "Saving..." : "Mark read"}</button> : null}
     </motion.article>
   );
 }
@@ -84,25 +84,20 @@ export function NotificationBell() {
         whileTap={{ scale: 0.9 }}
         aria-label={`알림 ${state.unreadCount}건`}
         aria-expanded={open}
+        title="Notifications"
+        className="lag-utility-button"
         style={{
-          width: 34,
-          height: 34,
-          borderRadius: "50%",
-          border: `1.5px solid ${state.unreadCount > 0 ? "rgba(248,197,78,0.65)" : "rgba(160,140,100,0.28)"}`,
-          background: open ? "rgba(30,26,18,0.98)" : "linear-gradient(135deg, rgba(20,17,12,0.97), rgba(16,14,10,0.96))",
-          boxShadow: state.unreadCount > 0 ? "0 0 10px rgba(248,197,78,0.15)" : "none",
-          color: "rgba(235,218,175,0.88)",
+          borderColor: state.unreadCount > 0 || open ? "var(--lag-focus)" : "var(--lag-control-border)",
+          background: open ? "var(--lag-selected-surface)" : "var(--lag-control-bg)",
+          boxShadow: state.unreadCount > 0 ? "0 0 10px color-mix(in srgb, var(--lag-focus) 24%, transparent)" : "none",
           cursor: "pointer",
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
           fontSize: 14,
           position: "relative",
         }}
       >
         ◈
         <AnimatePresence>
-          {state.unreadCount > 0 ? <motion.span key="badge" initial={{ scale: 0 }} animate={{ scale: 1 }} exit={{ scale: 0 }} style={{ position: "absolute", top: -3, right: -3, minWidth: 16, height: 16, borderRadius: 8, background: "rgba(248,197,78,1)", color: "#1a1200", fontSize: 9, fontWeight: 700, display: "flex", alignItems: "center", justifyContent: "center", padding: "0 3px", lineHeight: 1 }}>{state.unreadCount > 9 ? "9+" : state.unreadCount}</motion.span> : null}
+          {state.unreadCount > 0 ? <motion.span key="badge" initial={{ scale: 0 }} animate={{ scale: 1 }} exit={{ scale: 0 }} style={{ position: "absolute", top: -3, right: -3, minWidth: 16, height: 16, borderRadius: 8, background: "var(--lag-state-error)", color: "var(--lag-text)", fontSize: 9, fontWeight: 700, display: "flex", alignItems: "center", justifyContent: "center", padding: "0 3px", lineHeight: 1 }}>{state.unreadCount > 9 ? "9+" : state.unreadCount}</motion.span> : null}
         </AnimatePresence>
       </motion.button>
 
@@ -116,24 +111,25 @@ export function NotificationBell() {
             animate={{ opacity: 1, y: 0, scale: 1 }}
             exit={{ opacity: 0, y: -6, scale: 0.97 }}
             transition={{ type: "spring", stiffness: 400, damping: 32 }}
-            style={{ position: "absolute", top: 42, right: -8, width: 320, background: "linear-gradient(155deg, rgba(14,12,8,0.99) 0%, rgba(18,16,11,0.98) 100%)", border: "1px solid rgba(200,165,50,0.32)", borderRadius: 8, boxShadow: "0 12px 40px rgba(0,0,0,0.75), inset 0 0 0 1px rgba(218,178,55,0.05)", zIndex: 9990, overflow: "hidden" }}
+            className="lag-notification-dropdown"
+            style={{ position: "absolute", top: 42, right: 0, width: 320, borderRadius: "var(--lag-radius-md)", zIndex: 9990, overflow: "hidden" }}
           >
-            <header style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8, padding: "9px 14px 8px", borderBottom: "1px solid rgba(200,165,50,0.15)" }}>
-              <span style={{ fontSize: 10, fontWeight: 700, color: "rgba(218,178,55,0.85)", letterSpacing: "0.1em" }}>NOTIFICATIONS</span>
-              <button type="button" disabled={state.markAllPending} onClick={() => void state.markAllRead()} style={{ fontSize: 9, color: "rgba(190,175,138,0.88)", background: "none", border: 0, cursor: "pointer", opacity: state.markAllPending ? 0.45 : 1 }}>{state.markAllPending ? "Saving..." : "모두 읽음"}</button>
+            <header style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8, padding: "9px 14px 8px", background: "var(--lag-panel-2)", borderBottom: "1px solid var(--lag-divider)" }}>
+              <span style={{ fontSize: 10, fontWeight: 700, color: "var(--lag-text)", letterSpacing: "0.1em" }}>NOTIFICATIONS</span>
+              <button type="button" disabled={state.markAllPending} onClick={() => void state.markAllRead()} style={{ fontSize: 9, color: "var(--lag-text-2)", background: "none", border: 0, cursor: "pointer", opacity: state.markAllPending ? 0.45 : 1 }}>{state.markAllPending ? "Saving..." : "모두 읽음"}</button>
             </header>
 
-            {state.unreadError ? <div style={{ padding: "8px 14px" }}><p role="alert" style={{ fontSize: 10, color: "rgba(224,62,99,0.9)" }}>{state.unreadError}</p><button type="button" onClick={() => void state.unreadRetry()} style={{ fontSize: 9 }}>Retry count</button></div> : null}
-            {state.inboxError ? <div style={{ padding: "8px 14px" }}><p role="alert" style={{ fontSize: 10, color: "rgba(224,62,99,0.9)" }}>{state.inboxError}</p><button type="button" onClick={() => void state.inboxRetry()} style={{ fontSize: 9 }}>Retry</button></div> : null}
-            {state.mutationError ? <p role="alert" style={{ padding: "8px 14px", fontSize: 10, color: "rgba(224,62,99,0.9)" }}>{state.mutationError}</p> : null}
+            {state.unreadError ? <div style={{ padding: "8px 14px" }}><p role="alert" style={{ fontSize: 10, color: "var(--lag-state-error)" }}>{state.unreadError}</p><button type="button" className="lag-button-secondary" onClick={() => void state.unreadRetry()} style={{ fontSize: 9 }}>Retry count</button></div> : null}
+            {state.inboxError ? <div style={{ padding: "8px 14px" }}><p role="alert" style={{ fontSize: 10, color: "var(--lag-state-error)" }}>{state.inboxError}</p><button type="button" className="lag-button-secondary" onClick={() => void state.inboxRetry()} style={{ fontSize: 9 }}>Retry</button></div> : null}
+            {state.mutationError ? <p role="alert" style={{ padding: "8px 14px", fontSize: 10, color: "var(--lag-state-error)" }}>{state.mutationError}</p> : null}
 
             <div style={{ maxHeight: 360, overflowY: "auto" }}>
-              {state.inboxLoading ? <p style={{ padding: "24px 14px", textAlign: "center", fontSize: 11, color: "rgba(160,148,115,0.55)" }}>Loading...</p> : null}
-              {!state.inboxLoading && state.inboxLoaded && state.inbox.length === 0 ? <p style={{ padding: "24px 14px", textAlign: "center", fontSize: 11, color: "rgba(160,148,115,0.55)" }}>알림이 없습니다</p> : null}
+              {state.inboxLoading ? <p style={{ padding: "24px 14px", textAlign: "center", fontSize: 11, color: "var(--lag-text-2)" }}>Loading...</p> : null}
+              {!state.inboxLoading && state.inboxLoaded && state.inbox.length === 0 ? <p style={{ padding: "24px 14px", textAlign: "center", fontSize: 11, color: "var(--lag-text-2)" }}>알림이 없습니다</p> : null}
               {state.inbox.map((notification) => <NotificationRow key={notification.id} notification={notification} pending={state.pendingId === notification.id} onMarkRead={(id) => void state.markRead(id)} />)}
-              {state.hasMore ? <button type="button" disabled={state.olderLoading} onClick={() => void state.loadOlder()} style={{ display: "block", margin: "8px auto", padding: "4px 8px", fontSize: 9 }}>{state.olderLoading ? "Loading..." : "Load older"}</button> : null}
+              {state.hasMore ? <button type="button" className="lag-button-secondary" disabled={state.olderLoading} onClick={() => void state.loadOlder()} style={{ display: "block", margin: "8px auto", padding: "4px 8px", fontSize: 9 }}>{state.olderLoading ? "Loading..." : "Load older"}</button> : null}
             </div>
-            <div style={{ height: 2, background: "linear-gradient(90deg, transparent, rgba(218,178,55,0.25), transparent)" }} />
+            <div style={{ height: 2, background: "linear-gradient(90deg, transparent, var(--lag-focus), transparent)" }} />
           </motion.div>
         ) : null}
       </AnimatePresence>

--- a/features/player/AchievementShell.test.tsx
+++ b/features/player/AchievementShell.test.tsx
@@ -13,12 +13,28 @@ vi.mock("@/shared/ui/PanelCard", () => ({
 
 const listItem: PlayerAchievementInfo = { achievementId: 31, code: "LIST_CODE", name: "List name", category: "Growth", descMd: "List description", acquiredAt: "2026-08-13T00:00:00Z" };
 const detail: PlayerAchievementInfo = { achievementId: 31, code: "SERVER_CODE", name: "Server detail name", category: "Milestone", descMd: "**Server-owned** description", acquiredAt: "2026-08-14T00:00:00Z" };
+const secondListItem: PlayerAchievementInfo = { ...listItem, achievementId: 32, code: "SECOND", name: "Second achievement" };
 
 describe("Current Player Achievement surface를 사용할 때", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     api.getPlayerAchievementsApi.mockResolvedValue([listItem]);
     api.getPlayerAchievementApi.mockResolvedValue(detail);
+  });
+
+  it("선택 전에는 detail stage가 없고 선택 replacement identity를 바꾼다", async () => {
+    api.getPlayerAchievementsApi.mockResolvedValue([listItem, secondListItem]);
+    api.getPlayerAchievementApi.mockImplementation(async (id: number) => ({ ...detail, achievementId: id }));
+    render(<AchievementShell />);
+
+    const entries = await screen.findAllByTestId("achievement-entry");
+    expect(screen.queryByText("Achievement Detail")).not.toBeInTheDocument();
+
+    fireEvent.click(entries[0]);
+    expect(document.querySelector('[data-stage-key="player-achievement-detail-31"]')).toBeInTheDocument();
+
+    fireEvent.click(entries[1]);
+    expect(document.querySelector('[data-stage-key="player-achievement-detail-32"]')).toBeInTheDocument();
   });
 
   it("acquired list/detail fields와 empty state만 렌더하고 fabricated rows는 만들지 않는다", async () => {

--- a/features/player/AchievementShell.tsx
+++ b/features/player/AchievementShell.tsx
@@ -1,16 +1,18 @@
 "use client";
 
-import { SAO } from "@/shared/design/tokens";
+import { AnimatePresence } from "framer-motion";
+
 import PanelCard from "@/shared/ui/PanelCard";
+import PanelStage from "@/shared/ui/PanelStage";
 import { PanelFrame } from "@/widgets/right-panels/ui/PanelFrame";
 import { GoldRow, InfoCard } from "@/widgets/right-panels/ui/Rows";
 import { useAchievementQueries } from "./useAchievementQueries";
 
 const buttonStyle = {
-  border: `1px solid ${SAO.color.border.panel}`,
-  background: SAO.color.bg.inset,
-  color: SAO.color.text.secondary,
-  borderRadius: SAO.radius.panel,
+  border: "1px solid var(--lag-control-border)",
+  background: "var(--lag-control-bg)",
+  color: "var(--lag-control-text)",
+  borderRadius: "var(--lag-radius-sm)",
   padding: "7px 10px",
   fontSize: "0.68rem",
   letterSpacing: "0.08em",
@@ -19,7 +21,7 @@ const buttonStyle = {
 function ErrorState({ message, retry }: { message: string; retry: () => void }) {
   return (
     <div className="space-y-2 px-3">
-      <p role="alert" className="text-xs" style={{ color: SAO.color.action.red }}>{message}</p>
+      <p role="alert" className="text-xs" style={{ color: "var(--lag-state-error)" }}>{message}</p>
       <button type="button" style={buttonStyle} onClick={retry}>Retry</button>
     </div>
   );
@@ -30,8 +32,9 @@ export default function AchievementShell() {
   const detail = achievements.detail.data;
 
   return (
-    <div className="relative flex min-w-0 w-fit flex-row flex-nowrap items-center gap-3" data-testid="achievement-shell">
-      <PanelFrame title="Acquired Achievements" depth={1}>
+    <div className="lag-panel-rail relative" data-testid="achievement-shell">
+      <PanelStage stageKey="player-achievement-list">
+        <PanelFrame title="Acquired Achievements" depth={1}>
         <div className="space-y-3">
           {achievements.list.loading && achievements.list.items.length === 0 ? <InfoCard>Loading Achievements...</InfoCard> : null}
           {achievements.list.error ? <ErrorState message={achievements.list.error} retry={() => void achievements.list.reload()} /> : null}
@@ -50,22 +53,28 @@ export default function AchievementShell() {
             ))}
           </div>
         </div>
-      </PanelFrame>
+        </PanelFrame>
+      </PanelStage>
 
-      <PanelFrame title="Achievement Detail" depth={0}>
-        {!achievements.selectedId ? <InfoCard>Select an acquired Achievement.</InfoCard> : null}
-        {achievements.detail.loading && !detail ? <InfoCard>Loading Achievement...</InfoCard> : null}
-        {achievements.detail.error ? <ErrorState message={achievements.detail.error} retry={() => void achievements.detail.retry()} /> : null}
-        {detail ? (
-          <div className="space-y-3 px-3">
-            <InfoCard>{detail.name}</InfoCard>
-            <GoldRow>Code: {detail.code}</GoldRow>
-            <GoldRow>Category: {detail.category}</GoldRow>
-            <GoldRow>Acquired: {detail.acquiredAt}</GoldRow>
-            <InfoCard label="Description"><span style={{ whiteSpace: "pre-wrap" }}>{detail.descMd}</span></InfoCard>
-          </div>
+      <AnimatePresence initial={false} mode="popLayout">
+        {achievements.selectedId ? (
+          <PanelStage key={`player-achievement-detail-${achievements.selectedId}`} stageKey={`player-achievement-detail-${achievements.selectedId}`} index={1}>
+            <PanelFrame title="Achievement Detail" depth={0}>
+              {achievements.detail.loading && !detail ? <InfoCard>Loading Achievement...</InfoCard> : null}
+              {achievements.detail.error ? <ErrorState message={achievements.detail.error} retry={() => void achievements.detail.retry()} /> : null}
+              {detail ? (
+                <div className="space-y-3 px-3">
+                  <InfoCard>{detail.name}</InfoCard>
+                  <GoldRow>Code: {detail.code}</GoldRow>
+                  <GoldRow>Category: {detail.category}</GoldRow>
+                  <GoldRow>Acquired: {detail.acquiredAt}</GoldRow>
+                  <InfoCard label="Description"><span style={{ whiteSpace: "pre-wrap" }}>{detail.descMd}</span></InfoCard>
+                </div>
+              ) : null}
+            </PanelFrame>
+          </PanelStage>
         ) : null}
-      </PanelFrame>
+      </AnimatePresence>
     </div>
   );
 }

--- a/features/player/CertificationShell.tsx
+++ b/features/player/CertificationShell.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 import { useState } from "react";
+import { AnimatePresence } from "framer-motion";
 
 import type { PlayerCertificationDatesRequest } from "@/shared/api/types";
 import { INPUT_STYLE, SAO } from "@/shared/design/tokens";
 import PanelCard from "@/shared/ui/PanelCard";
+import PanelStage from "@/shared/ui/PanelStage";
 import { PanelFrame } from "@/widgets/right-panels/ui/PanelFrame";
 import { GoldRow, InfoCard } from "@/widgets/right-panels/ui/Rows";
 import { useCertificationQueries } from "./useCertificationQueries";
@@ -49,8 +51,9 @@ export default function CertificationShell() {
   const selected = certifications.selected;
 
   return (
-    <div className="relative flex min-w-0 w-fit flex-row flex-nowrap items-center gap-3" data-testid="certification-shell">
-      <PanelFrame title="Certification Catalog" depth={2}>
+    <div className="lag-panel-rail relative" data-testid="certification-shell">
+      <PanelStage stageKey="player-certification-catalog">
+        <PanelFrame title="Certification Catalog" depth={2}>
         <div className="space-y-3 px-3">
           {certifications.catalog.loading && certifications.catalog.items.length === 0 ? <InfoCard>Loading Certification catalog...</InfoCard> : null}
           {certifications.catalog.error ? <ErrorState message={certifications.catalog.error} retry={() => void certifications.catalog.retry()} /> : null}
@@ -77,9 +80,11 @@ export default function CertificationShell() {
             </form>
           ) : null}
         </div>
-      </PanelFrame>
+        </PanelFrame>
+      </PanelStage>
 
-      <PanelFrame title="My Certifications" depth={1}>
+      <PanelStage stageKey="player-certification-list" index={1}>
+        <PanelFrame title="My Certifications" depth={1}>
         <div className="space-y-3">
           {certifications.owned.loading && certifications.owned.items.length === 0 ? <InfoCard>Loading Certifications...</InfoCard> : null}
           {certifications.owned.error ? <ErrorState message={certifications.owned.error} retry={() => void certifications.owned.reload()} /> : null}
@@ -91,11 +96,14 @@ export default function CertificationShell() {
             ))}
           </div>
         </div>
-      </PanelFrame>
+        </PanelFrame>
+      </PanelStage>
 
-      <PanelFrame title="Certification Detail" depth={0}>
-        {!selected ? <InfoCard>Select an owned Certification.</InfoCard> : (
-          <div className="space-y-3 px-3">
+      <AnimatePresence initial={false} mode="popLayout">
+        {selected ? (
+          <PanelStage key={`player-certification-detail-${selected.certificationId}`} stageKey={`player-certification-detail-${selected.certificationId}`} index={2}>
+            <PanelFrame title="Certification Detail" depth={0}>
+              <div className="space-y-3 px-3">
             <InfoCard>{selected.name}</InfoCard>
             <GoldRow>Issuer: {selected.issuer}</GoldRow>
             <GoldRow>Category: {selected.category}</GoldRow>
@@ -117,9 +125,11 @@ export default function CertificationShell() {
                 }}>Delete</button>
               </div>
             </form>
-          </div>
-        )}
-      </PanelFrame>
+              </div>
+            </PanelFrame>
+          </PanelStage>
+        ) : null}
+      </AnimatePresence>
     </div>
   );
 }

--- a/features/player/HobbyShell.tsx
+++ b/features/player/HobbyShell.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 import { useState } from "react";
+import { AnimatePresence } from "framer-motion";
 
 import type { HobbyStatus, PlayerHobbyMutationRequest } from "@/shared/api/types";
 import { INPUT_STYLE, SAO } from "@/shared/design/tokens";
 import PanelCard from "@/shared/ui/PanelCard";
+import PanelStage from "@/shared/ui/PanelStage";
 import { PanelFrame } from "@/widgets/right-panels/ui/PanelFrame";
 import { GoldRow, InfoCard } from "@/widgets/right-panels/ui/Rows";
 import { useHobbyQueries } from "./useHobbyQueries";
@@ -47,8 +49,9 @@ export default function HobbyShell() {
   const selected = hobbies.selected;
 
   return (
-    <div className="relative flex min-w-0 w-fit flex-row flex-nowrap items-center gap-3" data-testid="hobby-shell">
-      <PanelFrame title="Hobby Catalog" depth={2}>
+    <div className="lag-panel-rail relative" data-testid="hobby-shell">
+      <PanelStage stageKey="player-hobby-catalog">
+        <PanelFrame title="Hobby Catalog" depth={2}>
         <div className="space-y-3 px-3">
           {hobbies.catalog.loading && hobbies.catalog.items.length === 0 ? <InfoCard>Loading Hobby catalog...</InfoCard> : null}
           {hobbies.catalog.error ? <ErrorState message={hobbies.catalog.error} retry={() => void hobbies.catalog.retry()} /> : null}
@@ -69,9 +72,11 @@ export default function HobbyShell() {
             </form>
           ) : null}
         </div>
-      </PanelFrame>
+        </PanelFrame>
+      </PanelStage>
 
-      <PanelFrame title="My Hobbies" depth={1}>
+      <PanelStage stageKey="player-hobby-list" index={1}>
+        <PanelFrame title="My Hobbies" depth={1}>
         <div className="space-y-3">
           {hobbies.owned.loading && hobbies.owned.items.length === 0 ? <InfoCard>Loading Hobbies...</InfoCard> : null}
           {hobbies.owned.error ? <ErrorState message={hobbies.owned.error} retry={() => void hobbies.owned.reload()} /> : null}
@@ -79,11 +84,14 @@ export default function HobbyShell() {
           {hobbies.mutationError ? <p role="alert" className="px-3 text-xs" style={{ color: SAO.color.action.red }}>{hobbies.mutationError}</p> : null}
           <div className="space-y-2">{hobbies.owned.items.map((item, index) => <PanelCard key={item.hobbyId} label={item.customName} slotLabel={item.category.slice(0, 2).toUpperCase()} subtitle={`${item.name} · ${item.status} · ${item.proficiency}/100`} selected={hobbies.selectedId === item.hobbyId} index={index} onClick={() => hobbies.select(item.hobbyId)} />)}</div>
         </div>
-      </PanelFrame>
+        </PanelFrame>
+      </PanelStage>
 
-      <PanelFrame title="Hobby Detail" depth={0}>
-        {!selected ? <InfoCard>Select an owned Hobby.</InfoCard> : (
-          <div className="space-y-3 px-3">
+      <AnimatePresence initial={false} mode="popLayout">
+        {selected ? (
+          <PanelStage key={`player-hobby-detail-${selected.hobbyId}`} stageKey={`player-hobby-detail-${selected.hobbyId}`} index={2}>
+            <PanelFrame title="Hobby Detail" depth={0}>
+              <div className="space-y-3 px-3">
             <InfoCard>{selected.customName}</InfoCard>
             <GoldRow>Hobby: {selected.name}</GoldRow><GoldRow>Category: {selected.category}</GoldRow><GoldRow>Status: {selected.status}</GoldRow><GoldRow>Proficiency: {selected.proficiency}/100</GoldRow><GoldRow>Started: {selected.startedOn ?? "Not recorded"}</GoldRow><GoldRow>XP: {selected.xp}</GoldRow><InfoCard label="Detail">{selected.detail ?? "Not recorded"}</InfoCard>
             <form key={selected.hobbyId} className="space-y-2" onSubmit={(event) => { event.preventDefault(); void hobbies.update(selected.hobbyId, fields(new FormData(event.currentTarget))); }}>
@@ -95,9 +103,11 @@ export default function HobbyShell() {
               <p className="text-xs" style={{ color: SAO.color.text.label }}>Blank fields preserve current values; fields cannot be cleared.</p>
               <div className="flex gap-2"><button type="submit" disabled={pending} style={{ ...buttonStyle, flex: 1 }}>{pending ? "Working..." : "Update Hobby"}</button><button type="button" disabled={pending} style={buttonStyle} onClick={() => { if (window.confirm(`Delete ${selected.customName}?`)) void hobbies.remove(selected.hobbyId); }}>Delete</button></div>
             </form>
-          </div>
-        )}
-      </PanelFrame>
+              </div>
+            </PanelFrame>
+          </PanelStage>
+        ) : null}
+      </AnimatePresence>
     </div>
   );
 }

--- a/features/player/TitleShell.test.tsx
+++ b/features/player/TitleShell.test.tsx
@@ -17,12 +17,27 @@ vi.mock("@/shared/ui/PanelCard", () => ({
 }));
 
 const title: PlayerTitleInfo = { titleId: 1, code: "BLACK_SWORDSMAN", name: "Black Swordsman", category: "Combat", descMd: "Canonical description.", acquiredAt: "2026-08-01T00:00:00Z" };
+const secondTitle: PlayerTitleInfo = { ...title, titleId: 2, code: "BEATER", name: "Beater" };
 
 describe("Title surface와 routing을 사용할 때", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     api.getCurrentPlayerApi.mockResolvedValue({ ...MOCK_CHARACTER_SHEET.player, representativeTitleId: 1 });
     api.getPlayerTitlesApi.mockResolvedValue([title]);
+  });
+
+  it("선택 전에는 detail stage가 없고 선택 교체 시 transition identity를 바꾼다", async () => {
+    api.getPlayerTitlesApi.mockResolvedValue([title, secondTitle]);
+    render(<TitleShell />);
+
+    const entries = await screen.findAllByTestId("title-entry");
+    expect(screen.queryByText("Title Detail")).not.toBeInTheDocument();
+
+    fireEvent.click(entries[0]);
+    expect(document.querySelector('[data-stage-key="player-title-detail-1"]')).toBeInTheDocument();
+
+    fireEvent.click(entries[1]);
+    expect(document.querySelector('[data-stage-key="player-title-detail-2"]')).toBeInTheDocument();
   });
 
   it("acquired fields와 representative marker를 표시하고 fabricated state는 만들지 않는다", async () => {

--- a/features/player/TitleShell.tsx
+++ b/features/player/TitleShell.tsx
@@ -1,16 +1,18 @@
 "use client";
 
-import { SAO } from "@/shared/design/tokens";
+import { AnimatePresence } from "framer-motion";
+
 import PanelCard from "@/shared/ui/PanelCard";
+import PanelStage from "@/shared/ui/PanelStage";
 import { PanelFrame } from "@/widgets/right-panels/ui/PanelFrame";
 import { GoldRow, InfoCard } from "@/widgets/right-panels/ui/Rows";
 import { useTitleQueries } from "./useTitleQueries";
 
 const buttonStyle = {
-  border: `1px solid ${SAO.color.border.panel}`,
-  background: SAO.color.bg.inset,
-  color: SAO.color.text.secondary,
-  borderRadius: SAO.radius.panel,
+  border: "1px solid var(--lag-control-border)",
+  background: "var(--lag-control-bg)",
+  color: "var(--lag-control-text)",
+  borderRadius: "var(--lag-radius-sm)",
   padding: "7px 10px",
   fontSize: "0.68rem",
   letterSpacing: "0.08em",
@@ -19,7 +21,7 @@ const buttonStyle = {
 function ErrorState({ message, retry }: { message: string; retry: () => void }) {
   return (
     <div className="space-y-2 px-3">
-      <p role="alert" className="text-xs" style={{ color: SAO.color.action.red }}>{message}</p>
+      <p role="alert" className="text-xs" style={{ color: "var(--lag-state-error)" }}>{message}</p>
       <button type="button" style={buttonStyle} onClick={retry}>Retry</button>
     </div>
   );
@@ -32,8 +34,9 @@ export default function TitleShell() {
   const representativeAvailable = representative === null || titles.titles.items.some(({ titleId }) => titleId === representative);
 
   return (
-    <div className="relative flex min-w-0 w-fit flex-row flex-nowrap items-center gap-3" data-testid="title-shell">
-      <PanelFrame title="Acquired Titles" depth={1}>
+    <div className="lag-panel-rail relative" data-testid="title-shell">
+      <PanelStage stageKey="player-title-list">
+        <PanelFrame title="Acquired Titles" depth={1}>
         <div className="space-y-3">
           {titles.player.loading && !titles.player.data ? <InfoCard>Loading Current Player...</InfoCard> : null}
           {titles.player.error ? <ErrorState message={titles.player.error} retry={() => void titles.player.reload()} /> : null}
@@ -41,7 +44,7 @@ export default function TitleShell() {
           {titles.titles.error ? <ErrorState message={titles.titles.error} retry={() => void titles.titles.reload()} /> : null}
           {!titles.titles.loading && !titles.titles.error && titles.titles.items.length === 0 ? <InfoCard>No acquired Titles.</InfoCard> : null}
           {!representativeAvailable ? <InfoCard>Representative Title #{representative} is unavailable in acquired Titles.</InfoCard> : null}
-          {titles.mutationError ? <p role="alert" className="px-3 text-xs" style={{ color: SAO.color.action.red }}>{titles.mutationError}</p> : null}
+          {titles.mutationError ? <p role="alert" className="px-3 text-xs" style={{ color: "var(--lag-state-error)" }}>{titles.mutationError}</p> : null}
           <div className="space-y-2">
             {titles.titles.items.map((title, index) => (
               <PanelCard
@@ -56,28 +59,33 @@ export default function TitleShell() {
             ))}
           </div>
         </div>
-      </PanelFrame>
+        </PanelFrame>
+      </PanelStage>
 
-      <PanelFrame title="Title Detail" depth={0}>
-        {!selected ? <InfoCard>Select an acquired Title.</InfoCard> : (
-          <div className="space-y-3 px-3">
-            <InfoCard>{selected.name}</InfoCard>
-            <GoldRow>Code: {selected.code}</GoldRow>
-            <GoldRow>Category: {selected.category}</GoldRow>
-            <GoldRow>Acquired: {selected.acquiredAt}</GoldRow>
-            {representative === selected.titleId ? <GoldRow>Representative Title</GoldRow> : null}
-            <InfoCard label="Description"><span style={{ whiteSpace: "pre-wrap" }}>{selected.descMd}</span></InfoCard>
-            <button
-              type="button"
-              disabled={titles.pendingMutation || representative === selected.titleId}
-              style={buttonStyle}
-              onClick={() => void titles.setRepresentative(selected.titleId)}
-            >
-              {titles.pendingMutation ? "Working..." : representative === selected.titleId ? "Representative Title" : "Set Representative"}
-            </button>
-          </div>
-        )}
-      </PanelFrame>
+      <AnimatePresence initial={false} mode="popLayout">
+        {selected ? (
+          <PanelStage key={`player-title-detail-${selected.titleId}`} stageKey={`player-title-detail-${selected.titleId}`} index={1}>
+            <PanelFrame title="Title Detail" depth={0}>
+              <div className="space-y-3 px-3">
+                <InfoCard>{selected.name}</InfoCard>
+                <GoldRow>Code: {selected.code}</GoldRow>
+                <GoldRow>Category: {selected.category}</GoldRow>
+                <GoldRow>Acquired: {selected.acquiredAt}</GoldRow>
+                {representative === selected.titleId ? <GoldRow>Representative Title</GoldRow> : null}
+                <InfoCard label="Description"><span style={{ whiteSpace: "pre-wrap" }}>{selected.descMd}</span></InfoCard>
+                <button
+                  type="button"
+                  disabled={titles.pendingMutation || representative === selected.titleId}
+                  style={buttonStyle}
+                  onClick={() => void titles.setRepresentative(selected.titleId)}
+                >
+                  {titles.pendingMutation ? "Working..." : representative === selected.titleId ? "Representative Title" : "Set Representative"}
+                </button>
+              </div>
+            </PanelFrame>
+          </PanelStage>
+        ) : null}
+      </AnimatePresence>
     </div>
   );
 }

--- a/features/quests/JourneyShell.test.tsx
+++ b/features/quests/JourneyShell.test.tsx
@@ -116,6 +116,22 @@ describe("Journey에서 Quest와 QuestRoute를 볼 때", () => {
     });
   });
 
+  describe("Journey main navigation으로 직접 진입하면", () => {
+    it("root stage만 열고 subsection과 detail은 선택 전까지 만들지 않는다", async () => {
+      render(<JourneyShell initialSurface={null} />);
+
+      expect(screen.getByRole("button", { name: /Current/ })).toBeInTheDocument();
+      expect(document.querySelector('[data-stage-key="journey-root"]')).toBeInTheDocument();
+      expect(document.querySelector('[data-stage-key^="journey-list-"]')).not.toBeInTheDocument();
+      expect(document.querySelector('[data-stage-key*="detail-"]')).not.toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole("button", { name: /Current/ }));
+      expect(await screen.findByText(/In Progress · 1\/3/)).toBeInTheDocument();
+      expect(document.querySelector('[data-stage-key="journey-list-current"]')).toBeInTheDocument();
+      expect(document.querySelector('[data-stage-key*="detail-"]')).not.toBeInTheDocument();
+    });
+  });
+
   describe("Current Quest의 상태와 next action을 확인하면", () => {
     it("IN_PROGRESS/GOAL_REACHED/COMPLETED/CANCELED를 구분하고 Party/Guild surface나 reward claim을 노출하지 않는다", async () => {
       render(<JourneyShell />);
@@ -196,7 +212,7 @@ describe("Journey에서 Quest와 QuestRoute를 볼 때", () => {
         stale.reject(new Error("stale Quest failure"));
         await stale.promise.catch(() => undefined);
       });
-      expect(screen.getByText("Loading Quest detail...")).toBeInTheDocument();
+      expect(screen.getAllByText("Loading Quest detail...").length).toBeGreaterThan(0);
       expect(screen.queryByText("stale Quest failure")).not.toBeInTheDocument();
 
       await act(async () => {
@@ -238,7 +254,7 @@ describe("Journey에서 Quest와 QuestRoute를 볼 때", () => {
 
       await waitFor(() => expect(api.acceptQuestApi).toHaveBeenCalledTimes(1));
       expect(await screen.findByText(/Request outcome was not confirmed/)).toBeInTheDocument();
-      expect(screen.getByText("Acceptance: In Progress")).toBeInTheDocument();
+      expect(screen.getAllByText("Acceptance: In Progress").length).toBeGreaterThan(0);
       expect(screen.queryByRole("button", { name: "Accept Quest" })).not.toBeInTheDocument();
     });
   });
@@ -311,6 +327,7 @@ describe("Journey에서 Quest와 QuestRoute를 볼 때", () => {
       fireEvent.click(await screen.findByRole("button", { name: /기록으로 시작하기/ }));
 
       expect(await screen.findByText("Current Step Detail: 첫 흔적 남기기 · READY_TO_ADVANCE")).toBeInTheDocument();
+      expect(document.querySelector('[data-stage-key^="journey-route-detail-"] .lag-panel-body')).toHaveClass("lag-panel-body");
       expect(api.getMyQuestRouteApi).toHaveBeenCalledWith(selectedRoute.id);
       expect(api.getQuestRouteApi).not.toHaveBeenCalled();
     });

--- a/features/quests/JourneyShell.tsx
+++ b/features/quests/JourneyShell.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import { useRef, useState } from "react";
+import { AnimatePresence } from "framer-motion";
 
 import { SUBMENUS_BY_MAIN } from "@/entities/nav";
 import type { QuestsSubId } from "@/entities/nav";
 import type { PlayerQuestDetail, QuestRoute, QuestRouteStepDetail } from "@/shared/api/types";
-import { SAO } from "@/shared/design/tokens";
 import PanelCard from "@/shared/ui/PanelCard";
+import PanelStage from "@/shared/ui/PanelStage";
 import { PanelFrame } from "@/widgets/right-panels/ui/PanelFrame";
 import { GoldRow, InfoCard } from "@/widgets/right-panels/ui/Rows";
 import { actionBtnStyle } from "@/widgets/right-panels/ui/styles";
@@ -32,10 +33,10 @@ import {
 import { useJourneyQueries } from "./useJourneyQueries";
 
 const secondaryButton = {
-  border: `1px solid ${SAO.color.border.panel}`,
-  background: SAO.color.bg.inset,
-  color: SAO.color.text.secondary,
-  borderRadius: SAO.radius.panel,
+  border: "1px solid var(--lag-control-border)",
+  background: "var(--lag-control-bg)",
+  color: "var(--lag-control-text)",
+  borderRadius: "var(--lag-radius-sm)",
   padding: "7px 10px",
   fontSize: "0.68rem",
   letterSpacing: "0.08em",
@@ -48,7 +49,7 @@ function message(caught: unknown, fallback: string): string {
 function ErrorState({ text, retry }: { text: string; retry: () => void }) {
   return (
     <div className="space-y-2 px-3">
-      <p role="alert" className="text-xs" style={{ color: SAO.color.action.red }}>{text}</p>
+      <p role="alert" className="text-xs" style={{ color: "var(--lag-state-error)" }}>{text}</p>
       <button type="button" style={secondaryButton} onClick={retry}>Retry</button>
     </div>
   );
@@ -69,9 +70,9 @@ type RouteDetailState = {
   error: string | null;
 };
 
-export default function JourneyShell({ initialSurface = "current" }: { initialSurface?: QuestsSubId }) {
+export default function JourneyShell({ initialSurface = "current" }: { initialSurface?: QuestsSubId | null }) {
   const queries = useJourneyQueries(true);
-  const [surface, setSurface] = useState<QuestsSubId>(initialSurface);
+  const [surface, setSurface] = useState<QuestsSubId | null>(initialSurface);
   const [selectedAcceptanceId, setSelectedAcceptanceId] = useState<number | null>(null);
   const [selectedCatalogCode, setSelectedCatalogCode] = useState<string | null>(null);
   const [selectedRouteId, setSelectedRouteId] = useState<number | null>(null);
@@ -82,6 +83,18 @@ export default function JourneyShell({ initialSurface = "current" }: { initialSu
   const mutationLocked = useRef(false);
   const questDetailRequestId = useRef(0);
   const routeDetailRequestId = useRef(0);
+
+  const selectSurface = (next: QuestsSubId) => {
+    setSurface(next);
+    setSelectedAcceptanceId(null);
+    setSelectedCatalogCode(null);
+    setSelectedRouteId(null);
+    setQuestDetail({ code: null, data: null, loading: false, error: null });
+    setRouteDetail({ routeId: null, data: null, step: null, loading: false, error: null });
+    setMutationError(null);
+    questDetailRequestId.current += 1;
+    routeDetailRequestId.current += 1;
+  };
 
   const mineById = new Map(queries.routes.data.mine.map((route) => [route.id, route]));
   const catalogIds = new Set(queries.routes.data.catalog.map((route) => route.id));
@@ -254,8 +267,8 @@ export default function JourneyShell({ initialSurface = "current" }: { initialSu
     if (detail?.error && !detail.data) return <ErrorState text={detail.error} retry={() => void loadQuestDetail(selectedAcceptance.code)} />;
     return (
       <div className="space-y-3 px-3">
-        {detail?.error ? <p role="alert" className="text-xs" style={{ color: SAO.color.action.red }}>{detail.error}</p> : null}
-        {mutationError ? <p role="alert" className="text-xs" style={{ color: SAO.color.action.red }}>{mutationError}</p> : null}
+        {detail?.error ? <p role="alert" className="text-xs" style={{ color: "var(--lag-state-error)" }}>{detail.error}</p> : null}
+        {mutationError ? <p role="alert" className="text-xs" style={{ color: "var(--lag-state-error)" }}>{mutationError}</p> : null}
         <InfoCard>{detail?.data?.descriptionMd ?? selectedAcceptance.descriptionMd}</InfoCard>
         <GoldRow>Status: {QUEST_STATUS_LABEL[selectedAcceptance.status]}</GoldRow>
         <GoldRow>Progress: {selectedAcceptance.progressValue} / {selectedAcceptance.targetValue} ({questProgressPercent(selectedAcceptance)}%)</GoldRow>
@@ -286,7 +299,7 @@ export default function JourneyShell({ initialSurface = "current" }: { initialSu
     if (detail?.error && !detail.data) return <ErrorState text={detail.error} retry={() => void loadQuestDetail(selectedBlueprint.code)} />;
     return (
       <div className="space-y-3 px-3">
-        {mutationError ? <p role="alert" className="text-xs" style={{ color: SAO.color.action.red }}>{mutationError}</p> : null}
+        {mutationError ? <p role="alert" className="text-xs" style={{ color: "var(--lag-state-error)" }}>{mutationError}</p> : null}
         <InfoCard>{detail?.data?.descriptionMd ?? selectedBlueprint.descriptionMd}</InfoCard>
         <GoldRow>Target: {selectedBlueprint.targetType} × {selectedBlueprint.targetValue}</GoldRow>
         <GoldRow>Completion policy: {selectedBlueprint.completionPolicy}</GoldRow>
@@ -314,20 +327,20 @@ export default function JourneyShell({ initialSurface = "current" }: { initialSu
     const canAdvance = progress?.status === "IN_PROGRESS" && currentStep?.state === "READY_TO_ADVANCE";
     return (
       <div className="space-y-3 px-3">
-        {detailState?.error ? <p role="alert" className="text-xs" style={{ color: SAO.color.action.red }}>{detailState.error}</p> : null}
-        {mutationError ? <p role="alert" className="text-xs" style={{ color: SAO.color.action.red }}>{mutationError}</p> : null}
+        {detailState?.error ? <p role="alert" className="text-xs" style={{ color: "var(--lag-state-error)" }}>{detailState.error}</p> : null}
+        {mutationError ? <p role="alert" className="text-xs" style={{ color: "var(--lag-state-error)" }}>{mutationError}</p> : null}
         <InfoCard>{route.description ?? "No Route description."}</InfoCard>
         <GoldRow>Status: {progress?.status ?? "NOT_SELECTED"}</GoldRow>
         {progress ? <GoldRow>Current Step ID: {progress.currentStepId}</GoldRow> : null}
         <section className="space-y-2" aria-label="Ordered Route Steps">
           {route.steps.slice().sort((left, right) => left.stepOrder - right.stepOrder).map((step) => (
-            <div key={step.id} className="rounded-sm px-3 py-2" style={{ background: SAO.color.bg.inset, border: `1px solid ${step.id === progress?.currentStepId ? SAO.color.border.gold : SAO.color.border.panel}` }}>
-              <p className="text-sm font-semibold" style={{ color: SAO.color.text.primary }}>{step.stepOrder}. {step.title}</p>
-              <p className="text-xs" style={{ color: SAO.color.text.label }}>{step.state} · criteria {step.criteriaSatisfied ? "satisfied" : "not satisfied"}</p>
-              <p className="text-xs" style={{ color: SAO.color.text.secondary }}>{step.description ?? "No Step description."}</p>
+            <div key={step.id} className="rounded-sm px-3 py-2" style={{ background: "var(--lag-muted-surface)", border: `1px solid ${step.id === progress?.currentStepId ? "var(--lag-focus)" : "var(--lag-divider)"}` }}>
+              <p className="text-sm font-semibold" style={{ color: "var(--lag-text)" }}>{step.stepOrder}. {step.title}</p>
+              <p className="text-xs" style={{ color: "var(--lag-text-2)" }}>{step.state} · criteria {step.criteriaSatisfied ? "satisfied" : "not satisfied"}</p>
+              <p className="text-xs" style={{ color: "var(--lag-text-2)" }}>{step.description ?? "No Step description."}</p>
               {step.questLinks.map((link) => {
                 const acceptedQuest = queries.current.data.find((quest) => quest.questId === link.questId);
-                return <p key={link.questId} className="text-xs" style={{ color: SAO.color.text.label }}>Requirement: {acceptedQuest?.title ?? `Quest #${link.questId}`} · {link.requirementType}</p>;
+                return <p key={link.questId} className="text-xs" style={{ color: "var(--lag-text-2)" }}>Requirement: {acceptedQuest?.title ?? `Quest #${link.questId}`} · {link.requirementType}</p>;
               })}
             </div>
           ))}
@@ -340,23 +353,45 @@ export default function JourneyShell({ initialSurface = "current" }: { initialSu
     );
   };
 
+  const detailStageKey = surface === "current" && selectedAcceptance
+    ? `journey-current-detail-${selectedAcceptance.id}`
+    : surface === "catalog" && selectedBlueprint
+      ? `journey-catalog-detail-${selectedBlueprint.code}`
+      : surface === "routes" && selectedRoute
+        ? `journey-route-detail-${selectedRoute.id}`
+        : null;
+
   return (
-    <div className="relative flex min-w-0 w-fit flex-row flex-nowrap items-center gap-3" data-testid="journey-shell">
-      <PanelFrame title="Journey" depth={2}>
-        <div className="grid gap-1">
-          {SUBMENUS_BY_MAIN.quests.map((item, index) => (
-            <PanelCard key={item.id} label={item.label} slotLabel={item.slotLabel} selected={surface === item.id} index={index} onClick={() => { setSurface(item.id as QuestsSubId); setMutationError(null); }} />
-          ))}
-        </div>
-      </PanelFrame>
+    <div className="lag-panel-rail relative" data-testid="journey-shell">
+      <PanelStage stageKey="journey-root">
+        <PanelFrame title="Journey" depth={2}>
+          <div className="grid gap-1">
+            {SUBMENUS_BY_MAIN.quests.map((item, index) => (
+              <PanelCard key={item.id} label={item.label} slotLabel={item.slotLabel} selected={surface === item.id} index={index} onClick={() => selectSurface(item.id as QuestsSubId)} />
+            ))}
+          </div>
+        </PanelFrame>
+      </PanelStage>
 
-      <PanelFrame title={SUBMENUS_BY_MAIN.quests.find((item) => item.id === surface)?.label ?? "Journey"} depth={1}>
-        {surface === "current" ? renderCurrentList() : surface === "catalog" ? renderCatalogList() : renderRouteList()}
-      </PanelFrame>
+      <AnimatePresence initial={false}>
+        {surface ? (
+          <PanelStage key={`journey-list-${surface}`} stageKey={`journey-list-${surface}`} index={1}>
+            <PanelFrame title={SUBMENUS_BY_MAIN.quests.find((item) => item.id === surface)?.label ?? "Journey"} depth={1}>
+              {surface === "current" ? renderCurrentList() : surface === "catalog" ? renderCatalogList() : renderRouteList()}
+            </PanelFrame>
+          </PanelStage>
+        ) : null}
+      </AnimatePresence>
 
-      <PanelFrame title={surface === "current" ? selectedAcceptance?.title ?? "Quest Detail" : surface === "catalog" ? selectedBlueprint?.title ?? "Catalog Detail" : selectedRoute?.title ?? "Route Detail"} depth={0}>
-        {surface === "current" ? renderCurrentDetail() : surface === "catalog" ? renderCatalogDetail() : renderRouteDetail()}
-      </PanelFrame>
+      <AnimatePresence initial={false} mode="popLayout">
+        {detailStageKey ? (
+          <PanelStage key={detailStageKey} stageKey={detailStageKey} index={2}>
+            <PanelFrame title={surface === "current" ? selectedAcceptance?.title ?? "Quest Detail" : surface === "catalog" ? selectedBlueprint?.title ?? "Catalog Detail" : selectedRoute?.title ?? "Route Detail"} depth={0}>
+              {surface === "current" ? renderCurrentDetail() : surface === "catalog" ? renderCatalogDetail() : renderRouteDetail()}
+            </PanelFrame>
+          </PanelStage>
+        ) : null}
+      </AnimatePresence>
     </div>
   );
 }

--- a/features/role/RoleShell.test.tsx
+++ b/features/role/RoleShell.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { readFileSync } from "node:fs";
 import { useState } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -69,6 +70,14 @@ describe("실제 Role shell을 사용할 때", () => {
     api.cancelRoleEventApi.mockResolvedValue({ ...roleEvent, status: "CANCELED" });
   });
 
+  it("Role list/surface/detail/form이 shared semantic material만 사용한다", () => {
+    const source = readFileSync("features/role/RoleShell.tsx", "utf8");
+
+    expect(source).toContain("var(--lag-control-bg)");
+    expect(source).toContain("var(--lag-state-error)");
+    expect(source).not.toMatch(/SAO\.color|INPUT_STYLE|rgba\(/);
+  });
+
   describe("Role 목록을 탐색하고 관리하면", () => {
     it("loading/empty/error 상태를 표시하고 선택·create·edit·archive 흐름을 제공한다", async () => {
       const refresh = vi.fn().mockResolvedValue(undefined);
@@ -83,6 +92,7 @@ describe("실제 Role shell을 사용할 때", () => {
 
       rerender(<Harness refresh={refresh} />);
       fireEvent.click(screen.getByRole("button", { name: "Family Member" }));
+      fireEvent.click(screen.getByRole("button", { name: "Overview" }));
       expect(screen.getByText("Be present")).toBeInTheDocument();
 
       fireEvent.click(screen.getByRole("button", { name: "Create Role" }));
@@ -100,10 +110,36 @@ describe("실제 Role shell을 사용할 때", () => {
   });
 
   describe("Role을 선택하지 않은 상태이면", () => {
-    it("Relation/Event 하위 API를 호출하지 않고 선택 guard를 표시한다", () => {
+    it("첫 Role을 자동 선택하지 않고 downstream stage/API를 열지 않는다", () => {
+      const onSelectRole = vi.fn();
+      render(<RoleShell roles={roles} selectedRoleId={null} isLoading={false} error={null} onSelectRole={onSelectRole} onRefresh={vi.fn()} />);
+
+      expect(onSelectRole).not.toHaveBeenCalled();
+      expect(screen.queryByRole("button", { name: "Overview" })).not.toBeInTheDocument();
+      expect(screen.queryByText("Build systems")).not.toBeInTheDocument();
+      expect(api.listPersonsApi).not.toHaveBeenCalled();
+      expect(api.listRoleRelationsApi).not.toHaveBeenCalled();
+      expect(api.listRoleEventsApi).not.toHaveBeenCalled();
+    });
+
+    it("Role 선택은 surfaces만 열고 surface 선택 후 detail을 열며 Role 교체 시 detail을 닫는다", async () => {
+      render(<Harness initialRoleId={null} />);
+
+      fireEvent.click(screen.getByRole("button", { name: "Backend Engineer" }));
+      expect(screen.getByRole("button", { name: "Overview" })).toBeInTheDocument();
+      expect(screen.queryByText("Build systems")).not.toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole("button", { name: "Overview" }));
+      expect(screen.getByText("Build systems")).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole("button", { name: "Family Member" }));
+      await waitFor(() => expect(screen.queryByText("Build systems")).not.toBeInTheDocument());
+      expect(screen.queryByText("Be present")).not.toBeInTheDocument();
+    });
+
+    it("Role이 비어 있으면 downstream API를 호출하지 않는다", () => {
       render(<Harness initialRoleId={null} availableRoles={[]} />);
 
-      expect(screen.getAllByText(/Select a Role/).length).toBeGreaterThan(0);
       expect(api.listPersonsApi).not.toHaveBeenCalled();
       expect(api.listRoleRelationsApi).not.toHaveBeenCalled();
       expect(api.listRoleEventsApi).not.toHaveBeenCalled();

--- a/features/role/RoleShell.tsx
+++ b/features/role/RoleShell.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
+import { AnimatePresence } from "framer-motion";
 
 import type {
   PersonDetail,
@@ -10,8 +11,8 @@ import type {
   RoleEventInput,
   RoleRelationDetail,
 } from "@/shared/api/types";
-import { INPUT_STYLE, SAO } from "@/shared/design/tokens";
 import PanelCard from "@/shared/ui/PanelCard";
+import PanelStage from "@/shared/ui/PanelStage";
 import { PanelFrame } from "@/widgets/right-panels/ui/PanelFrame";
 import { GoldRow, InfoCard } from "@/widgets/right-panels/ui/Rows";
 import { actionBtnStyle } from "@/widgets/right-panels/ui/styles";
@@ -41,10 +42,10 @@ const ROLE_SURFACES: Array<{ id: RoleSurface; label: string; slotLabel: string }
 ];
 
 const secondaryButton = {
-  border: `1px solid ${SAO.color.border.panel}`,
-  background: SAO.color.bg.inset,
-  color: SAO.color.text.secondary,
-  borderRadius: SAO.radius.panel,
+  border: "1px solid var(--lag-control-border)",
+  background: "var(--lag-control-bg)",
+  color: "var(--lag-control-text)",
+  borderRadius: "var(--lag-radius-sm)",
   padding: "7px 10px",
   fontSize: "0.68rem",
   letterSpacing: "0.08em",
@@ -54,8 +55,21 @@ const fieldLabel = {
   display: "block",
   fontSize: "0.62rem",
   letterSpacing: "0.14em",
-  color: SAO.color.text.label,
+  color: "var(--lag-text-2)",
   textTransform: "uppercase",
+} as const;
+
+const inputStyle = {
+  width: "100%",
+  boxSizing: "border-box",
+  padding: "8px 12px",
+  background: "var(--lag-control-bg)",
+  border: "1px solid var(--lag-control-border)",
+  borderRadius: "var(--lag-radius-sm)",
+  color: "var(--lag-control-text)",
+  fontSize: "0.875rem",
+  letterSpacing: "0.04em",
+  outline: "none",
 } as const;
 
 function value(form: FormData, key: string) {
@@ -80,7 +94,7 @@ function toInstant(local: string) {
 function ErrorState({ message, onRetry }: { message: string; onRetry: () => void }) {
   return (
     <div className="space-y-3 px-3">
-      <p role="alert" className="text-sm" style={{ color: SAO.color.action.red }}>{message}</p>
+      <p role="alert" className="text-sm" style={{ color: "var(--lag-state-error)" }}>{message}</p>
       <button type="button" style={secondaryButton} onClick={onRetry}>Retry</button>
     </div>
   );
@@ -111,10 +125,10 @@ function RoleEditForm({ role, onSaved, onCancel }: { role: RoleDetail; onSaved: 
 
   return (
     <form className="space-y-3 px-3" onSubmit={submit}>
-      <label style={fieldLabel}>Role Type<input name="roleType" required defaultValue={role.roleType} style={INPUT_STYLE} /></label>
-      <label style={fieldLabel}>Name<input name="name" required defaultValue={role.name} style={INPUT_STYLE} /></label>
-      <label style={fieldLabel}>Description<textarea name="description" required defaultValue={role.description} rows={4} style={{ ...INPUT_STYLE, resize: "vertical" }} /></label>
-      {error ? <p role="alert" className="text-xs" style={{ color: SAO.color.action.red }}>{error}</p> : null}
+      <label style={fieldLabel}>Role Type<input className="lag-role-control" name="roleType" required defaultValue={role.roleType} style={inputStyle} /></label>
+      <label style={fieldLabel}>Name<input className="lag-role-control" name="name" required defaultValue={role.name} style={inputStyle} /></label>
+      <label style={fieldLabel}>Description<textarea className="lag-role-control" name="description" required defaultValue={role.description} rows={4} style={{ ...inputStyle, resize: "vertical" }} /></label>
+      {error ? <p role="alert" className="text-xs" style={{ color: "var(--lag-state-error)" }}>{error}</p> : null}
       <div className="flex gap-2">
         <button type="submit" disabled={pending} style={{ ...actionBtnStyle, flex: 1 }}>{pending ? "Saving..." : "Save Role"}</button>
         <button type="button" style={secondaryButton} onClick={onCancel}>Cancel</button>
@@ -222,23 +236,23 @@ function RelationsSurface({ roleId }: { roleId: number }) {
 
   return (
     <div className="space-y-5 px-3">
-      {error ? <p role="alert" className="text-xs" style={{ color: SAO.color.action.red }}>{error}</p> : null}
+      {error ? <p role="alert" className="text-xs" style={{ color: "var(--lag-state-error)" }}>{error}</p> : null}
       <section className="space-y-2" aria-labelledby="persons-heading">
         <h3 id="persons-heading" style={fieldLabel}>Persons</h3>
         {persons.length ? persons.map((person) => (
-          <div key={person.id} className="rounded-sm px-3 py-2" style={{ background: SAO.color.bg.inset, border: `1px solid ${SAO.color.border.panel}` }}>
-            <p className="text-sm font-semibold" style={{ color: SAO.color.text.primary }}>{person.displayName}</p>
-            <p className="text-xs" style={{ color: SAO.color.text.label }}>
+          <div key={person.id} className="lag-utility-row rounded-sm border px-3 py-2">
+            <p className="text-sm font-semibold" style={{ color: "var(--lag-text)" }}>{person.displayName}</p>
+            <p className="text-xs" style={{ color: "var(--lag-text-2)" }}>
               {person.linkedUserId ? "Linked account available · identity remains Person" : "Person"}
             </p>
           </div>
         )) : <InfoCard>No Persons yet.</InfoCard>}
         <form className="space-y-2" onSubmit={createPerson}>
-          <label style={fieldLabel}>Display Name<input name="displayName" required style={INPUT_STYLE} /></label>
-          <label style={fieldLabel}>Notes<input name="notes" style={INPUT_STYLE} /></label>
+          <label style={fieldLabel}>Display Name<input className="lag-role-control" name="displayName" required style={inputStyle} /></label>
+          <label style={fieldLabel}>Notes<input className="lag-role-control" name="notes" style={inputStyle} /></label>
           <div className="grid grid-cols-2 gap-2">
-            <label style={fieldLabel}>Birthday<input name="birthday" type="date" style={INPUT_STYLE} /></label>
-            <label style={fieldLabel}>Contact<input name="contact" style={INPUT_STYLE} /></label>
+            <label style={fieldLabel}>Birthday<input className="lag-role-control" name="birthday" type="date" style={inputStyle} /></label>
+            <label style={fieldLabel}>Contact<input className="lag-role-control" name="contact" style={inputStyle} /></label>
           </div>
           <button type="submit" disabled={pending} style={secondaryButton}>Create Person</button>
         </form>
@@ -247,9 +261,9 @@ function RelationsSurface({ roleId }: { roleId: number }) {
       <section className="space-y-2" aria-labelledby="relations-heading">
         <h3 id="relations-heading" style={fieldLabel}>Role Relations</h3>
         {relations.length ? relations.map((relation) => (
-          <div key={relation.id} className="rounded-sm px-3 py-2" style={{ background: SAO.color.bg.inset, border: `1px solid ${SAO.color.border.panel}` }}>
-            <p className="text-sm font-semibold" style={{ color: SAO.color.text.primary }}>{relation.personDisplayName} · {relation.relationType}</p>
-            <p className="text-xs" style={{ color: SAO.color.text.secondary }}>{relation.roleNotes || "No role notes"}</p>
+          <div key={relation.id} className="lag-utility-row rounded-sm border px-3 py-2">
+            <p className="text-sm font-semibold" style={{ color: "var(--lag-text)" }}>{relation.personDisplayName} · {relation.relationType}</p>
+            <p className="text-xs" style={{ color: "var(--lag-text-2)" }}>{relation.roleNotes || "No role notes"}</p>
             <div className="mt-2 flex gap-2">
               <button type="button" style={secondaryButton} onClick={() => setEditing(relation)}>Edit</button>
               <button type="button" disabled={pending} style={secondaryButton} onClick={() => void archiveRelation(relation)}>Archive</button>
@@ -262,14 +276,14 @@ function RelationsSurface({ roleId }: { roleId: number }) {
             <InfoCard>Editing {editing.personDisplayName}. Person identity cannot be changed here.</InfoCard>
           ) : (
             <label style={fieldLabel}>Person
-              <select name="personId" required defaultValue="" style={INPUT_STYLE}>
+              <select className="lag-role-control" name="personId" required defaultValue="" style={inputStyle}>
                 <option value="" disabled>Select a Person</option>
                 {persons.map((person) => <option key={person.id} value={person.id}>{person.displayName}</option>)}
               </select>
             </label>
           )}
-          <label style={fieldLabel}>Relation Type<input name="relationType" required defaultValue={editing?.relationType ?? ""} placeholder="e.g. FAMILY" style={INPUT_STYLE} /></label>
-          <label style={fieldLabel}>Role Notes<textarea name="roleNotes" defaultValue={editing?.roleNotes ?? ""} rows={3} style={{ ...INPUT_STYLE, resize: "vertical" }} /></label>
+          <label style={fieldLabel}>Relation Type<input className="lag-role-control" name="relationType" required defaultValue={editing?.relationType ?? ""} placeholder="e.g. FAMILY" style={inputStyle} /></label>
+          <label style={fieldLabel}>Role Notes<textarea className="lag-role-control" name="roleNotes" defaultValue={editing?.roleNotes ?? ""} rows={3} style={{ ...inputStyle, resize: "vertical" }} /></label>
           <div className="flex gap-2">
             <button type="submit" disabled={pending || (!editing && persons.length === 0)} style={secondaryButton}>{editing ? "Update Relation" : "Create Relation"}</button>
             {editing ? <button type="button" style={secondaryButton} onClick={() => setEditing(null)}>Cancel Edit</button> : null}
@@ -309,11 +323,11 @@ function EventForm({ roleId, event, onSaved, onCancel }: { roleId: number; event
 
   return (
     <form className="space-y-3" onSubmit={submit}>
-      <label style={fieldLabel}>Title<input name="title" required maxLength={120} defaultValue={event?.title ?? ""} style={INPUT_STYLE} /></label>
-      <label style={fieldLabel}>Description<textarea name="description" maxLength={1000} defaultValue={event?.description ?? ""} rows={3} style={{ ...INPUT_STYLE, resize: "vertical" }} /></label>
-      <label style={fieldLabel}>Starts At<input name="startsAt" type="datetime-local" defaultValue={toLocalDateTime(event?.startsAt ?? null)} style={INPUT_STYLE} /></label>
-      <label style={fieldLabel}>Ends At<input name="endsAt" type="datetime-local" defaultValue={toLocalDateTime(event?.endsAt ?? null)} style={INPUT_STYLE} /></label>
-      {error ? <p role="alert" className="text-xs" style={{ color: SAO.color.action.red }}>{error}</p> : null}
+      <label style={fieldLabel}>Title<input className="lag-role-control" name="title" required maxLength={120} defaultValue={event?.title ?? ""} style={inputStyle} /></label>
+      <label style={fieldLabel}>Description<textarea className="lag-role-control" name="description" maxLength={1000} defaultValue={event?.description ?? ""} rows={3} style={{ ...inputStyle, resize: "vertical" }} /></label>
+      <label style={fieldLabel}>Starts At<input className="lag-role-control" name="startsAt" type="datetime-local" defaultValue={toLocalDateTime(event?.startsAt ?? null)} style={inputStyle} /></label>
+      <label style={fieldLabel}>Ends At<input className="lag-role-control" name="endsAt" type="datetime-local" defaultValue={toLocalDateTime(event?.endsAt ?? null)} style={inputStyle} /></label>
+      {error ? <p role="alert" className="text-xs" style={{ color: "var(--lag-state-error)" }}>{error}</p> : null}
       <div className="flex gap-2">
         <button type="submit" disabled={pending} style={secondaryButton}>{event ? "Update Event" : "Save New Event"}</button>
         <button type="button" style={secondaryButton} onClick={onCancel}>Cancel</button>
@@ -381,13 +395,13 @@ function EventsSurface({ roleId }: { roleId: number }) {
 
   return (
     <div className="space-y-4 px-3">
-      {error ? <p role="alert" className="text-xs" style={{ color: SAO.color.action.red }}>{error}</p> : null}
+      {error ? <p role="alert" className="text-xs" style={{ color: "var(--lag-state-error)" }}>{error}</p> : null}
       <button type="button" style={actionBtnStyle} onClick={() => setFormEvent("create")}>Create Event</button>
       <div className="space-y-2">
         {events.length ? events.map((roleEvent) => (
-          <button key={roleEvent.id} type="button" className="w-full rounded-sm px-3 py-2 text-left" style={{ background: SAO.color.bg.inset, border: `1px solid ${selectedEvent?.id === roleEvent.id ? SAO.color.border.gold : SAO.color.border.panel}` }} onClick={() => void selectEvent(roleEvent.id)}>
-            <span className="block text-sm font-semibold" style={{ color: SAO.color.text.primary }}>{roleEvent.title}</span>
-            <span className="block text-xs" style={{ color: SAO.color.text.label }}>{roleEvent.status}</span>
+          <button key={roleEvent.id} type="button" className="w-full rounded-sm px-3 py-2 text-left" style={{ background: selectedEvent?.id === roleEvent.id ? "var(--lag-selected-surface)" : "var(--lag-control-bg)", border: `1px solid ${selectedEvent?.id === roleEvent.id ? "var(--lag-focus)" : "var(--lag-control-border)"}` }} onClick={() => void selectEvent(roleEvent.id)}>
+            <span className="block text-sm font-semibold" style={{ color: "var(--lag-text)" }}>{roleEvent.title}</span>
+            <span className="block text-xs" style={{ color: "var(--lag-text-2)" }}>{roleEvent.status}</span>
           </button>
         )) : <InfoCard>No Events for this Role.</InfoCard>}
       </div>
@@ -437,18 +451,15 @@ export default function RoleShell({
   onRefresh: () => Promise<void>;
 }) {
   const router = useRouter();
-  const [surface, setSurface] = useState<RoleSurface>("overview");
+  const [surface, setSurface] = useState<RoleSurface | null>(null);
   const [editingRoleId, setEditingRoleId] = useState<number | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
   const selectedRole = roles.find(({ id }) => id === selectedRoleId) ?? null;
   const editingRole = selectedRole?.id === editingRoleId;
 
   useEffect(() => {
-    if (roles.length > 0 && !selectedRole) onSelectRole(roles[0].id);
-  }, [onSelectRole, roles, selectedRole, selectedRoleId]);
-
-  useEffect(() => {
-    setSurface("overview");
+    setSurface(null);
+    setEditingRoleId((current) => current === selectedRoleId ? current : null);
   }, [selectedRoleId]);
 
   const archiveRole = async (role: RoleDetail) => {
@@ -464,13 +475,14 @@ export default function RoleShell({
   };
 
   return (
-    <div className="relative flex min-w-0 w-fit flex-row flex-nowrap items-center gap-3" data-testid="role-shell">
-      <PanelFrame title="Roles" depth={2}>
+    <div className="lag-panel-rail relative" data-testid="role-shell">
+      <PanelStage stageKey="role-list">
+        <PanelFrame title="Roles" depth={2}>
         <div className="space-y-3">
           <div className="px-3"><button type="button" style={actionBtnStyle} onClick={() => router.push("/roles/create")}>Create Role</button></div>
           {isLoading ? <InfoCard>Loading Roles...</InfoCard> : null}
           {error ? <ErrorState message={error} onRetry={() => void onRefresh()} /> : null}
-          {actionError ? <p role="alert" className="px-3 text-xs" style={{ color: SAO.color.action.red }}>{actionError}</p> : null}
+          {actionError ? <p role="alert" className="px-3 text-xs" style={{ color: "var(--lag-state-error)" }}>{actionError}</p> : null}
           {!isLoading && !error && roles.length === 0 ? <InfoCard>No Roles yet. Create your first Role.</InfoCard> : null}
           {roles.map((role, index) => (
             <PanelCard
@@ -493,25 +505,36 @@ export default function RoleShell({
             />
           ))}
         </div>
-      </PanelFrame>
+        </PanelFrame>
+      </PanelStage>
 
-      <PanelFrame title={selectedRole?.name ?? "Role Surfaces"} depth={1}>
+      <AnimatePresence initial={false}>
         {selectedRole ? (
-          <div className="grid gap-1">
-            {ROLE_SURFACES.map((item, index) => (
-              <PanelCard key={item.id} label={item.label} slotLabel={item.slotLabel} selected={surface === item.id} index={index} onClick={() => { setSurface(item.id); setEditingRoleId(null); }} />
-            ))}
-          </div>
-        ) : <InfoCard>Select a Role.</InfoCard>}
-      </PanelFrame>
+          <PanelStage key={`role-surfaces-${selectedRole.id}`} stageKey={`role-surfaces-${selectedRole.id}`} index={1}>
+            <PanelFrame title={selectedRole.name} depth={1}>
+              <div className="grid gap-1">
+                {ROLE_SURFACES.map((item, index) => (
+                  <PanelCard key={item.id} label={item.label} slotLabel={item.slotLabel} selected={surface === item.id} index={index} onClick={() => { setSurface(item.id); setEditingRoleId(null); }} />
+                ))}
+              </div>
+            </PanelFrame>
+          </PanelStage>
+        ) : null}
+      </AnimatePresence>
 
-      <PanelFrame title={editingRole ? "Edit Role" : ROLE_SURFACES.find(({ id }) => id === surface)?.label ?? "Overview"} depth={0}>
-        {!selectedRole ? <InfoCard>Select a Role to open its shell.</InfoCard> : editingRole ? (
-          <RoleEditForm role={selectedRole} onSaved={async () => { await onRefresh(); setEditingRoleId(null); }} onCancel={() => setEditingRoleId(null)} />
-        ) : surface === "overview" ? <Overview role={selectedRole} />
-          : surface === "relations" ? <RelationsSurface roleId={selectedRole.id} />
-            : <EventsSurface roleId={selectedRole.id} />}
-      </PanelFrame>
+      <AnimatePresence initial={false} mode="popLayout">
+        {selectedRole && (editingRole || surface) ? (
+          <PanelStage key={editingRole ? `role-edit-${selectedRole.id}` : `role-${selectedRole.id}-${surface}`} stageKey={editingRole ? `role-edit-${selectedRole.id}` : `role-${selectedRole.id}-${surface}`} index={2}>
+            <PanelFrame title={editingRole ? "Edit Role" : ROLE_SURFACES.find(({ id }) => id === surface)?.label ?? "Role"} depth={0}>
+              {editingRole ? (
+                <RoleEditForm role={selectedRole} onSaved={async () => { await onRefresh(); setEditingRoleId(null); }} onCancel={() => setEditingRoleId(null)} />
+              ) : surface === "overview" ? <Overview role={selectedRole} />
+                : surface === "relations" ? <RelationsSurface roleId={selectedRole.id} />
+                  : <EventsSurface roleId={selectedRole.id} />}
+            </PanelFrame>
+          </PanelStage>
+        ) : null}
+      </AnimatePresence>
     </div>
   );
 }

--- a/features/social/ConnectionsDrawer.tsx
+++ b/features/social/ConnectionsDrawer.tsx
@@ -3,21 +3,20 @@
 import { useCallback, useEffect, useState } from "react";
 
 import type { ConnectionPeer } from "@/shared/api/types";
-import { SAO } from "@/shared/design/tokens";
 import { useConnectionsQueries } from "./useConnectionsQueries";
 
 const buttonStyle = {
-  border: `1px solid ${SAO.color.border.inner}`,
-  background: SAO.color.bg.inset,
-  color: SAO.color.text.secondary,
-  borderRadius: SAO.radius.input,
+  border: "1px solid var(--lag-control-border)",
+  background: "var(--lag-control-bg)",
+  color: "var(--lag-control-text)",
+  borderRadius: "var(--lag-radius-sm)",
 } as const;
 
 function Peer({ peer }: { peer: ConnectionPeer }) {
   return (
     <div className="min-w-0 flex-1">
-      <strong className="block truncate text-sm" style={{ color: SAO.color.text.primary }}>{peer.name}</strong>
-      <span className="block truncate text-xs" style={{ color: SAO.color.text.label }}>
+      <strong className="block truncate text-sm" style={{ color: "var(--lag-text)" }}>{peer.name}</strong>
+      <span className="block truncate text-xs" style={{ color: "var(--lag-text-2)" }}>
         {peer.job ? `${peer.job} · ` : ""}Level {peer.level}
       </span>
     </div>
@@ -58,29 +57,23 @@ export default function ConnectionsDrawer({ open: controlledOpen, onOpenChange, 
         type="button"
         aria-label="Connections"
         aria-expanded={open}
+        title="Connections"
         onClick={() => setOpen(!open)}
-        className="h-[34px] rounded-full px-3 text-[10px] font-semibold uppercase tracking-[0.12em]"
-        style={buttonStyle}
+        className="lag-utility-button"
       >
-        Connections
+        <span className="lag-utility-label">CN</span>
       </button>
 
       {open ? (
         <aside
           role="dialog"
           aria-label="Current Player Connections"
-          className="fixed right-6 top-6 z-[500000] flex max-h-[calc(100vh-3rem)] w-[min(420px,calc(100vw-3rem))] flex-col overflow-hidden p-4"
-          style={{
-            background: "linear-gradient(160deg, rgba(18,15,10,0.99), rgba(14,12,8,0.99))",
-            border: `1px solid ${SAO.color.border.panel}`,
-            borderRadius: SAO.radius.panel,
-            boxShadow: SAO.shadow.panel,
-          }}
+          className="lag-utility-drawer fixed right-6 top-6 z-[500000] flex max-h-[calc(100vh-3rem)] w-[min(420px,calc(100vw-3rem))] flex-col overflow-hidden p-4"
         >
           <header className="flex items-center justify-between gap-3">
             <div>
-              <p className="text-[10px] uppercase tracking-[0.2em]" style={{ color: SAO.color.text.label }}>Current Player</p>
-              <h2 className="text-lg font-semibold tracking-[0.08em]" style={{ color: SAO.color.text.primary }}>Connections</h2>
+              <p className="text-[10px] uppercase tracking-[0.2em]" style={{ color: "var(--lag-text-2)" }}>Current Player</p>
+              <h2 className="text-lg font-semibold tracking-[0.08em]" style={{ color: "var(--lag-text)" }}>Connections</h2>
             </div>
             <button type="button" aria-label="Close Connections" onClick={() => setOpen(false)} className="px-3 py-2 text-xs" style={buttonStyle}>Close</button>
           </header>
@@ -94,39 +87,39 @@ export default function ConnectionsDrawer({ open: controlledOpen, onOpenChange, 
                 aria-selected={state.activeTab === tab}
                 onClick={() => state.setActiveTab(tab)}
                 className="px-3 py-2 text-xs font-semibold uppercase tracking-[0.12em]"
-                style={{ ...buttonStyle, borderColor: state.activeTab === tab ? SAO.color.border.gold : SAO.color.border.inner }}
+                style={{ ...buttonStyle, background: state.activeTab === tab ? "var(--lag-selected-surface)" : "var(--lag-control-bg)", borderColor: state.activeTab === tab ? "var(--lag-focus)" : "var(--lag-control-border)" }}
               >
                 {tab === "followings" ? "Followings" : "Followers"}
               </button>
             ))}
           </div>
 
-          <p className="mt-3 text-xs" style={{ color: SAO.color.text.label }}>{page.totalElements} total</p>
-          {queryError ? <div className="mt-2 flex items-center gap-2"><p role="alert" className="text-xs" style={{ color: SAO.color.action.red }}>{queryError}</p><button type="button" className="px-2 py-1 text-xs" style={buttonStyle} onClick={() => void retry()}>Retry</button></div> : null}
-          {state.mutationError ? <p role="alert" className="mt-2 text-xs" style={{ color: SAO.color.action.red }}>{state.mutationError}</p> : null}
+          <p className="mt-3 text-xs" style={{ color: "var(--lag-text-2)" }}>{page.totalElements} total</p>
+          {queryError ? <div className="mt-2 flex items-center gap-2"><p role="alert" className="text-xs" style={{ color: "var(--lag-state-error)" }}>{queryError}</p><button type="button" className="px-2 py-1 text-xs" style={buttonStyle} onClick={() => void retry()}>Retry</button></div> : null}
+          {state.mutationError ? <p role="alert" className="mt-2 text-xs" style={{ color: "var(--lag-state-error)" }}>{state.mutationError}</p> : null}
 
           <div className="mt-3 min-h-28 flex-1 space-y-2 overflow-y-auto">
-            {state.loading[state.activeTab] ? <p className="py-6 text-center text-sm" style={{ color: SAO.color.text.secondary }}>Loading...</p> : null}
-            {!state.loading[state.activeTab] && page.contents.length === 0 ? <p className="py-6 text-center text-sm" style={{ color: SAO.color.text.secondary }}>No connections.</p> : null}
+            {state.loading[state.activeTab] ? <p className="py-6 text-center text-sm" style={{ color: "var(--lag-text-2)" }}>Loading...</p> : null}
+            {!state.loading[state.activeTab] && page.contents.length === 0 ? <p className="py-6 text-center text-sm" style={{ color: "var(--lag-text-2)" }}>No connections.</p> : null}
 
             {state.activeTab === "followings" ? state.followings.contents.map((following) => (
-              <article key={following.followId} className="rounded-sm border p-3" style={{ borderColor: SAO.color.border.inner, background: SAO.color.bg.inset }}>
+              <article key={following.followId} className="lag-utility-row rounded-sm border p-3">
                 <div className="flex items-start gap-3">
                   <Peer peer={following.peer} />
-                  <span className="text-[10px] uppercase" style={{ color: SAO.color.text.label }}>
+                  <span className="text-[10px] uppercase" style={{ color: "var(--lag-text-2)" }}>
                     {[following.muted && "Muted", following.blocked && "Blocked"].filter(Boolean).join(" · ") || "Following"}
                   </span>
                 </div>
                 <div className="mt-3 flex flex-wrap gap-2">
                   <button type="button" disabled={locked} onClick={() => void state.toggleMute(following)} className="px-2 py-1 text-xs disabled:opacity-40" style={buttonStyle}>{following.muted ? "Unmute" : "Mute"}</button>
                   <button type="button" disabled={locked} onClick={() => void state.toggleBlock(following)} className="px-2 py-1 text-xs disabled:opacity-40" style={buttonStyle}>{following.blocked ? "Unblock" : "Block"}</button>
-                  <button type="button" disabled={locked} onClick={() => void state.unfollowFollowing(following)} className="px-2 py-1 text-xs disabled:opacity-40" style={{ ...buttonStyle, color: SAO.color.action.red }}>Unfollow</button>
+                  <button type="button" disabled={locked} onClick={() => void state.unfollowFollowing(following)} className="px-2 py-1 text-xs disabled:opacity-40" style={{ ...buttonStyle, color: "var(--lag-state-error)" }}>Unfollow</button>
                 </div>
               </article>
             )) : state.followers.contents.map((follower) => {
               const inconsistent = follower.followedBack && follower.outboundFollowId === null;
               return (
-                <article key={follower.peer.playerId} className="flex items-center gap-3 rounded-sm border p-3" style={{ borderColor: SAO.color.border.inner, background: SAO.color.bg.inset }}>
+                <article key={follower.peer.playerId} className="lag-utility-row flex items-center gap-3 rounded-sm border p-3">
                   <Peer peer={follower.peer} />
                   <div className="flex flex-wrap justify-end gap-2">
                     {follower.followedBack && onMessage ? <button type="button" onClick={() => onMessage(follower.peer.playerId)} className="px-2 py-1 text-xs" style={buttonStyle}>Message</button> : null}
@@ -145,9 +138,9 @@ export default function ConnectionsDrawer({ open: controlledOpen, onOpenChange, 
             })}
           </div>
 
-          <footer className="mt-3 flex items-center justify-between gap-3 border-t pt-3" style={{ borderColor: SAO.color.border.subtle }}>
+          <footer className="mt-3 flex items-center justify-between gap-3 border-t pt-3" style={{ borderColor: "var(--lag-divider)" }}>
             <button type="button" disabled={pageIndex === 0} onClick={() => setPage((current) => current - 1)} className="px-3 py-1.5 text-xs disabled:opacity-40" style={buttonStyle}>Previous</button>
-            <span className="text-xs" style={{ color: SAO.color.text.label }}>Page {page.totalPages === 0 ? 0 : page.page + 1} of {page.totalPages}</span>
+            <span className="text-xs" style={{ color: "var(--lag-text-2)" }}>Page {page.totalPages === 0 ? 0 : page.page + 1} of {page.totalPages}</span>
             <button type="button" disabled={pageIndex + 1 >= page.totalPages} onClick={() => setPage((current) => current + 1)} className="px-3 py-1.5 text-xs disabled:opacity-40" style={buttonStyle}>Next</button>
           </footer>
         </aside>

--- a/features/social/chat/DirectChatDrawer.tsx
+++ b/features/social/chat/DirectChatDrawer.tsx
@@ -3,14 +3,13 @@
 import { useEffect, useState } from "react";
 
 import { useAuth } from "@/features/auth/AuthContext";
-import { SAO } from "@/shared/design/tokens";
 import type { DirectChatState } from "./useDirectChat";
 
 const buttonStyle = {
-  border: `1px solid ${SAO.color.border.inner}`,
-  background: SAO.color.bg.inset,
-  color: SAO.color.text.secondary,
-  borderRadius: SAO.radius.input,
+  border: "1px solid var(--lag-control-border)",
+  background: "var(--lag-control-bg)",
+  color: "var(--lag-control-text)",
+  borderRadius: "var(--lag-radius-sm)",
 } as const;
 
 export function MessageTimestamp({ createdAt }: { createdAt: string }) {
@@ -37,42 +36,36 @@ export default function DirectChatDrawer({ chat, onOpen }: { chat: DirectChatSta
         type="button"
         aria-label="Direct Chat"
         aria-expanded={chat.open}
+        title="Direct Chat"
         onClick={() => {
           if (!chat.open) onOpen?.();
           chat.setOpen(!chat.open);
         }}
-        className="h-[34px] rounded-full px-3 text-[10px] font-semibold uppercase tracking-[0.12em]"
-        style={buttonStyle}
+        className="lag-utility-button"
       >
-        Chat
+        <span className="lag-utility-label">CH</span>
       </button>
 
       {chat.open ? (
         <aside
           role="dialog"
           aria-label="Direct Friend Chat"
-          className="fixed right-6 top-6 z-[500000] flex h-[min(680px,calc(100vh-3rem))] w-[min(720px,calc(100vw-3rem))] flex-col overflow-hidden p-4"
-          style={{
-            background: "linear-gradient(160deg, rgba(18,15,10,0.99), rgba(14,12,8,0.99))",
-            border: `1px solid ${SAO.color.border.panel}`,
-            borderRadius: SAO.radius.panel,
-            boxShadow: SAO.shadow.panel,
-          }}
+          className="lag-utility-drawer fixed right-6 top-6 z-[500000] flex h-[min(680px,calc(100vh-3rem))] w-[min(720px,calc(100vw-3rem))] flex-col overflow-hidden p-4"
         >
           <header className="flex items-center justify-between gap-3">
             <div>
-              <p className="text-[10px] uppercase tracking-[0.2em]" style={{ color: SAO.color.text.label }}>Current Player</p>
-              <h2 className="text-lg font-semibold tracking-[0.08em]" style={{ color: SAO.color.text.primary }}>Direct Chat</h2>
+              <p className="text-[10px] uppercase tracking-[0.2em]" style={{ color: "var(--lag-text-2)" }}>Current Player</p>
+              <h2 className="text-lg font-semibold tracking-[0.08em]" style={{ color: "var(--lag-text)" }}>Direct Chat</h2>
             </div>
             <button type="button" aria-label="Close Direct Chat" onClick={() => chat.setOpen(false)} className="px-3 py-2 text-xs" style={buttonStyle}>Close</button>
           </header>
 
-          {chat.openError ? <p role="alert" className="mt-2 text-xs" style={{ color: SAO.color.action.red }}>{chat.openError}</p> : null}
-          <div className="mt-4 grid min-h-0 flex-1 grid-cols-[190px_1fr] gap-3">
-            <section aria-label="Friend channels" className="min-h-0 overflow-y-auto border-r pr-3" style={{ borderColor: SAO.color.border.subtle }}>
-              {chat.channelsLoading ? <p className="py-4 text-xs" style={{ color: SAO.color.text.secondary }}>Loading channels...</p> : null}
-              {chat.channelsError ? <div><p role="alert" className="text-xs" style={{ color: SAO.color.action.red }}>{chat.channelsError}</p><button type="button" className="mt-2 px-2 py-1 text-xs" style={buttonStyle} onClick={() => void chat.channelsRetry()}>Retry</button></div> : null}
-              {!chat.channelsLoading && !chat.channelsError && chat.channels.length === 0 ? <p className="py-4 text-xs" style={{ color: SAO.color.text.secondary }}>No friend channels.</p> : null}
+          {chat.openError ? <p role="alert" className="mt-2 text-xs" style={{ color: "var(--lag-state-error)" }}>{chat.openError}</p> : null}
+          <div className="lag-chat-layout mt-4 grid min-h-0 flex-1 grid-cols-[190px_1fr] gap-3">
+            <section aria-label="Friend channels" className="lag-chat-channels min-h-0 overflow-y-auto border-r pr-3" style={{ borderColor: "var(--lag-divider)" }}>
+              {chat.channelsLoading ? <p className="py-4 text-xs" style={{ color: "var(--lag-text-2)" }}>Loading channels...</p> : null}
+              {chat.channelsError ? <div><p role="alert" className="text-xs" style={{ color: "var(--lag-state-error)" }}>{chat.channelsError}</p><button type="button" className="mt-2 px-2 py-1 text-xs" style={buttonStyle} onClick={() => void chat.channelsRetry()}>Retry</button></div> : null}
+              {!chat.channelsLoading && !chat.channelsError && chat.channels.length === 0 ? <p className="py-4 text-xs" style={{ color: "var(--lag-text-2)" }}>No friend channels.</p> : null}
               <div className="space-y-2">
                 {chat.channels.map((channel) => (
                   <button
@@ -81,36 +74,36 @@ export default function DirectChatDrawer({ chat, onOpen }: { chat: DirectChatSta
                     aria-pressed={channel.channelId === chat.selectedChannelId}
                     onClick={() => void chat.selectChannel(channel.channelId)}
                     className="w-full p-2 text-left"
-                    style={{ ...buttonStyle, borderColor: channel.channelId === chat.selectedChannelId ? SAO.color.border.gold : SAO.color.border.inner }}
+                    style={{ ...buttonStyle, background: channel.channelId === chat.selectedChannelId ? "var(--lag-selected-surface)" : "var(--lag-control-bg)", borderColor: channel.channelId === chat.selectedChannelId ? "var(--lag-focus)" : "var(--lag-control-border)" }}
                   >
                     <strong className="block truncate text-xs">{channel.peer.name}</strong>
-                    <span className="block truncate text-[10px]" style={{ color: SAO.color.text.label }}>{channel.peer.job ? `${channel.peer.job} · ` : ""}Level {channel.peer.level}</span>
-                    {channel.readOnly ? <span className="text-[10px] uppercase" style={{ color: SAO.color.action.red }}>Read only</span> : null}
+                    <span className="block truncate text-[10px]" style={{ color: "var(--lag-text-2)" }}>{channel.peer.job ? `${channel.peer.job} · ` : ""}Level {channel.peer.level}</span>
+                    {channel.readOnly ? <span className="text-[10px] uppercase" style={{ color: "var(--lag-state-error)" }}>Read only</span> : null}
                   </button>
                 ))}
               </div>
             </section>
 
             <section aria-label="Messages" className="flex min-h-0 flex-col">
-              {!selected ? <p className="m-auto text-sm" style={{ color: SAO.color.text.secondary }}>Select a friend channel.</p> : playerId === null ? <p role="alert" className="m-auto text-sm" style={{ color: SAO.color.action.red }}>Authenticated player identity is unavailable.</p> : (
+              {!selected ? <p className="m-auto text-sm" style={{ color: "var(--lag-text-2)" }}>Select a friend channel.</p> : playerId === null ? <p role="alert" className="m-auto text-sm" style={{ color: "var(--lag-state-error)" }}>Authenticated player identity is unavailable.</p> : (
                 <>
                   <div className="min-h-0 flex-1 space-y-2 overflow-y-auto">
                     {chat.hasMore ? <button type="button" disabled={chat.olderLoading} onClick={() => void chat.loadOlder()} className="mx-auto block px-3 py-1 text-xs disabled:opacity-40" style={buttonStyle}>{chat.olderLoading ? "Loading..." : "Load older"}</button> : null}
-                    {chat.messagesError ? <div className="text-center"><p role="alert" className="text-xs" style={{ color: SAO.color.action.red }}>{chat.messagesError}</p><button type="button" className="mt-2 px-2 py-1 text-xs" style={buttonStyle} onClick={() => void chat.loadLatest()}>Retry</button></div> : null}
-                    {chat.messagesLoading ? <p className="py-8 text-center text-sm" style={{ color: SAO.color.text.secondary }}>Loading messages...</p> : null}
+                    {chat.messagesError ? <div className="text-center"><p role="alert" className="text-xs" style={{ color: "var(--lag-state-error)" }}>{chat.messagesError}</p><button type="button" className="mt-2 px-2 py-1 text-xs" style={buttonStyle} onClick={() => void chat.loadLatest()}>Retry</button></div> : null}
+                    {chat.messagesLoading ? <p className="py-8 text-center text-sm" style={{ color: "var(--lag-text-2)" }}>Loading messages...</p> : null}
                     {!chat.messagesLoading && chat.messages.map((message) => {
                       const mine = message.senderId === playerId;
                       return (
-                        <article key={message.id} className={`max-w-[85%] rounded-sm border p-2 ${mine ? "ml-auto" : "mr-auto"}`} style={{ borderColor: SAO.color.border.inner, background: SAO.color.bg.inset }}>
-                          <div className="flex gap-2 text-[10px]" style={{ color: SAO.color.text.label }}><span>{mine ? "You" : selected.peer.name}</span><MessageTimestamp createdAt={message.createdAt} />{message.edited ? <span>Edited</span> : null}</div>
-                          <p className="mt-1 whitespace-pre-wrap break-words text-sm" style={{ color: SAO.color.text.primary }}>{message.content}</p>
+                        <article key={message.id} className={`lag-utility-row max-w-[85%] rounded-sm border p-2 ${mine ? "ml-auto" : "mr-auto"}`}>
+                          <div className="flex gap-2 text-[10px]" style={{ color: "var(--lag-text-2)" }}><span>{mine ? "You" : selected.peer.name}</span><MessageTimestamp createdAt={message.createdAt} />{message.edited ? <span>Edited</span> : null}</div>
+                          <p className="mt-1 whitespace-pre-wrap break-words text-sm" style={{ color: "var(--lag-text)" }}>{message.content}</p>
                         </article>
                       );
                     })}
                   </div>
-                  <form className="mt-3 border-t pt-3" style={{ borderColor: SAO.color.border.subtle }} onSubmit={(event) => { event.preventDefault(); void chat.send(); }}>
-                    {selected.readOnly ? <p className="mb-2 text-xs" style={{ color: SAO.color.text.label }}>This channel is read-only.</p> : null}
-                    {chat.sendError ? <p role="alert" className="mb-2 text-xs" style={{ color: SAO.color.action.red }}>{chat.sendError}</p> : null}
+                  <form className="mt-3 border-t pt-3" style={{ borderColor: "var(--lag-divider)" }} onSubmit={(event) => { event.preventDefault(); void chat.send(); }}>
+                    {selected.readOnly ? <p className="mb-2 text-xs" style={{ color: "var(--lag-text-2)" }}>This channel is read-only.</p> : null}
+                    {chat.sendError ? <p role="alert" className="mb-2 text-xs" style={{ color: "var(--lag-state-error)" }}>{chat.sendError}</p> : null}
                     <div className="flex gap-2">
                       <textarea aria-label="Message" rows={2} disabled={selected.readOnly || chat.sending} value={chat.draft} onChange={(event) => chat.setDraft(event.target.value)} className="min-w-0 flex-1 resize-none px-3 py-2 text-sm disabled:opacity-40" style={buttonStyle} />
                       <button type="submit" disabled={selected.readOnly || chat.sending || !chat.draft.trim()} className="px-4 text-xs disabled:opacity-40" style={buttonStyle}>{chat.sending ? "Sending..." : "Send"}</button>

--- a/features/system/settings/SettingsShell.test.tsx
+++ b/features/system/settings/SettingsShell.test.tsx
@@ -48,11 +48,11 @@ describe("System Options surface save timing", () => {
     render(<ThemeProvider><SettingsShell /></ThemeProvider>);
     expect(await screen.findByText("Master Volume: 70%")).toBeInTheDocument();
 
-    fireEvent.change(screen.getByRole("combobox", { name: "Theme" }), { target: { value: "ASTRAL" } });
+    fireEvent.click(screen.getByRole("radio", { name: /Astral Neutral/ }));
     expect(document.documentElement.dataset.theme).toBe("astral");
     expect(localStorage.getItem("lifeasgame.themePreference")).toBe("ASTRAL");
     expect(await screen.findByText("theme save failed")).toBeInTheDocument();
-    expect(screen.getByRole("combobox", { name: "Theme" })).toHaveValue("ASTRAL");
+    expect(screen.getByRole("radio", { name: /Astral Neutral/ })).toBeChecked();
     expect(screen.queryByRole("button", { name: /apply/i })).not.toBeInTheDocument();
 
     const request = api.updateSettingsApi.mock.calls[0][0];

--- a/features/system/settings/SettingsShell.tsx
+++ b/features/system/settings/SettingsShell.tsx
@@ -4,7 +4,6 @@ import { useState } from "react";
 
 import { useToast } from "@/context/ToastContext";
 import type { GraphicsQuality, InputPreset, SettingsView, ThemePreference, UiScale, VoiceChatMode } from "@/shared/api/types";
-import { INPUT_STYLE, SAO } from "@/shared/design/tokens";
 import { PanelFrame } from "@/widgets/right-panels/ui/PanelFrame";
 import { GoldRow, InfoCard } from "@/widgets/right-panels/ui/Rows";
 import { actionBtnStyle } from "@/widgets/right-panels/ui/styles";
@@ -12,22 +11,21 @@ import { SYSTEM_OPTIONS_FORM_FIELDS } from "../model";
 import { useSettings } from "./useSettings";
 
 const secondaryButton = {
-  border: `1px solid ${SAO.color.border.panel}`,
-  background: SAO.color.bg.inset,
-  color: SAO.color.text.secondary,
-  borderRadius: SAO.radius.panel,
   padding: "7px 10px",
   fontSize: "0.68rem",
   letterSpacing: "0.08em",
 } as const;
 
-const fieldLabel = {
-  display: "block",
-  fontSize: "0.62rem",
-  letterSpacing: "0.14em",
-  color: SAO.color.text.label,
-  textTransform: "uppercase",
-} as const;
+const THEME_OPTIONS: Array<{
+  value: ThemePreference;
+  title: string;
+  description: string;
+  previewTheme?: "astral" | "warm-beige";
+}> = [
+  { value: "ASTRAL", title: "Astral Neutral", description: "Dark · spatial · focused", previewTheme: "astral" },
+  { value: "WARM_BEIGE", title: "Warm Beige / Analog Spatial", description: "Analog · calm · archive", previewTheme: "warm-beige" },
+  { value: "SYSTEM", title: "System follow", description: "Dark OS → Astral · Light OS → Warm Beige" },
+];
 
 const UI_SCALES = [75, 100, 125, 150] as const;
 const isUiScale = (value: number): value is UiScale => UI_SCALES.some((scale) => scale === value);
@@ -85,34 +83,53 @@ export default function SettingsShell() {
   };
 
   return (
-    <PanelFrame title="System Options" depth={1}>
-      <div className="space-y-3 px-3" data-testid="settings-shell">
+    <div className="lag-settings-shell">
+      <PanelFrame title="Settings" depth={1}>
+        <div className="space-y-3 px-3" data-testid="settings-shell">
         {settings.loading && !settings.canonical ? <InfoCard>Loading Settings...</InfoCard> : null}
         {settings.error ? (
           <div className="space-y-2">
-            <p role="alert" className="text-xs" style={{ color: SAO.color.action.red }}>{settings.error}</p>
-            <button type="button" style={secondaryButton} onClick={() => void settings.retry()}>Retry</button>
+            <p role="alert" className="lag-state-error text-xs">{settings.error}</p>
+            <button type="button" className="lag-button-secondary" style={secondaryButton} onClick={() => void settings.retry()}>Retry</button>
           </div>
         ) : null}
 
         {!settings.error && settings.canonical ? (
-          <section aria-label="Appearance">
-            <label style={fieldLabel}>
-              Theme
-              <select
-                aria-label="Theme"
-                value={settings.themePreference}
-                disabled={settings.themeSaving || settings.saving}
-                onChange={(event) => { if (isThemePreference(event.target.value)) void settings.setThemePreference(event.target.value); }}
-                style={INPUT_STYLE}
-              >
-                <option value="SYSTEM">System</option>
-                <option value="ASTRAL">Astral</option>
-                <option value="WARM_BEIGE">Warm Beige</option>
-              </select>
-            </label>
-            {settings.themeSaveError ? <p role="alert" className="mt-1 text-xs" style={{ color: SAO.color.action.red }}>{settings.themeSaveError}</p> : null}
-          </section>
+          <fieldset aria-label="Appearance" className="space-y-3">
+            <legend className="lag-settings-label">Theme</legend>
+            <div className="lag-theme-preview" aria-live="polite">
+              <div className="text-center">
+                <strong className="block text-sm">Immediate preview</strong>
+                <span className="lag-text-meta mt-1 block text-xs">{settings.themePreference.replace("_", " ")}</span>
+              </div>
+            </div>
+            <div className="lag-theme-picker">
+              {THEME_OPTIONS.map((option) => (
+                <label
+                  key={option.value}
+                  className={`lag-theme-option${option.value === "SYSTEM" ? " lag-theme-option-system" : ""}`}
+                  data-lag-preview-theme={option.previewTheme}
+                >
+                  <input
+                    type="radio"
+                    name="themePreference"
+                    value={option.value}
+                    checked={settings.themePreference === option.value}
+                    disabled={settings.themeSaving || settings.saving}
+                    onChange={(event) => { if (isThemePreference(event.target.value)) void settings.setThemePreference(event.target.value); }}
+                  />
+                  <strong className="text-sm">{option.title}</strong>
+                  <span className="lag-text-meta text-xs">{option.description}</span>
+                  {option.previewTheme ? (
+                    <span className="lag-theme-swatches" aria-hidden>
+                      {Array.from({ length: 5 }, (_, index) => <span key={index} className="lag-theme-swatch" />)}
+                    </span>
+                  ) : null}
+                </label>
+              ))}
+            </div>
+            {settings.themeSaveError ? <p role="alert" className="lag-state-error mt-1 text-xs">{settings.themeSaveError}</p> : null}
+          </fieldset>
         ) : null}
 
         {!settings.error && settings.canonical && !editing ? (
@@ -121,17 +138,17 @@ export default function SettingsShell() {
             <div className="space-y-1.5">
               {summaryRows(settings.canonical.view).map((row) => <GoldRow key={row}>{row}</GoldRow>)}
             </div>
-            <button type="button" style={actionBtnStyle} onClick={() => setEditing(true)}>설정 편집</button>
+            <button type="button" className="lag-button-primary" style={actionBtnStyle} onClick={() => setEditing(true)}>설정 편집</button>
           </>
         ) : null}
 
         {!settings.error && editing && draft ? (
           <form className="space-y-3" onSubmit={submit}>
             {SYSTEM_OPTIONS_FORM_FIELDS.map((field) => (
-              <label key={field.key} style={fieldLabel}>
+              <label key={field.key} className="lag-settings-label block">
                 {field.label}
                 {field.type === "select" ? (
-                  <select title={field.label} value={String(draft[field.key as keyof SettingsView])} onChange={(event) => change(field.key, event.target.value)} style={INPUT_STYLE}>
+                  <select className="lag-settings-control mt-1" title={field.label} value={String(draft[field.key as keyof SettingsView])} onChange={(event) => change(field.key, event.target.value)}>
                     {field.options?.map((option) => <option key={option.value} value={option.value}>{option.label}</option>)}
                   </select>
                 ) : (
@@ -143,19 +160,20 @@ export default function SettingsShell() {
                     step={1}
                     value={draft.volume}
                     onChange={(event) => change(field.key, event.target.value)}
-                    style={INPUT_STYLE}
+                    className="lag-settings-control mt-1"
                   />
                 )}
               </label>
             ))}
-            {settings.saveError ? <p role="alert" className="text-xs" style={{ color: SAO.color.action.red }}>{settings.saveError}</p> : null}
+            {settings.saveError ? <p role="alert" className="lag-state-error text-xs">{settings.saveError}</p> : null}
             <div className="flex gap-2">
-              <button type="submit" disabled={!settings.dirty || settings.saving || settings.themeSaving} style={{ ...actionBtnStyle, flex: 1 }}>{settings.saving ? "Saving..." : "Save Settings"}</button>
-              <button type="button" disabled={settings.saving || settings.themeSaving} style={secondaryButton} onClick={() => { settings.cancel(); setEditing(false); }}>Cancel</button>
+              <button type="submit" className="lag-button-primary" disabled={!settings.dirty || settings.saving || settings.themeSaving} style={{ ...actionBtnStyle, flex: 1 }}>{settings.saving ? "Saving..." : "Save Settings"}</button>
+              <button type="button" className="lag-button-secondary" disabled={settings.saving || settings.themeSaving} style={secondaryButton} onClick={() => { settings.cancel(); setEditing(false); }}>Cancel</button>
             </div>
           </form>
         ) : null}
-      </div>
-    </PanelFrame>
+        </div>
+      </PanelFrame>
+    </div>
   );
 }

--- a/features/theme/ThemeProvider.test.tsx
+++ b/features/theme/ThemeProvider.test.tsx
@@ -1,4 +1,5 @@
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { readFileSync } from "node:fs";
 import { useState } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -50,6 +51,21 @@ describe("dual theme runtime", () => {
     expect(resolveTheme("WARM_BEIGE", true)).toBe("warm-beige");
     expect(resolveTheme("FUTURE_THEME", true)).toBe("warm-beige");
     expect(readStoredThemePreference({ getItem: () => "FUTURE_THEME" })).toBe("WARM_BEIGE");
+  });
+
+  it("exposes the approved representative tokens on the existing runtime selectors", () => {
+    const css = readFileSync("app/globals.css", "utf8");
+
+    expect(css).toContain(':root[data-theme="warm-beige"]');
+    expect(css).toContain("--lag-ambient: #EDE6DA;");
+    expect(css).toContain("--lag-panel: #FBF7F0;");
+    expect(css).toContain("--lag-focus: #5B9295;");
+    expect(css).toContain(':root[data-theme="astral"]');
+    expect(css).toContain("--lag-ambient: #07111F;");
+    expect(css).toContain("--lag-panel: #162337;");
+    expect(css).toContain("--lag-focus: #54D4DE;");
+    expect(css).not.toContain('data-theme="beige"');
+    expect(css).not.toContain('data-theme="warm_beige"');
   });
 
   it("bootstraps local preference, follows OS only for SYSTEM, persists, and never remounts child state", async () => {

--- a/features/theme/ThemeProvider.test.tsx
+++ b/features/theme/ThemeProvider.test.tsx
@@ -33,6 +33,15 @@ function Harness() {
   );
 }
 
+function selectorBlock(css: string, selector: string) {
+  const blocks: string[] = [];
+  for (const match of css.matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
+    if (match[1].split(",").some((part) => part.trim() === selector)) blocks.push(match[2]);
+  }
+  if (blocks.length > 0) return blocks.join("\n");
+  throw new Error(`Missing selector block: ${selector}`);
+}
+
 describe("dual theme runtime", () => {
   beforeEach(() => {
     dark = false;
@@ -55,17 +64,28 @@ describe("dual theme runtime", () => {
 
   it("exposes the approved representative tokens on the existing runtime selectors", () => {
     const css = readFileSync("app/globals.css", "utf8");
+    const warm = selectorBlock(css, ':root[data-theme="warm-beige"]');
+    const astral = selectorBlock(css, ':root[data-theme="astral"]');
 
-    expect(css).toContain(':root[data-theme="warm-beige"]');
-    expect(css).toContain("--lag-ambient: #EDE6DA;");
-    expect(css).toContain("--lag-panel: #FBF7F0;");
-    expect(css).toContain("--lag-focus: #5B9295;");
-    expect(css).toContain(':root[data-theme="astral"]');
-    expect(css).toContain("--lag-ambient: #07111F;");
-    expect(css).toContain("--lag-panel: #162337;");
-    expect(css).toContain("--lag-focus: #54D4DE;");
+    expect(warm).toContain("--lag-ambient: #EDE6DA;");
+    expect(warm).toContain("--lag-panel: #FBF7F0;");
+    expect(warm).toContain("--lag-focus: #5B9295;");
+    expect(warm).not.toContain("--lag-ambient: #07111F;");
+    expect(astral).toContain("--lag-ambient: #07111F;");
+    expect(astral).toContain("--lag-panel: #162337;");
+    expect(astral).toContain("--lag-focus: #54D4DE;");
+    expect(astral).not.toContain("--lag-ambient: #EDE6DA;");
     expect(css).not.toContain('data-theme="beige"');
     expect(css).not.toContain('data-theme="warm_beige"');
+  });
+
+  it("derives stronger controls from the approved palette while keeping meta text readable", () => {
+    const css = readFileSync("app/globals.css", "utf8");
+
+    expect(css).toContain("--lag-control-bg: color-mix(in srgb, var(--lag-panel-2) 76%, var(--lag-border));");
+    expect(css).toContain("--lag-control-border: color-mix(in srgb, var(--lag-border) 76%, var(--lag-text));");
+    expect(selectorBlock(css, ".lag-button-secondary")).toContain("background-color: var(--lag-control-bg)");
+    expect(selectorBlock(css, ".lag-text-meta")).toContain("color: var(--lag-text-2)");
   });
 
   it("bootstraps local preference, follows OS only for SYSTEM, persists, and never remounts child state", async () => {

--- a/shared/hooks/useStageCamera.test.ts
+++ b/shared/hooks/useStageCamera.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { focusStage, stageFocusPlan } from "./useStageCamera";
+
+describe("stage camera contract", () => {
+  it("targets a newly opened stage and replacement detail identity", () => {
+    expect(stageFocusPlan(["root"], ["root", "detail-a"])).toEqual({ key: "detail-a", align: "nearest" });
+    expect(stageFocusPlan(["root", "detail-a"], ["root", "detail-b"])).toEqual({ key: "detail-b", align: "center" });
+  });
+
+  it("returns focus to the parent when a stage closes", () => {
+    expect(stageFocusPlan(["root", "list", "detail"], ["root", "list"])).toEqual({ key: "list", align: "center" });
+  });
+
+  it("uses non-animated scrolling for reduced motion", () => {
+    const owner = document.createElement("div");
+    const target = document.createElement("div");
+    const scrollTo = vi.fn();
+    Object.defineProperties(owner, {
+      scrollTo: { configurable: true, value: scrollTo },
+      clientWidth: { configurable: true, value: 400 },
+      scrollWidth: { configurable: true, value: 900 },
+    });
+    owner.getBoundingClientRect = () => ({ left: 0, right: 400, top: 0, bottom: 600, width: 400, height: 600, x: 0, y: 0, toJSON: () => ({}) });
+    target.getBoundingClientRect = () => ({ left: 500, right: 800, top: 100, bottom: 500, width: 300, height: 400, x: 500, y: 100, toJSON: () => ({}) });
+
+    focusStage(owner, target, "nearest", true);
+
+    expect(scrollTo).toHaveBeenCalledWith({ left: 424, behavior: "auto" });
+  });
+});

--- a/shared/hooks/useStageCamera.ts
+++ b/shared/hooks/useStageCamera.ts
@@ -1,0 +1,98 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+type StageFocusPlan = { key: string; align: "center" | "nearest" } | null;
+
+export function stageFocusPlan(previous: string[], next: string[]): StageFocusPlan {
+  const previousSet = new Set(previous);
+  const added = next.filter((key) => !previousSet.has(key));
+  if (added.length > 0) {
+    return { key: added.at(-1)!, align: next.length === previous.length ? "center" : "nearest" };
+  }
+  if (previous.at(-1) && !next.includes(previous.at(-1)!) && next.at(-1)) {
+    return { key: next.at(-1)!, align: "center" };
+  }
+  return null;
+}
+
+export function focusStage(
+  owner: HTMLElement,
+  target: HTMLElement,
+  align: "center" | "nearest",
+  reducedMotion: boolean,
+) {
+  const ownerRect = owner.getBoundingClientRect();
+  const targetRect = target.getBoundingClientRect();
+  const targetLeft = owner.scrollLeft + targetRect.left - ownerRect.left;
+  const safe = 24;
+  let left = owner.scrollLeft;
+
+  if (align === "center") {
+    left = targetLeft + targetRect.width / 2 - owner.clientWidth / 2;
+  } else if (targetLeft < owner.scrollLeft + safe) {
+    left = targetLeft - safe;
+  } else if (targetLeft + targetRect.width > owner.scrollLeft + owner.clientWidth - safe) {
+    left = targetLeft + targetRect.width - owner.clientWidth + safe;
+  }
+
+  owner.scrollTo({
+    left: Math.max(0, Math.min(left, Math.max(0, owner.scrollWidth - owner.clientWidth))),
+    behavior: reducedMotion ? "auto" : "smooth",
+  });
+}
+
+function stages(owner: HTMLElement) {
+  return [...owner.querySelectorAll<HTMLElement>("[data-stage-key]")];
+}
+
+function prefersReducedMotion() {
+  return typeof window.matchMedia === "function" && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+}
+
+export function useStageCamera(
+  viewportRef: React.RefObject<HTMLDivElement | null>,
+  workspaceRef: React.RefObject<HTMLDivElement | null>,
+  mainSelectionKey: string,
+) {
+  const [mobile, setMobile] = useState(false);
+
+  useEffect(() => {
+    if (typeof window.matchMedia !== "function") return;
+    const query = window.matchMedia("(max-width: 767px)");
+    const update = () => setMobile(query.matches);
+    update();
+    query.addEventListener("change", update);
+    return () => query.removeEventListener("change", update);
+  }, []);
+
+  useEffect(() => {
+    const owner = mobile ? viewportRef.current : workspaceRef.current;
+    if (!owner) return;
+    let previous = stages(owner).map((stage) => stage.dataset.stageKey!);
+    let frame = 0;
+    const observer = new MutationObserver(() => {
+      cancelAnimationFrame(frame);
+      frame = requestAnimationFrame(() => {
+        const nextStages = stages(owner);
+        const plan = stageFocusPlan(previous, nextStages.map((stage) => stage.dataset.stageKey!));
+        previous = nextStages.map((stage) => stage.dataset.stageKey!);
+        const target = plan && nextStages.find((stage) => stage.dataset.stageKey === plan.key);
+        if (plan && target) focusStage(owner, target, plan.align, prefersReducedMotion());
+      });
+    });
+    observer.observe(owner, { childList: true, subtree: true });
+    return () => {
+      cancelAnimationFrame(frame);
+      observer.disconnect();
+    };
+  }, [mobile, viewportRef, workspaceRef]);
+
+  useEffect(() => {
+    const owner = mobile ? viewportRef.current : workspaceRef.current;
+    const target = owner && stages(owner)[0];
+    if (!owner || !target) return;
+    const frame = requestAnimationFrame(() => focusStage(owner, target, "center", prefersReducedMotion()));
+    return () => cancelAnimationFrame(frame);
+  }, [mainSelectionKey, mobile, viewportRef, workspaceRef]);
+}

--- a/shared/lib/uiConsts.ts
+++ b/shared/lib/uiConsts.ts
@@ -2,7 +2,7 @@ export const UI_CONSTS = {
   layout: {
     // Reference image estimate (landscape): left card ~35%, center orb rail ~12%, right panels ~53%
     leftWidth: 520,
-    centerWidth: 176,
+    centerWidth: 112,
     rightMinWidth: 560,
     columnGap: 28,
     canvasMinHeight: 860,
@@ -14,11 +14,11 @@ export const UI_CONSTS = {
   },
   orbNav: {
     viewportHeight: 560,
-    orbSize: 88,
-    orbGap: 34,
+    orbSize: 48,
+    orbGap: 22,
     framePaddingY: 12,
-    safePaddingY: 32,
-    labelGap: 8,
+    safePaddingY: 24,
+    labelGap: 4,
     labelHeight: 18,
     labelPaddingY: 2,
     outerRingPadding: 4,

--- a/shared/ui/AmbientOverlay.tsx
+++ b/shared/ui/AmbientOverlay.tsx
@@ -98,7 +98,7 @@ export default function AmbientOverlay() {
 
   return (
     <div
-      className="pointer-events-none fixed inset-0"
+      className="lag-ambient-overlay pointer-events-none fixed inset-0"
       style={{ zIndex: 8000 }}
       aria-hidden
     >

--- a/shared/ui/IconSlot.tsx
+++ b/shared/ui/IconSlot.tsx
@@ -16,11 +16,11 @@ export function IconSlot({
   className = "",
   iconSrc,
 }: IconSlotProps) {
-  const ring = active ? "rgba(244, 198, 86, 0.92)" : "rgba(200, 210, 225, 0.70)";
-  const border = active ? "rgba(249, 210, 108, 0.85)" : "rgba(180, 192, 210, 0.55)";
+  const ring = active ? "var(--lag-state-selected)" : "var(--lag-divider)";
+  const border = active ? "var(--lag-focus)" : "var(--lag-border)";
   const fill = active
-    ? "radial-gradient(circle at 32% 28%, rgba(255, 220, 120, 0.22), rgba(255, 173, 33, 0.08) 45%, rgba(255,255,255,0.02) 100%)"
-    : "radial-gradient(circle at 35% 30%, rgba(255,255,255,0.55), rgba(240,244,252,0.25) 42%, rgba(0,0,0,0) 100%)";
+    ? "color-mix(in srgb, var(--lag-state-selected) 14%, var(--lag-panel))"
+    : "var(--lag-panel-2)";
 
   const iconSize = Math.round(size * 0.6);
 
@@ -34,8 +34,8 @@ export function IconSlot({
         background: fill,
         border: `1px solid ${border}`,
         boxShadow: subtle
-          ? `inset 0 0 0 1px rgba(255,255,255,0.55), 0 0 0 1px rgba(0,0,0,0.18)`
-          : `inset 0 0 0 1px rgba(255,255,255,0.55), 0 0 0 1px rgba(0,0,0,0.12), 0 0 14px ${active ? "rgba(242,186,58,0.18)" : "rgba(180,190,210,0.08)"}`,
+          ? "inset 0 0 0 1px color-mix(in srgb, var(--lag-paper) 55%, transparent)"
+          : `0 0 14px ${active ? "color-mix(in srgb, var(--lag-state-selected) 18%, transparent)" : "transparent"}`,
       }}
     >
       <div
@@ -44,7 +44,7 @@ export function IconSlot({
           width: size - 8,
           height: size - 8,
           border: `1px solid ${ring}`,
-          boxShadow: `inset 0 0 0 1px rgba(255,255,255,0.03)`,
+          boxShadow: "none",
         }}
       >
         {iconSrc ? (
@@ -71,8 +71,8 @@ export function IconSlot({
                 "line-height: 1",
                 "font-weight: 600",
                 "letter-spacing: 0.18em",
-                "color: " + (active ? "rgba(255,235,184,0.95)" : "rgba(80,100,135,0.85)"),
-                active ? "text-shadow: 0 0 10px rgba(244,197,79,0.28)" : "",
+                "color: " + (active ? "var(--lag-text)" : "var(--lag-text-2)"),
+                active ? "text-shadow: 0 0 10px color-mix(in srgb,var(--lag-focus) 28%,transparent)" : "",
               ].join(";");
               img.parentElement?.replaceChild(span, img);
             }}
@@ -83,8 +83,8 @@ export function IconSlot({
             style={{
               fontSize: Math.max(10, Math.round(size * 0.22)),
               lineHeight: 1,
-              color: active ? "rgba(255, 235, 184, 0.95)" : "rgba(80, 100, 135, 0.85)",
-              textShadow: active ? "0 0 10px rgba(244, 197, 79, 0.28)" : "none",
+              color: active ? "var(--lag-text)" : "var(--lag-text-2)",
+              textShadow: active ? "0 0 10px color-mix(in srgb, var(--lag-focus) 28%, transparent)" : "none",
             }}
           >
             {label}
@@ -96,9 +96,9 @@ export function IconSlot({
         style={{
           width: Math.max(4, Math.round(size * 0.08)),
           height: Math.max(4, Math.round(size * 0.08)),
-          background: active ? "rgba(255, 221, 120, 0.85)" : "rgba(180, 195, 215, 0.55)",
+          background: active ? "var(--lag-focus)" : "var(--lag-disabled)",
           bottom: Math.round(size * 0.15),
-          boxShadow: active ? "0 0 8px rgba(247, 206, 94, 0.45)" : "none",
+          boxShadow: active ? "0 0 8px color-mix(in srgb, var(--lag-focus) 45%, transparent)" : "none",
         }}
       />
     </div>

--- a/shared/ui/IconSlot.tsx
+++ b/shared/ui/IconSlot.tsx
@@ -58,7 +58,7 @@ export function IconSlot({
               display: "block",
               opacity: active ? 1 : 0.72,
               filter: active
-                ? "drop-shadow(0 0 4px rgba(244,197,79,0.4))"
+                ? "drop-shadow(0 0 4px var(--lag-focus))"
                 : "brightness(1.1)",
             }}
             onError={(e) => {

--- a/shared/ui/PanelCard.tsx
+++ b/shared/ui/PanelCard.tsx
@@ -268,37 +268,35 @@ export default function PanelCard({
           onPointerLeave={(hasActions || hasDelete || onDoubleClick) ? handlePointerLeave : undefined}
           onPointerCancel={(hasActions || hasDelete || onDoubleClick) ? handlePointerCancel : undefined}
           whileTap={isInteractive ? { scale: 0.97 } : undefined}
+          aria-pressed={selected}
           transition={{ type: "spring", stiffness: 480, damping: 28 }}
           className={[
             "group relative flex w-full items-center gap-4 overflow-hidden",
             "border text-left",
-            "sao-card-shimmer",
+            "lag-panel-card sao-card-shimmer",
             isInteractive || hasActions || onDoubleClick ? "cursor-pointer" : "cursor-default",
           ].join(" ")}
           style={{
             height: UI_CONSTS.rightPanels.rowHeight,
-            borderRadius: "9px",
+            borderRadius: "var(--lag-radius-sm)",
             background: showActions
-              ? `rgba(30,25,12,0.97)`
+              ? "var(--lag-personal)"
               : selected
-              ? "linear-gradient(165deg, rgba(32,26,10,0.97), rgba(26,20,8,0.96))"
-              : "linear-gradient(165deg, rgba(18,15,10,0.95), rgba(14,12,8,0.93))",
+              ? "color-mix(in srgb, var(--lag-state-selected) 10%, var(--lag-panel))"
+              : "var(--lag-paper)",
             borderColor: showActions
-              ? `rgba(225,185,60,0.72)`
+              ? "var(--lag-focus)"
               : isLongPressing
-              ? `rgba(218,178,55,0.68)`
+              ? "var(--lag-focus)"
               : selected
-              ? "rgba(218,178,55,0.62)"
-              : "rgba(200,165,50,0.24)",
+              ? "var(--lag-state-selected)"
+              : "var(--lag-divider)",
             boxShadow: selected
-              ? [
-                  "inset 0 0 0 1px rgba(218,178,55,0.12)",
-                  "0 0 22px rgba(212,168,37,0.14)",
-                ].join(", ")
+              ? "0 0 0 1px var(--lag-state-selected)"
               : isLongPressing
-              ? `inset 0 0 0 1px rgba(218,178,55,0.18), 0 0 14px rgba(212,168,37,0.12)`
-              : `inset 0 0 0 1px rgba(218,178,55,0.04)`,
-            transition: "border-color 0.5s ease, background 0.3s ease, box-shadow 0.4s ease",
+              ? "0 0 0 2px color-mix(in srgb, var(--lag-focus) 30%, transparent)"
+              : "none",
+            transition: "border-color var(--lag-motion-normal) ease, background-color var(--lag-motion-normal) ease, box-shadow var(--lag-motion-normal) ease",
           }}
         >
           <div
@@ -306,14 +304,14 @@ export default function PanelCard({
             style={{
               borderRadius: "0 3px 3px 0",
               background: selected
-                ? "linear-gradient(180deg, rgba(255,232,120,0.98), rgba(212,168,30,0.96))"
+                ? "var(--lag-state-selected)"
                 : showActions
-                ? "rgba(218,178,55,0.70)"
-                : "rgba(200,165,50,0.28)",
+                ? "var(--lag-focus)"
+                : "var(--lag-divider)",
               boxShadow: selected
-                ? "0 0 12px rgba(212,168,37,0.60), inset 0 1px 0 rgba(255,248,180,0.55)"
+                ? "0 0 8px color-mix(in srgb, var(--lag-state-selected) 50%, transparent)"
                 : showActions
-                ? "0 0 8px rgba(218,178,55,0.40)"
+                ? "0 0 8px color-mix(in srgb, var(--lag-focus) 40%, transparent)"
                 : "none",
             }}
           />
@@ -330,7 +328,7 @@ export default function PanelCard({
             <p
               className="break-words font-semibold uppercase tracking-[0.08em]"
               style={{
-                color: selected ? "rgba(242,222,158,0.98)" : "rgba(225,208,162,0.90)",
+                color: selected ? "var(--lag-text)" : "var(--lag-text-2)",
                 fontSize: compact ? "0.9rem" : "1.1rem",
                 lineHeight: compact ? 1.2 : 1.15,
                 display: "-webkit-box",
@@ -345,7 +343,7 @@ export default function PanelCard({
               <p
                 className="mt-1 break-words text-sm tracking-[0.08em]"
                 style={{
-                  color: rarityColor(subtitle) ?? (selected ? "rgba(195,172,112,0.85)" : "rgba(162,148,108,0.78)"),
+                  color: rarityColor(subtitle) ?? (selected ? "var(--lag-text-2)" : "var(--lag-meta)"),
                   display: "-webkit-box",
                   WebkitLineClamp: compact ? 1 : 2,
                   WebkitBoxOrient: "vertical",

--- a/shared/ui/PanelCard.tsx
+++ b/shared/ui/PanelCard.tsx
@@ -218,7 +218,7 @@ export default function PanelCard({
         <div
           className="absolute inset-0 flex items-center justify-end"
           style={{
-            background: `rgba(244,63,94,${0.82 + swipeDeleteProgress * 0.18})`,
+            background: `color-mix(in srgb, var(--lag-state-error) ${82 + swipeDeleteProgress * 18}%, transparent)`,
             paddingRight: 20,
           }}
           aria-hidden
@@ -282,15 +282,15 @@ export default function PanelCard({
             background: showActions
               ? "var(--lag-personal)"
               : selected
-              ? "color-mix(in srgb, var(--lag-state-selected) 10%, var(--lag-panel))"
-              : "var(--lag-paper)",
+              ? "var(--lag-selected-surface)"
+              : "var(--lag-control-bg)",
             borderColor: showActions
               ? "var(--lag-focus)"
               : isLongPressing
               ? "var(--lag-focus)"
               : selected
               ? "var(--lag-state-selected)"
-              : "var(--lag-divider)",
+              : "var(--lag-control-border)",
             boxShadow: selected
               ? "0 0 0 1px var(--lag-state-selected)"
               : isLongPressing
@@ -376,15 +376,15 @@ export default function PanelCard({
               className="absolute inset-0 z-[400001] flex items-center justify-end gap-2 overflow-hidden border"
               style={{
                 borderRadius: "9px",
-                background: "linear-gradient(180deg, rgba(22,18,10,0.98), rgba(16,13,7,0.97))",
-                borderColor: `rgba(218,178,55,0.58)`,
-                boxShadow: "inset 0 0 0 1px rgba(218,178,55,0.06), 0 0 20px rgba(212,168,37,0.08)",
+                background: "var(--lag-raised-surface)",
+                borderColor: "var(--lag-focus)",
+                boxShadow: "0 0 20px color-mix(in srgb, var(--lag-shadow) 20%, transparent)",
                 paddingInline: 12,
               }}
             >
               <span
                 className="mr-auto uppercase"
-                style={{ fontSize: "10px", letterSpacing: "0.2em", color: "rgba(148,135,98,0.72)" }}
+                style={{ fontSize: "10px", letterSpacing: "0.2em", color: "var(--lag-text-2)" }}
               >
                 Action
               </span>

--- a/shared/ui/PanelStage.tsx
+++ b/shared/ui/PanelStage.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { motion, useReducedMotion } from "framer-motion";
+
+import { MOTION } from "@/shared/lib/motion";
+
+export default function PanelStage({
+  stageKey,
+  index = 0,
+  children,
+  onPointerDownCapture,
+  zIndex,
+}: {
+  stageKey: string;
+  index?: number;
+  children: React.ReactNode;
+  onPointerDownCapture?: () => void;
+  zIndex?: number;
+}) {
+  const reducedMotion = useReducedMotion();
+
+  return (
+    <motion.div
+      layout="position"
+      className="lag-panel-stage relative"
+      data-stage-key={stageKey}
+      onPointerDownCapture={onPointerDownCapture}
+      initial={reducedMotion ? false : MOTION.panelSlot.initial}
+      animate={MOTION.panelSlot.animate}
+      exit={MOTION.panelSlot.exit}
+      transition={reducedMotion ? { duration: 0 } : { type: "spring", stiffness: 380, damping: 28, delay: index * 0.055 }}
+      style={{ willChange: "transform, opacity", zIndex }}
+    >
+      {children}
+    </motion.div>
+  );
+}

--- a/widgets/left-context/LeftContext.test.tsx
+++ b/widgets/left-context/LeftContext.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react";
+import { readFileSync } from "node:fs";
 import { describe, expect, it, vi } from "vitest";
 
 import type { RoleDetail } from "@/shared/api/types";
@@ -9,6 +10,17 @@ const roles: RoleDetail[] = [
 ];
 
 describe("LeftContext에서 Role을 사용할 때", () => {
+  it("legacy Astral frame 대신 shared semantic material을 사용한다", () => {
+    const frame = readFileSync("widgets/left-context/LeftContext.tsx", "utf8");
+    const children = ["PlayerPanel.tsx", "RoleContextPanel.tsx", "SocialPanel.tsx"]
+      .map((file) => readFileSync(`widgets/left-context/ui/${file}`, "utf8"))
+      .join("\n");
+
+    expect(frame).toContain("lag-left-context");
+    expect(`${frame}\n${children}`).toContain("var(--lag-control-bg)");
+    expect(`${frame}\n${children}`).not.toMatch(/PANEL_STYLE|GRID_OVERLAY_STYLE|SAO\.color|rgba\(/);
+  });
+
   describe("Player context의 실제 Role badge를 선택하면", () => {
     it("선택한 Role ID를 primary Role navigation callback에 전달한다", () => {
       const selectRole = vi.fn();

--- a/widgets/left-context/LeftContext.tsx
+++ b/widgets/left-context/LeftContext.tsx
@@ -3,7 +3,6 @@
 import { AnimatePresence, motion } from "framer-motion";
 
 import type { EquipmentView, PlayerInfo, RoleDetail } from "@/shared/api/types";
-import { PANEL_STYLE, GRID_OVERLAY_STYLE } from "@/shared/design/tokens";
 import { MOTION } from "@/shared/lib/motion";
 import type { SocialContextData } from "@/entities/nav";
 import { UI_CONSTS } from "@/shared/lib/uiConsts";
@@ -52,25 +51,24 @@ export default function LeftContext({
           animate={MOTION.panelReset.animate}
           exit={MOTION.panelReset.exit}
           transition={MOTION.panelReset.transition}
-          className="relative h-full min-h-[420px] overflow-hidden border"
+          className="lag-left-context lag-panel-stage relative h-full min-h-[420px] overflow-hidden"
+          data-stage-key={`left-context-${mode}`}
           onPointerDownCapture={onFocus}
           style={{
-            ...PANEL_STYLE,
             width: UI_CONSTS.leftContext.width,
             minHeight: UI_CONSTS.leftContext.minHeight,
             willChange: "transform, opacity",
             zIndex,
-            borderRadius: "6px",
           }}
         >
-          <div style={GRID_OVERLAY_STYLE} />
+          <div className="lag-left-context-grid pointer-events-none absolute inset-0 opacity-40" />
 
           {/* Corner L-bracket ornaments */}
           {[
-            { top: 4, left: 4, borderTop: "1.5px solid rgba(218,178,55,0.60)", borderLeft: "1.5px solid rgba(218,178,55,0.60)" },
-            { top: 4, right: 4, borderTop: "1.5px solid rgba(218,178,55,0.60)", borderRight: "1.5px solid rgba(218,178,55,0.60)" },
-            { bottom: 4, left: 4, borderBottom: "1.5px solid rgba(218,178,55,0.60)", borderLeft: "1.5px solid rgba(218,178,55,0.60)" },
-            { bottom: 4, right: 4, borderBottom: "1.5px solid rgba(218,178,55,0.60)", borderRight: "1.5px solid rgba(218,178,55,0.60)" },
+            { top: 4, left: 4, borderTop: "1.5px solid var(--lag-focus)", borderLeft: "1.5px solid var(--lag-focus)" },
+            { top: 4, right: 4, borderTop: "1.5px solid var(--lag-focus)", borderRight: "1.5px solid var(--lag-focus)" },
+            { bottom: 4, left: 4, borderBottom: "1.5px solid var(--lag-focus)", borderLeft: "1.5px solid var(--lag-focus)" },
+            { bottom: 4, right: 4, borderBottom: "1.5px solid var(--lag-focus)", borderRight: "1.5px solid var(--lag-focus)" },
           ].map((c, i) => (
             <div key={i} aria-hidden style={{ position: "absolute", width: 14, height: 14, pointerEvents: "none", zIndex: 30, ...c }} />
           ))}
@@ -82,7 +80,7 @@ export default function LeftContext({
               top: 0, left: 0, right: 0,
               height: "1px",
               zIndex: 20,
-              background: "linear-gradient(90deg, transparent 5%, rgba(218,178,55,0.72) 35%, rgba(218,178,55,0.72) 65%, transparent 95%)",
+              background: "linear-gradient(90deg, transparent 5%, var(--lag-focus) 35%, var(--lag-focus) 65%, transparent 95%)",
               pointerEvents: "none",
             }}
           />

--- a/widgets/left-context/ui/PlayerPanel.tsx
+++ b/widgets/left-context/ui/PlayerPanel.tsx
@@ -5,7 +5,6 @@ import { useState } from "react";
 
 import type { EquipmentView, PlayerInfo, RoleDetail } from "@/shared/api/types";
 import { MOCK_EQUIPPED_ITEMS } from "@/features/player/mock";
-import { SAO } from "@/shared/design/tokens";
 import { RoleBadges } from "./RoleContextPanel";
 
 function StatBar({
@@ -23,14 +22,14 @@ function StatBar({
   return (
     <div>
       <div className="mb-1 flex items-center justify-between">
-        <span className="uppercase" style={{ fontSize: "10px", letterSpacing: "0.18em", color: SAO.color.text.label }}>
+        <span className="uppercase" style={{ fontSize: "10px", letterSpacing: "0.18em", color: "var(--lag-text-2)" }}>
           {label}
         </span>
-        <span style={{ fontSize: "10px", letterSpacing: "0.1em", color: SAO.color.text.label }}>
+        <span style={{ fontSize: "10px", letterSpacing: "0.1em", color: "var(--lag-text-2)" }}>
           {value.toLocaleString()} / {max.toLocaleString()}
         </span>
       </div>
-      <div className="w-full" style={{ height: "6px", background: SAO.color.bar.track, borderRadius: "1px" }}>
+      <div className="w-full" style={{ height: "6px", background: "color-mix(in srgb, var(--lag-divider) 72%, transparent)", borderRadius: "1px" }}>
         <div
           style={{
             width: `${pct}%`,
@@ -38,7 +37,7 @@ function StatBar({
             background: color,
             borderRadius: "1px",
             transition: "width 0.5s ease",
-            boxShadow: `0 0 8px ${color.includes("f43") || color.includes("f87") ? "rgba(244,63,94,0.60)" : color.includes("38b") || color.includes("60a") ? "rgba(56,189,248,0.60)" : "rgba(248,197,78,0.55)"}`,
+            boxShadow: "0 0 8px color-mix(in srgb, var(--lag-focus) 36%, transparent)",
           }}
         />
       </div>
@@ -91,9 +90,9 @@ export function PlayerPanel({
   }, {});
 
   const statCellStyle = {
-    background: SAO.color.bg.inset,
-    border: `1px solid rgba(0,0,0,0.08)`,
-    borderRadius: SAO.radius.panel,
+    background: "var(--lag-muted-surface)",
+    border: "1px solid var(--lag-divider)",
+    borderRadius: "var(--lag-radius-sm)",
   };
 
   return (
@@ -101,24 +100,24 @@ export function PlayerPanel({
       <div className="p-7">
         {/* Identity header */}
         <div className="text-center">
-          <h2 className="font-semibold" style={{ fontSize: "2.25rem", letterSpacing: "0.08em", color: SAO.color.text.primary }}>
+          <h2 className="font-semibold" style={{ fontSize: "2.25rem", letterSpacing: "0.08em", color: "var(--lag-text)" }}>
             {name}
           </h2>
-          <p className="mt-0.5 uppercase" style={{ fontSize: "11px", letterSpacing: "0.22em", color: SAO.color.text.label }}>
+          <p className="mt-0.5 uppercase" style={{ fontSize: "11px", letterSpacing: "0.22em", color: "var(--lag-text-2)" }}>
             {[gender, guildName].filter(Boolean).join(" · ")}
           </p>
-          <p className="mt-1 uppercase" style={{ fontSize: "11px", letterSpacing: "0.22em", color: SAO.color.text.label }}>
+          <p className="mt-1 uppercase" style={{ fontSize: "11px", letterSpacing: "0.22em", color: "var(--lag-text-2)" }}>
             Lv.{level} {job}
           </p>
           <div
             className="mx-auto mt-4"
-            style={{ width: "88%", height: "1px", background: `linear-gradient(90deg, transparent, ${SAO.color.border.panel}, transparent)` }}
+            style={{ width: "88%", height: "1px", background: "linear-gradient(90deg, transparent, var(--lag-divider), transparent)" }}
           />
         </div>
 
         {roles.length > 0 ? (
           <div className="mt-4 px-1">
-            <p className="mb-2 text-center uppercase" style={{ fontSize: 10, letterSpacing: "0.2em", color: SAO.color.text.label }}>Roles</p>
+            <p className="mb-2 text-center uppercase" style={{ fontSize: 10, letterSpacing: "0.2em", color: "var(--lag-text-2)" }}>Roles</p>
             <RoleBadges roles={roles} selectedRoleId={selectedRoleId} onSelect={onRoleSelect} />
           </div>
         ) : null}
@@ -126,17 +125,17 @@ export function PlayerPanel({
         {/* EXP bar */}
         <div className="mt-4 px-1">
           <div className="mb-1 flex items-center justify-between">
-            <span className="uppercase" style={{ fontSize: "10px", letterSpacing: "0.2em", color: SAO.color.text.label }}>EXP</span>
-            <span style={{ fontSize: "11px", letterSpacing: "0.1em", color: SAO.color.text.label, fontWeight: 600 }}>
+            <span className="uppercase" style={{ fontSize: "10px", letterSpacing: "0.2em", color: "var(--lag-text-2)" }}>EXP</span>
+            <span style={{ fontSize: "11px", letterSpacing: "0.1em", color: "var(--lag-text-2)", fontWeight: 600 }}>
               {exp.toLocaleString()} xp
             </span>
           </div>
-          <div style={{ height: "6px", background: SAO.color.bar.track, borderRadius: "1px" }}>
+          <div style={{ height: "6px", background: "color-mix(in srgb, var(--lag-divider) 72%, transparent)", borderRadius: "1px" }}>
             <div
               style={{
                 width: `${Math.min(100, Math.round(((exp % 10000) / 10000) * 100))}%`,
                 height: "100%",
-                background: `linear-gradient(90deg, rgba(248,197,78,0.85), rgba(234,168,40,0.85))`,
+                background: "linear-gradient(90deg, var(--lag-amber), var(--lag-warning))",
                 borderRadius: "1px",
                 transition: "width 0.5s ease",
               }}
@@ -146,8 +145,8 @@ export function PlayerPanel({
 
         {/* HP / MP bars */}
         <div className="mt-3 space-y-2.5 px-1">
-          <StatBar label="HP" value={hp} max={hpMax} color={`linear-gradient(90deg, #f87171, ${SAO.color.bar.hp})`} />
-          <StatBar label="MP" value={mp} max={mpMax} color={`linear-gradient(90deg, #60a5fa, ${SAO.color.bar.mp})`} />
+          <StatBar label="HP" value={hp} max={hpMax} color="linear-gradient(90deg, var(--lag-warning), var(--lag-error))" />
+          <StatBar label="MP" value={mp} max={mpMax} color="linear-gradient(90deg, var(--lag-cyan), var(--lag-focus))" />
         </div>
 
         {/* Stat grid 3×2 */}
@@ -160,15 +159,15 @@ export function PlayerPanel({
                 className="flex flex-col items-center px-1 py-2"
                 style={{
                   ...statCellStyle,
-                  border: `1px solid ${isTop ? SAO.color.border.gold : "rgba(0,0,0,0.08)"}`,
+                  border: `1px solid ${isTop ? "var(--lag-focus)" : "var(--lag-divider)"}`,
                 }}
               >
-                <span className="uppercase" style={{ fontSize: "10px", letterSpacing: "0.2em", color: SAO.color.text.label }}>
+                <span className="uppercase" style={{ fontSize: "10px", letterSpacing: "0.2em", color: "var(--lag-text-2)" }}>
                   {s.label}
                 </span>
                 <span
                   className="mt-1 font-semibold"
-                  style={{ fontSize: "18px", letterSpacing: "0.02em", color: isTop ? SAO.color.action.gold : SAO.color.text.primary }}
+                  style={{ fontSize: "18px", letterSpacing: "0.02em", color: isTop ? "var(--lag-focus)" : "var(--lag-text)" }}
                 >
                   {s.value}
                 </span>
@@ -182,8 +181,8 @@ export function PlayerPanel({
           <div className="mt-4 space-y-1 px-1">
             {Object.entries(extraStats).map(([k, v]) => (
               <div key={k} className="flex items-center justify-between rounded-sm px-3 py-1.5" style={statCellStyle}>
-                <span className="text-xs uppercase" style={{ letterSpacing: "0.12em", color: SAO.color.text.label }}>{k}</span>
-                <span className="text-sm font-semibold" style={{ color: SAO.color.text.primary }}>{v}</span>
+                <span className="text-xs uppercase" style={{ letterSpacing: "0.12em", color: "var(--lag-text-2)" }}>{k}</span>
+                <span className="text-sm font-semibold" style={{ color: "var(--lag-text)" }}>{v}</span>
               </div>
             ))}
           </div>
@@ -192,13 +191,13 @@ export function PlayerPanel({
         {/* Equipment section */}
         {Object.keys(equipByCat).length > 0 ? (
           <div className="mt-6 px-1">
-            <p className="mb-2 uppercase" style={{ fontSize: "10px", letterSpacing: "0.2em", color: SAO.color.text.label }}>
+            <p className="mb-2 uppercase" style={{ fontSize: "10px", letterSpacing: "0.2em", color: "var(--lag-text-2)" }}>
               Equipment
             </p>
             <div className="space-y-3">
               {Object.entries(equipByCat).map(([cat, slots]) => (
                 <div key={cat}>
-                  <p className="mb-1 uppercase" style={{ fontSize: "9px", letterSpacing: "0.18em", color: SAO.color.text.label, opacity: 0.7 }}>
+                  <p className="mb-1 uppercase" style={{ fontSize: "9px", letterSpacing: "0.18em", color: "var(--lag-text-2)", opacity: 0.7 }}>
                     {cat}
                   </p>
                   <div className="space-y-1">
@@ -215,20 +214,20 @@ export function PlayerPanel({
                             <div
                               className="flex items-center gap-2 rounded-sm px-3 py-2 transition-colors"
                               style={{
-                                background: isSelected ? "rgba(249,208,105,0.12)" : SAO.color.bg.inset,
-                                border: `1px solid ${isSelected ? SAO.color.border.gold : "rgba(0,0,0,0.08)"}`,
-                                borderRadius: SAO.radius.panel,
+                                background: isSelected ? "var(--lag-selected-surface)" : "var(--lag-control-bg)",
+                                border: `1px solid ${isSelected ? "var(--lag-focus)" : "var(--lag-control-border)"}`,
+                                borderRadius: "var(--lag-radius-sm)",
                               }}
                             >
                               <span
                                 className="uppercase"
-                                style={{ fontSize: "9px", letterSpacing: "0.14em", color: SAO.color.text.label, flexShrink: 0, width: 56 }}
+                                style={{ fontSize: "9px", letterSpacing: "0.14em", color: "var(--lag-text-2)", flexShrink: 0, width: 56 }}
                               >
                                 {slot.slotName}
                               </span>
                               <span
                                 className="min-w-0 flex-1 truncate text-sm"
-                                style={{ color: item ? SAO.color.text.primary : "rgba(90,128,178,0.55)", fontStyle: item ? "normal" : "italic" }}
+                                style={{ color: item ? "var(--lag-text)" : "var(--lag-meta)", fontStyle: item ? "normal" : "italic" }}
                               >
                                 {item ? item.name : "Empty"}
                               </span>
@@ -247,9 +246,9 @@ export function PlayerPanel({
                                 <div
                                   className="mt-1 rounded-sm px-3 py-2 space-y-0.5"
                                   style={{
-                                    background: "rgba(249,208,105,0.07)",
-                                    border: `1px solid rgba(249,208,105,0.35)`,
-                                    borderRadius: SAO.radius.panel,
+                                    background: "var(--lag-selected-surface)",
+                                    border: "1px solid var(--lag-focus)",
+                                    borderRadius: "var(--lag-radius-sm)",
                                   }}
                                 >
                                   {[
@@ -260,8 +259,8 @@ export function PlayerPanel({
                                     { k: "Equipped", v: item.equippedAt },
                                   ].map(({ k, v }) => (
                                     <div key={k} className="flex items-center gap-2">
-                                      <span className="uppercase" style={{ fontSize: "9px", letterSpacing: "0.14em", color: SAO.color.text.label, width: 54, flexShrink: 0 }}>{k}</span>
-                                      <span className="min-w-0 flex-1 truncate text-xs" style={{ color: SAO.color.text.primary }}>{v}</span>
+                                      <span className="uppercase" style={{ fontSize: "9px", letterSpacing: "0.14em", color: "var(--lag-text-2)", width: 54, flexShrink: 0 }}>{k}</span>
+                                      <span className="min-w-0 flex-1 truncate text-xs" style={{ color: "var(--lag-text)" }}>{v}</span>
                                     </div>
                                   ))}
                                 </div>

--- a/widgets/left-context/ui/RoleContextPanel.tsx
+++ b/widgets/left-context/ui/RoleContextPanel.tsx
@@ -1,12 +1,11 @@
 "use client";
 
 import type { RoleDetail } from "@/shared/api/types";
-import { SAO } from "@/shared/design/tokens";
 
 const cellStyle = {
-  background: SAO.color.bg.inset,
-  border: `1px solid ${SAO.color.border.panel}`,
-  borderRadius: SAO.radius.panel,
+  background: "var(--lag-control-bg)",
+  border: "1px solid var(--lag-control-border)",
+  borderRadius: "var(--lag-radius-sm)",
 } as const;
 
 export function RoleBadges({ roles, selectedRoleId, onSelect }: { roles: RoleDetail[]; selectedRoleId?: number | null; onSelect?: (roleId: number) => void }) {
@@ -20,8 +19,9 @@ export function RoleBadges({ roles, selectedRoleId, onSelect }: { roles: RoleDet
           className="rounded-sm px-2.5 py-1.5 text-xs uppercase transition-opacity hover:opacity-80"
           style={{
             ...cellStyle,
-            borderColor: selectedRoleId === role.id ? SAO.color.border.gold : SAO.color.border.panel,
-            color: selectedRoleId === role.id ? SAO.color.action.gold : SAO.color.text.secondary,
+            background: selectedRoleId === role.id ? "var(--lag-selected-surface)" : "var(--lag-control-bg)",
+            borderColor: selectedRoleId === role.id ? "var(--lag-focus)" : "var(--lag-control-border)",
+            color: selectedRoleId === role.id ? "var(--lag-text)" : "var(--lag-text-2)",
             letterSpacing: "0.08em",
           }}
           onClick={() => onSelect?.(role.id)}
@@ -49,14 +49,14 @@ export function RoleContextPanel({
   return (
     <div className="relative z-10 overflow-y-auto p-7 scrollbar-hide" style={{ maxHeight: "100%" }}>
       <div className="text-center">
-        <p className="uppercase" style={{ fontSize: 11, letterSpacing: "0.24em", color: SAO.color.text.label }}>ROLE CONTEXT</p>
-        <h2 className="mt-2 text-2xl font-semibold" style={{ letterSpacing: "0.08em", color: SAO.color.text.primary }}>My Roles</h2>
+        <p className="uppercase" style={{ fontSize: 11, letterSpacing: "0.24em", color: "var(--lag-text-2)" }}>ROLE CONTEXT</p>
+        <h2 className="mt-2 text-2xl font-semibold" style={{ letterSpacing: "0.08em", color: "var(--lag-text)" }}>My Roles</h2>
       </div>
 
       <div className="mt-5">
-        {isLoading ? <p className="text-center text-sm" style={{ color: SAO.color.text.secondary }}>Loading Roles...</p> : null}
-        {error ? <p role="alert" className="text-center text-xs" style={{ color: SAO.color.action.red }}>{error}</p> : null}
-        {!isLoading && !error && roles.length === 0 ? <p className="text-center text-sm" style={{ color: SAO.color.text.secondary }}>No Roles yet.</p> : null}
+        {isLoading ? <p className="text-center text-sm" style={{ color: "var(--lag-text-2)" }}>Loading Roles...</p> : null}
+        {error ? <p role="alert" className="text-center text-xs" style={{ color: "var(--lag-state-error)" }}>{error}</p> : null}
+        {!isLoading && !error && roles.length === 0 ? <p className="text-center text-sm" style={{ color: "var(--lag-text-2)" }}>No Roles yet.</p> : null}
         <RoleBadges roles={roles} selectedRoleId={selectedRoleId} onSelect={onRoleSelect} />
       </div>
     </div>

--- a/widgets/left-context/ui/SocialPanel.tsx
+++ b/widgets/left-context/ui/SocialPanel.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { SAO } from "@/shared/design/tokens";
 import type { SocialContextData } from "@/entities/nav";
 
 export function SocialPanel({
@@ -9,42 +8,42 @@ export function SocialPanel({
   socialContext: SocialContextData | null;
 }) {
   const cellStyle = {
-    background: SAO.color.bg.inset,
-    border: `1px solid rgba(0,0,0,0.08)`,
-    borderRadius: SAO.radius.panel,
+    background: "var(--lag-muted-surface)",
+    border: "1px solid var(--lag-divider)",
+    borderRadius: "var(--lag-radius-sm)",
   };
 
   return (
     <div className="relative z-10 p-7">
       <div className="text-center">
-        <p className="uppercase" style={{ fontSize: "11px", letterSpacing: "0.24em", color: SAO.color.text.label }}>
+        <p className="uppercase" style={{ fontSize: "11px", letterSpacing: "0.24em", color: "var(--lag-text-2)" }}>
           SOCIAL CONTEXT
         </p>
-        <h2 className="mt-2 font-semibold" style={{ fontSize: "1.875rem", letterSpacing: "0.08em", color: SAO.color.text.primary }}>
+        <h2 className="mt-2 font-semibold" style={{ fontSize: "1.875rem", letterSpacing: "0.08em", color: "var(--lag-text)" }}>
           {socialContext?.categoryLabel ?? "Social"}
         </h2>
         <div
           className="mx-auto mt-5"
-          style={{ width: "88%", height: "1px", background: `linear-gradient(90deg, transparent, ${SAO.color.border.panel}, transparent)` }}
+          style={{ width: "88%", height: "1px", background: "linear-gradient(90deg, transparent, var(--lag-divider), transparent)" }}
         />
       </div>
 
       {socialContext ? (
         <div className="mt-8 space-y-3">
           <div className="rounded-sm px-4 py-3" style={cellStyle}>
-            <p className="uppercase" style={{ fontSize: "10px", letterSpacing: "0.2em", color: SAO.color.text.label }}>TARGET</p>
-            <p className="mt-1 break-words text-lg font-semibold" style={{ letterSpacing: "0.08em", color: SAO.color.text.primary }}>
+            <p className="uppercase" style={{ fontSize: "10px", letterSpacing: "0.2em", color: "var(--lag-text-2)" }}>TARGET</p>
+            <p className="mt-1 break-words text-lg font-semibold" style={{ letterSpacing: "0.08em", color: "var(--lag-text)" }}>
               {socialContext.title}
             </p>
             {socialContext.subtitle ? (
-              <p className="mt-1 break-words text-sm" style={{ letterSpacing: "0.08em", color: SAO.color.text.secondary }}>
+              <p className="mt-1 break-words text-sm" style={{ letterSpacing: "0.08em", color: "var(--lag-text-2)" }}>
                 {socialContext.subtitle}
               </p>
             ) : null}
           </div>
           <div className="rounded-sm px-4 py-3" style={cellStyle}>
-            <p className="uppercase" style={{ fontSize: "10px", letterSpacing: "0.2em", color: SAO.color.text.label }}>DETAIL</p>
-            <p className="mt-1 break-words text-sm" style={{ letterSpacing: "0.07em", color: SAO.color.text.primary }}>
+            <p className="uppercase" style={{ fontSize: "10px", letterSpacing: "0.2em", color: "var(--lag-text-2)" }}>DETAIL</p>
+            <p className="mt-1 break-words text-sm" style={{ letterSpacing: "0.07em", color: "var(--lag-text)" }}>
               {socialContext.description}
             </p>
           </div>
@@ -55,8 +54,8 @@ export function SocialPanel({
                 className="flex min-h-10 items-center gap-3 rounded-sm px-3 py-2"
                 style={cellStyle}
               >
-                <span className="rounded-full flex-shrink-0" style={{ width: "6px", height: "6px", background: SAO.color.action.gold }} />
-                <span className="break-words text-sm" style={{ letterSpacing: "0.06em", color: SAO.color.text.primary }}>
+                <span className="rounded-full flex-shrink-0" style={{ width: "6px", height: "6px", background: "var(--lag-focus)" }} />
+                <span className="break-words text-sm" style={{ letterSpacing: "0.06em", color: "var(--lag-text)" }}>
                   {row}
                 </span>
               </div>
@@ -66,8 +65,8 @@ export function SocialPanel({
       ) : (
         <div className="mt-8 space-y-2.5">
           <div className="rounded-sm px-4 py-3" style={cellStyle}>
-            <p className="uppercase" style={{ fontSize: "10px", letterSpacing: "0.2em", color: SAO.color.text.label }}>INFO</p>
-            <p className="mt-1 text-sm" style={{ letterSpacing: "0.07em", color: SAO.color.text.primary }}>
+            <p className="uppercase" style={{ fontSize: "10px", letterSpacing: "0.2em", color: "var(--lag-text-2)" }}>INFO</p>
+            <p className="mt-1 text-sm" style={{ letterSpacing: "0.07em", color: "var(--lag-text)" }}>
               Select a party or guild from the social list to load context here.
             </p>
           </div>

--- a/widgets/orb-nav/OrbNav.tsx
+++ b/widgets/orb-nav/OrbNav.tsx
@@ -6,7 +6,6 @@ import { AnimatePresence, motion } from "framer-motion";
 import type { MainNavId } from "@/entities/nav";
 import { MOTION } from "@/shared/lib/motion";
 import { UI_CONSTS } from "@/shared/lib/uiConsts";
-import { SAO_ICON } from "@/shared/design/tokens";
 import { usePanScroll } from "@/shared/hooks/usePanScroll";
 
 type OrbItem = {
@@ -24,32 +23,6 @@ type OrbNavProps = {
 };
 
 type Ripple = { id: number };
-
-// 기본 (비선택) 아이콘 — 흰 원 + 회색 픽토그램
-const ORB_ICONS: Partial<Record<MainNavId, string>> = {
-  player:    SAO_ICON.player,
-  skills:    SAO_ICON.skills,
-  inventory: SAO_ICON.items,
-  quests:    SAO_ICON.quest,
-  role:      SAO_ICON.social,
-  social:    SAO_ICON.social,
-  lifelog:   SAO_ICON.lifelog,
-  market:    SAO_ICON.market,
-  system:    SAO_ICON.config,
-};
-
-// 선택 상태 아이콘 — 금색 원 + 흰 픽토그램
-const ORB_ICONS_ON: Partial<Record<MainNavId, string>> = {
-  player:    SAO_ICON.playerOn,
-  skills:    SAO_ICON.skillsOn,
-  inventory: SAO_ICON.itemsOn,
-  quests:    SAO_ICON.questOn,
-  role:      SAO_ICON.socialOn,
-  social:    SAO_ICON.socialOn,
-  lifelog:   SAO_ICON.lifelogOn,
-  market:    SAO_ICON.marketOn,
-  system:    SAO_ICON.configOn,
-};
 
 export default function OrbNav({ items, selectedId, onSelect, zIndex, onFocus }: OrbNavProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -93,62 +66,29 @@ export default function OrbNav({ items, selectedId, onSelect, zIndex, onFocus }:
       style={zIndex ? { zIndex } : undefined}
     >
       <div
-        className="relative flex items-center justify-center overflow-hidden px-3"
+        className="lag-orb-nav relative flex items-center justify-center overflow-hidden px-3"
         style={{
           width: UI_CONSTS.layout.centerWidth,
           height: viewportHeight + framePaddingY * 2,
-          borderRadius: "18px",
-          border: "1px solid rgba(200,165,50,0.42)",
-          background: "linear-gradient(155deg, rgba(16,14,10,0.97), rgba(12,10,7,0.96))",
           backdropFilter: "blur(14px)",
           WebkitBackdropFilter: "blur(14px)",
-          boxShadow: [
-            "inset 0 0 0 1px rgba(218,178,55,0.07)",
-            "0 20px 50px rgba(0,0,0,0.78)",
-          ].join(", "),
         }}
       >
-        {/* 시안 탑 액센트 */}
-        <div
-          aria-hidden
-          style={{
-            position: "absolute",
-            top: 0, left: "12%", right: "12%",
-            height: "1px",
-            background: "linear-gradient(90deg, transparent, rgba(218,178,60,0.55) 40%, rgba(218,178,60,0.55) 60%, transparent)",
-            pointerEvents: "none",
-          }}
-        />
-        {/* 바텀 액센트 */}
-        <div
-          aria-hidden
-          style={{
-            position: "absolute",
-            bottom: 0, left: "12%", right: "12%",
-            height: "1px",
-            background: "linear-gradient(90deg, transparent, rgba(180,145,45,0.22) 40%, rgba(180,145,45,0.22) 60%, transparent)",
-            pointerEvents: "none",
-          }}
-        />
-
         <div
           ref={scrollRef}
           data-no-pan
-          className="scrollbar-hide relative w-full overflow-y-auto overflow-x-hidden"
+          className="lag-orb-scroll scrollbar-hide relative w-full overflow-y-auto overflow-x-hidden"
           style={{ height: viewportHeight, scrollbarWidth: "none", msOverflowStyle: "none" }}
         >
           <motion.div
             initial={{ opacity: 0.96 }}
             animate={{ opacity: 1 }}
             transition={MOTION.orbTrack.transition}
-            className="flex flex-col items-center"
+            className="lag-orb-track flex flex-col items-center"
             style={{ paddingTop: safePaddingY, paddingBottom: safePaddingY, gap: orbGap }}
           >
             {items.map((item) => {
               const selected = item.id === selectedId;
-              const iconSrc    = ORB_ICONS[item.id];
-              const iconSrcOn  = ORB_ICONS_ON[item.id];
-              const activeSrc  = selected ? (iconSrcOn ?? iconSrc) : iconSrc;
 
               return (
                 <motion.button
@@ -162,14 +102,14 @@ export default function OrbNav({ items, selectedId, onSelect, zIndex, onFocus }:
                     layout: { type: "tween", duration: 0.36, ease: [0.22, 1, 0.36, 1] },
                     scale:  { type: "spring", stiffness: 480, damping: 24 },
                   }}
-                  className="group relative flex flex-col items-center overflow-visible py-[1px]"
+                  className="lag-orb-item group relative flex flex-col items-center overflow-visible py-[1px]"
                   style={{ minHeight: itemBlockHeight }}
                   aria-pressed={selected}
                   aria-label={item.label}
                 >
                   {/* 오브 컨테이너 — SVG가 원형 배경을 포함하므로 래퍼는 최소한 */}
                   <div
-                    className="relative"
+                    className="lag-orb-icon relative"
                     style={{ width: orbSize, height: orbSize, flexShrink: 0 }}
                   >
                     {/* 선택 글로우 — 배경에서 숨쉬는 금빛 광원 */}
@@ -187,7 +127,7 @@ export default function OrbNav({ items, selectedId, onSelect, zIndex, onFocus }:
                       }
                       style={{
                         inset: -18,
-                        background: "radial-gradient(circle, rgba(248,180,40,0.40) 0%, rgba(248,180,40,0.14) 48%, rgba(248,180,40,0) 72%)",
+                        background: "radial-gradient(circle, color-mix(in srgb, var(--lag-focus) 40%, transparent), transparent 72%)",
                         filter: "blur(4px)",
                       }}
                     />
@@ -197,7 +137,7 @@ export default function OrbNav({ items, selectedId, onSelect, zIndex, onFocus }:
                       className="pointer-events-none absolute rounded-full opacity-0 transition-opacity duration-200 group-hover:opacity-100"
                       style={{
                         inset: -12,
-                        background: "radial-gradient(circle, rgba(220,200,140,0.18) 0%, rgba(200,178,90,0.06) 50%, transparent 72%)",
+                        background: "radial-gradient(circle, color-mix(in srgb, var(--lag-cyan) 18%, transparent), transparent 72%)",
                         filter: "blur(3px)",
                       }}
                     />
@@ -209,7 +149,7 @@ export default function OrbNav({ items, selectedId, onSelect, zIndex, onFocus }:
                           <motion.div
                             key={r.id}
                             className="absolute inset-0 rounded-full"
-                            style={{ background: "rgba(248,197,78,0.40)" }}
+                            style={{ background: "color-mix(in srgb, var(--lag-focus) 40%, transparent)" }}
                             initial={{ scale: 0.3, opacity: 0.75 }}
                             animate={{ scale: 3.5, opacity: 0 }}
                             exit={{}}
@@ -219,88 +159,42 @@ export default function OrbNav({ items, selectedId, onSelect, zIndex, onFocus }:
                       </AnimatePresence>
                     </div>
 
-                    {/* 아이콘 이미지 — SVG에 원형 배경 내장, 필터 없이 원본 색상 사용 */}
-                    {activeSrc ? (
-                      <img
-                        src={activeSrc}
-                        alt={item.label}
-                        width={orbSize}
-                        height={orbSize}
-                        draggable={false}
+                    <div
+                      className="grid h-full w-full place-items-center rounded-full"
+                      style={{
+                        background: selected ? "var(--lag-panel)" : "var(--lag-panel-2)",
+                        border: `1px solid ${selected ? "var(--lag-focus)" : "var(--lag-border)"}`,
+                        boxShadow: selected ? "0 0 0 4px color-mix(in srgb, var(--lag-focus) 12%, transparent)" : "none",
+                        position: "relative",
+                        zIndex: 1,
+                      }}
+                    >
+                      <span
+                        className="select-none font-semibold tracking-[0.14em]"
                         style={{
-                          display: "block",
-                          width: orbSize,
-                          height: orbSize,
-                          opacity: selected ? 1 : 0.72,
-                          transition: "opacity 0.28s ease",
-                          position: "relative",
-                          zIndex: 1,
-                        }}
-                        onError={(e) => {
-                          // SVG 로드 실패 시 텍스트 레이블로 대체
-                          const img = e.currentTarget;
-                          const span = document.createElement("span");
-                          span.textContent = item.slotLabel;
-                          span.style.cssText = [
-                            `width:${orbSize}px`,
-                            `height:${orbSize}px`,
-                            "display:grid",
-                            "place-items:center",
-                            "border-radius:9999px",
-                            `background:${selected ? "rgba(248,197,78,0.15)" : "rgba(0,40,90,0.55)"}`,
-                            `border:1px solid ${selected ? "rgba(249,208,105,0.70)" : "rgba(0,155,215,0.32)"}`,
-                            `font-size:${Math.max(10, Math.round(orbSize * 0.22))}px`,
-                            "font-weight:600",
-                            "letter-spacing:0.12em",
-                            `color:${selected ? "rgba(255,235,184,0.95)" : "rgba(200,220,245,0.80)"}`,
-                            "position:relative",
-                            "z-index:1",
-                          ].join(";");
-                          img.parentElement?.replaceChild(span, img);
-                        }}
-                      />
-                    ) : (
-                      // iconSrc가 없는 경우 텍스트 레이블
-                      <div
-                        className="grid place-items-center rounded-full"
-                        style={{
-                          width: orbSize,
-                          height: orbSize,
-                          background: selected
-                            ? "radial-gradient(circle, rgba(255,215,100,0.20), rgba(248,197,78,0.08) 60%, transparent)"
-                            : "radial-gradient(circle, rgba(0,70,150,0.30), rgba(0,30,80,0.14) 60%, transparent)",
-                          border: `1px solid ${selected ? "rgba(249,208,105,0.70)" : "rgba(0,155,215,0.32)"}`,
-                          position: "relative",
-                          zIndex: 1,
+                          fontSize: Math.max(10, Math.round(orbSize * 0.24)),
+                          color: selected ? "var(--lag-text)" : "var(--lag-text-2)",
+                          lineHeight: 1,
                         }}
                       >
-                        <span
-                          className="select-none font-semibold tracking-[0.14em]"
-                          style={{
-                            fontSize: Math.max(10, Math.round(orbSize * 0.24)),
-                            color: selected ? "rgba(255,235,184,0.95)" : "rgba(200,220,245,0.80)",
-                            lineHeight: 1,
-                          }}
-                        >
-                          {item.slotLabel}
-                        </span>
-                      </div>
-                    )}
+                        {item.slotLabel}
+                      </span>
+                    </div>
                   </div>
 
                   {/* 레이블 */}
                   <motion.span
                     animate={selected ? { opacity: 1 } : { opacity: 0.60 }}
-                    className="flex items-center justify-center text-center text-xs uppercase tracking-[0.26em]"
+                    className="lag-orb-label flex items-center justify-center text-center text-xs uppercase tracking-[0.26em]"
                     style={{
                       marginTop: labelGap,
                       minHeight: labelHeight + labelPaddingY * 2,
                       lineHeight: 1.2,
                       paddingInline: 4,
                       paddingBlock: labelPaddingY,
-                      color: selected ? "rgba(242,220,148,0.96)" : "rgba(175,162,122,0.72)",
-                      textShadow: selected ? "0 0 10px rgba(248,200,100,0.35)" : "none",
-                      transition: "color 0.25s ease",
+                      color: selected ? "var(--lag-text)" : "var(--lag-meta)",
+                      textShadow: selected ? "0 0 10px color-mix(in srgb, var(--lag-focus) 35%, transparent)" : "none",
+                      transition: "color var(--lag-motion-normal) ease",
                     }}
                   >
                     {item.label}

--- a/widgets/orb-nav/OrbNav.tsx
+++ b/widgets/orb-nav/OrbNav.tsx
@@ -194,7 +194,6 @@ export default function OrbNav({ items, selectedId, onSelect, zIndex, onFocus }:
                       paddingBlock: labelPaddingY,
                       color: selected ? "var(--lag-text)" : "var(--lag-meta)",
                       textShadow: selected ? "0 0 10px color-mix(in srgb, var(--lag-focus) 35%, transparent)" : "none",
-                      transition: "color var(--lag-motion-normal) ease",
                     }}
                   >
                     {item.label}

--- a/widgets/right-panels/RightPanels.tsx
+++ b/widgets/right-panels/RightPanels.tsx
@@ -8,6 +8,7 @@ import { UI_CONSTS } from "@/shared/lib/uiConsts";
 
 import SaoAlert from "@/shared/ui/SaoAlert";
 import PanelCard from "@/shared/ui/PanelCard";
+import PanelStage from "@/shared/ui/PanelStage";
 
 import { NAV_ICONS, actionBtnStyle } from "./ui/styles";
 import { GoldRow, InfoCard } from "./ui/Rows";
@@ -240,14 +241,11 @@ export default function RightPanels({
           animate={MOTION.hologramIn.animate}
           exit={MOTION.hologramIn.exit}
           transition={MOTION.hologramIn.transition}
-          className="relative flex min-w-0 w-fit flex-row flex-nowrap items-center overflow-x-hidden"
+          className="lag-panel-rail relative overflow-x-visible"
           data-main={selectedMain}
           style={{
-            minHeight: 420,
             width: "fit-content",
-            paddingBottom: UI_CONSTS.rightPanels.stackBottomSafePadding,
-            rowGap: UI_CONSTS.rightPanels.panelGap,
-            columnGap: UI_CONSTS.rightPanels.panelGap,
+            gap: UI_CONSTS.rightPanels.panelGap,
             willChange: "transform, opacity",
           }}
         >
@@ -255,24 +253,12 @@ export default function RightPanels({
             {panelStack.map((panel, panelIndex) => {
               const depth = panelStack.length - 1 - panelIndex;
               return (
-                <motion.div
-                  layout="position"
-                  key={`panel-slot-${panelIndex}`}
+                <PanelStage
+                  key={panel.id}
+                  stageKey={panel.id}
+                  index={panelIndex}
                   onPointerDownCapture={() => onPanelFocus?.(panelIndex, panel.id)}
-                  initial={MOTION.panelSlot.initial}
-                  animate={MOTION.panelSlot.animate}
-                  exit={MOTION.panelSlot.exit}
-                  transition={{
-                    type: "spring",
-                    stiffness: 380,
-                    damping: 28,
-                    delay: panelIndex * 0.055,
-                  }}
-                  style={{
-                    willChange: "transform, opacity",
-                    position: "relative",
-                    zIndex: getPanelZIndex?.(panelIndex, panel.id) ?? panelIndex + 1,
-                  }}
+                  zIndex={getPanelZIndex?.(panelIndex, panel.id) ?? panelIndex + 1}
                 >
                   <PanelContent
                     panel={panel}
@@ -286,7 +272,7 @@ export default function RightPanels({
                     onPanelBack={onPanelBack}
                     onPanelActionClick={onPanelActionClick}
                   />
-                </motion.div>
+                </PanelStage>
               );
             })}
           </AnimatePresence>

--- a/widgets/right-panels/ui/PanelFrame.tsx
+++ b/widgets/right-panels/ui/PanelFrame.tsx
@@ -2,7 +2,7 @@
 
 import { UI_CONSTS } from "@/shared/lib/uiConsts";
 import EdgeFadeScrollArea from "@/shared/ui/EdgeFadeScrollArea";
-import { getFrameStyle, D, cellStyle } from "./styles";
+import { getFrameBackground, getFrameStyle, D, cellStyle } from "./styles";
 
 export function BackButton({ onClick }: { onClick: () => void }) {
   return (
@@ -78,7 +78,7 @@ export function PanelFrame({
             <div style={{ flex: 1, height: "1px", background: "var(--lag-divider)" }} />
             <span aria-hidden style={{ color: "var(--lag-violet)", fontSize: "9px", flexShrink: 0 }}>◆</span>
             <h3
-              className="flex-shrink-0 font-semibold uppercase"
+              className="lag-panel-title font-semibold uppercase"
               style={{ fontSize: "0.9rem", letterSpacing: "0.20em", color: D.text }}
             >
               {title}
@@ -91,12 +91,12 @@ export function PanelFrame({
 
       <EdgeFadeScrollArea
         data-no-pan
-        className="scrollbar-hide"
+        className="lag-panel-body scrollbar-hide"
         centerTargetSelector='[data-scroll-center-target="true"]'
         centerTargetKey={centerTargetKey ?? null}
         resetScrollKey={resetScrollKey ?? null}
         centerBehavior={centerBehavior}
-        fadeColor="var(--lag-panel)"
+        fadeColor={getFrameBackground(depth)}
         style={
           fixedScrollHeight
             ? {

--- a/widgets/right-panels/ui/PanelFrame.tsx
+++ b/widgets/right-panels/ui/PanelFrame.tsx
@@ -4,13 +4,6 @@ import { UI_CONSTS } from "@/shared/lib/uiConsts";
 import EdgeFadeScrollArea from "@/shared/ui/EdgeFadeScrollArea";
 import { getFrameStyle, D, cellStyle } from "./styles";
 
-const CORNERS = [
-  { top: 4, left: 4, borderTop: "1.5px solid rgba(218,178,55,0.65)", borderLeft: "1.5px solid rgba(218,178,55,0.65)" },
-  { top: 4, right: 4, borderTop: "1.5px solid rgba(218,178,55,0.65)", borderRight: "1.5px solid rgba(218,178,55,0.65)" },
-  { bottom: 4, left: 4, borderBottom: "1.5px solid rgba(218,178,55,0.65)", borderLeft: "1.5px solid rgba(218,178,55,0.65)" },
-  { bottom: 4, right: 4, borderBottom: "1.5px solid rgba(218,178,55,0.65)", borderRight: "1.5px solid rgba(218,178,55,0.65)" },
-] as const;
-
 export function BackButton({ onClick }: { onClick: () => void }) {
   return (
     <button
@@ -47,45 +40,19 @@ export function PanelFrame({
 }) {
   return (
     <div
-      className="relative overflow-hidden"
+      className="lag-panel-frame relative overflow-hidden"
       style={{
         ...getFrameStyle(depth),
         width: UI_CONSTS.rightPanels.panelWidth,
         minHeight: 160,
-        transition: "background 0.35s ease",
-        borderRadius: "6px",
       }}
     >
-      {/* Corner L-bracket ornaments */}
-      {CORNERS.map((c, i) => (
-        <div
-          key={i}
-          aria-hidden
-          style={{ position: "absolute", width: 12, height: 12, pointerEvents: "none", zIndex: 30, ...c }}
-        />
-      ))}
-
-      {/* Gold top accent line */}
-      <div
-        aria-hidden
-        style={{
-          position: "absolute",
-          top: 0, left: 0, right: 0,
-          height: "1px",
-          zIndex: 20,
-          background: "linear-gradient(90deg, transparent 5%, rgba(218,178,55,0.72) 35%, rgba(218,178,55,0.72) 65%, transparent 95%)",
-          pointerEvents: "none",
-        }}
-      />
-
       {/* Header */}
       <div
-        className="relative z-10"
+        className="lag-panel-header relative z-10"
         style={{
-          borderBottom: "1px solid rgba(200,165,50,0.20)",
           paddingInline: UI_CONSTS.rightPanels.panelHeaderPaddingX,
           paddingBlock: UI_CONSTS.rightPanels.panelHeaderPaddingY,
-          background: "rgba(0,0,0,0.30)",
         }}
       >
         <div className="flex items-center gap-2">
@@ -101,23 +68,23 @@ export function PanelFrame({
               style={{
                 opacity: 0.72,
                 flexShrink: 0,
-                filter: "brightness(0) saturate(100%) invert(78%) sepia(35%) saturate(600%) hue-rotate(5deg) brightness(108%)",
+                filter: "none",
               }}
               onError={(e) => { e.currentTarget.style.display = "none"; }}
             />
           ) : null}
           {/* ◆ ─── TITLE ─── ◆ */}
           <div className="flex min-w-0 flex-1 items-center gap-2">
-            <div style={{ flex: 1, height: "1px", background: "linear-gradient(90deg, transparent, rgba(200,165,50,0.45))" }} />
-            <span aria-hidden style={{ color: "rgba(218,178,55,0.58)", fontSize: "9px", flexShrink: 0 }}>◆</span>
+            <div style={{ flex: 1, height: "1px", background: "var(--lag-divider)" }} />
+            <span aria-hidden style={{ color: "var(--lag-violet)", fontSize: "9px", flexShrink: 0 }}>◆</span>
             <h3
               className="flex-shrink-0 font-semibold uppercase"
               style={{ fontSize: "0.9rem", letterSpacing: "0.20em", color: D.text }}
             >
               {title}
             </h3>
-            <span aria-hidden style={{ color: "rgba(218,178,55,0.58)", fontSize: "9px", flexShrink: 0 }}>◆</span>
-            <div style={{ flex: 1, height: "1px", background: "linear-gradient(90deg, rgba(200,165,50,0.45), transparent)" }} />
+            <span aria-hidden style={{ color: "var(--lag-violet)", fontSize: "9px", flexShrink: 0 }}>◆</span>
+            <div style={{ flex: 1, height: "1px", background: "var(--lag-divider)" }} />
           </div>
         </div>
       </div>
@@ -129,7 +96,7 @@ export function PanelFrame({
         centerTargetKey={centerTargetKey ?? null}
         resetScrollKey={resetScrollKey ?? null}
         centerBehavior={centerBehavior}
-        fadeColor="rgba(14,12,9,0.97)"
+        fadeColor="var(--lag-panel)"
         style={
           fixedScrollHeight
             ? {

--- a/widgets/right-panels/ui/Rows.tsx
+++ b/widgets/right-panels/ui/Rows.tsx
@@ -5,16 +5,13 @@ import { D } from "./styles";
 export function GoldRow({ children }: { children: React.ReactNode }) {
   return (
     <div
-      className="flex min-h-[38px] items-center gap-2.5"
+      className="lag-row flex min-h-[38px] items-center gap-2.5"
       style={{
-        background: "rgba(218,178,55,0.08)",
-        border: "1px solid rgba(200,165,50,0.30)",
-        borderRadius: "20px",
         paddingInline: "16px",
         paddingBlock: "8px",
       }}
     >
-      <span aria-hidden style={{ color: "rgba(218,178,55,0.70)", fontSize: "9px", flexShrink: 0 }}>◆</span>
+      <span aria-hidden style={{ color: "var(--lag-violet)", fontSize: "9px", flexShrink: 0 }}>◆</span>
       <span className="break-words text-sm" style={{ letterSpacing: "0.06em", color: D.text }}>
         {children}
       </span>
@@ -25,10 +22,8 @@ export function GoldRow({ children }: { children: React.ReactNode }) {
 export function InfoCard({ label, children }: { label?: string; children: React.ReactNode }) {
   return (
     <div
+      className="lag-info-card"
       style={{
-        background: "rgba(218,178,55,0.06)",
-        border: "1px solid rgba(200,165,50,0.25)",
-        borderRadius: "12px",
         paddingInline: "16px",
         paddingBlock: "12px",
       }}

--- a/widgets/right-panels/ui/styles.ts
+++ b/widgets/right-panels/ui/styles.ts
@@ -2,38 +2,37 @@ import { GOLD_BTN_STYLE, SAO_ICON } from "@/shared/design/tokens";
 import type { MainNavId } from "@/entities/nav";
 
 export function getFrameStyle(depth: number) {
-  const baseR = depth === 0 ? "16,14,10" : depth === 1 ? "14,12,9" : "12,10,7";
-  const bgA   = depth === 0 ? 0.97 : depth === 1 ? 0.94 : 0.91;
-  const borderA = depth === 0 ? 0.42 : depth === 1 ? 0.30 : 0.22;
+  const background = depth === 0 ? "var(--lag-panel)" : depth === 1 ? "var(--lag-panel-2)" : "var(--lag-personal)";
 
   return {
-    background: `linear-gradient(155deg, rgba(${baseR},${bgA}), rgba(${baseR},${bgA - 0.02}))`,
-    border: `1px solid rgba(200,165,50,${borderA})`,
-    boxShadow: [
-      `inset 0 0 0 1px rgba(218,178,55,0.06)`,
-      `0 0 0 1px rgba(0,0,0,0.35)`,
-      `0 22px 55px rgba(0,0,0,0.80)`,
-    ].join(", "),
-    borderRadius: "6px",
+    background,
+    border: "1px solid var(--lag-border)",
+    boxShadow: "0 18px 40px color-mix(in srgb, var(--lag-shadow) 24%, transparent)",
+    borderRadius: "var(--lag-radius-md)",
     backdropFilter: "blur(16px)",
     WebkitBackdropFilter: "blur(16px)",
   };
 }
 
 export const D = {
-  text:    "rgba(235,218,175,0.96)",
-  textSub: "rgba(185,170,132,0.88)",
-  label:   "rgba(148,135,98,0.80)",
+  text:    "var(--lag-text)",
+  textSub: "var(--lag-text-2)",
+  label:   "var(--lag-text-2)",
 } as const;
 
 export const cellStyle = {
-  background: "rgba(218,178,55,0.07)",
-  border: "1px solid rgba(200,165,50,0.28)",
-  borderRadius: "18px",
+  background: "var(--lag-paper)",
+  border: "1px solid var(--lag-border)",
+  borderRadius: "var(--lag-radius-sm)",
 } as const;
 
 export const actionBtnStyle = {
   ...GOLD_BTN_STYLE,
+  background: "var(--lag-panel-2)",
+  color: "var(--lag-text)",
+  border: "1px solid var(--lag-focus)",
+  borderRadius: "var(--lag-radius-sm)",
+  boxShadow: "none",
   padding: "8px 12px",
   fontSize: "0.7rem",
   width: "100%",

--- a/widgets/right-panels/ui/styles.ts
+++ b/widgets/right-panels/ui/styles.ts
@@ -1,8 +1,12 @@
 import { GOLD_BTN_STYLE, SAO_ICON } from "@/shared/design/tokens";
 import type { MainNavId } from "@/entities/nav";
 
+export function getFrameBackground(depth: number) {
+  return depth === 0 ? "var(--lag-panel)" : depth === 1 ? "var(--lag-panel-2)" : "var(--lag-personal)";
+}
+
 export function getFrameStyle(depth: number) {
-  const background = depth === 0 ? "var(--lag-panel)" : depth === 1 ? "var(--lag-panel-2)" : "var(--lag-personal)";
+  const background = getFrameBackground(depth);
 
   return {
     background,


### PR DESCRIPTION
## Purpose

Apply the approved Stage 3 Enterprise Dual Theme v7 visual system to the existing Dual Theme runtime foundation.

Closes #50

## Delivered

- approved v7 semantic theme variable layer
- exact Astral Neutral theme values
- exact Warm Beige / Analog Spatial theme values
- shared spacing, radius, and motion tokens
- shared semantic state tokens
- shared shell/navigation/workspace/panel material migration
- Home desktop/mobile baseline fidelity
- Settings desktop/mobile baseline fidelity
- v7 Appearance/theme-switch visual treatment
- focus/error/selected/disabled semantic styling
- reduced-motion-safe theme transition behavior

## Source of Truth

Implementation is based on the approved reference-only package:

`LifeAsGame_Stage3_UI_VisualDesigner_Enterprise_Dual_Theme_Result_v7`

Primary token authority:

- Shared_Tokens.csv
- Astral_Neutral_Tokens.csv
- Warm_Beige_Tokens.csv
- Theme_Override_Map.csv
- Semantic_State_Map.csv
- Semantic_State_Rules.md
- FE_Handoff_v7.md

Reference artifacts are not shipped in the runtime bundle or committed to the repository.

## Runtime Compatibility

The existing runtime theme contract is preserved:

```text
data-theme="astral"
data-theme="warm-beige"
```

The v7 handoff labels `beige` and `warm_beige` are treated as design labels only.

Preference semantics remain:

```text
SYSTEM | ASTRAL | WARM_BEIGE
```

Warm Beige remains the default.

## Architecture

Both themes use the same component and feature tree.

Components consume shared semantic tokens rather than theme-specific branches.

No theme-specific navigation, business logic, feature flags, or duplicated screen trees are introduced.

## Shared Visual Foundation

The approved semantic material hierarchy now covers the in-scope shared surfaces:

- ambient
- shell
- navigation
- workspace
- panels
- cards/paper surfaces
- text hierarchy
- borders/dividers
- focus and semantic state accents

Shared spacing/radius/motion values follow the v7 handoff.

## Home / Settings Proof Surfaces

Home and Settings provide the first desktop/mobile implementation proof for both approved themes.

Theme switching retains its existing immediate-apply and persistence behavior.

No route, panel depth, scroll, input, chat draft, or selection reset is introduced.

## Accessibility / Motion

Semantic states are not communicated through color alone.

Focus/error/selected/disabled states preserve appropriate interaction or textual cues.

Theme switching uses only short material/color transitions and disables cross-fade under reduced-motion preference.

## Scope Boundaries

This PR does not complete the v7 visual fidelity pass for:

- Journal / Quick Record
- Journey
- Role / Growth
- Inventory / Gear
- Connections / Direct Chat
- Notification
- Economy

Those surfaces will consume the same approved token/material foundation in follow-up PRs.

This PR also does not change:

- backend contracts
- theme persistence authority
- responsive navigation architecture
- first-run theme behavior
- additional theme presets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Warm Beige and Astral Neutral visual themes with live previews and persistent selection in Settings.
  * Added responsive mobile layouts, improved focus and disabled states, and reduced-motion support.
* **UI Improvements**
  * Refreshed surfaces, panels, cards, controls, buttons, and navigation with consistent styling.
  * Simplified orb navigation with clearer CSS-rendered icons and more compact spacing.
  * Updated settings presentation, including a clearer “Settings” title and themed appearance picker.
  * Improved panel dividers, markers, shadows, borders, and loading shimmer visuals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->