### PR TITLE
[UX] Stabilize panel camera, utility windows, and reactive staged interactions

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -271,15 +271,18 @@ body {
 .lag-left-context {
   flex: 0 0 auto;
   display: flex;
-  height: min(680px, calc(100svh - 120px));
-  min-height: min(420px, calc(100svh - 120px));
-  max-height: calc(100svh - 120px);
+  height: min(680px, calc(100svh - max(48px, env(safe-area-inset-top)) - max(48px, env(safe-area-inset-bottom))));
+  min-height: min(420px, calc(100svh - max(48px, env(safe-area-inset-top)) - max(48px, env(safe-area-inset-bottom))));
+  max-height: calc(100svh - max(48px, env(safe-area-inset-top)) - max(48px, env(safe-area-inset-bottom)));
   flex-direction: column;
   border-radius: var(--lag-radius-md);
   backdrop-filter: blur(16px);
 }
 
-.lag-left-context > :last-child {
+.lag-left-context-content {
+  position: relative;
+  z-index: 10;
+  height: 100%;
   min-height: 0;
   overflow-y: auto;
 }
@@ -287,13 +290,33 @@ body {
 .lag-left-anchor,
 .lag-orb-column {
   position: sticky;
-  top: 50svh;
+  top: 0;
+  box-sizing: border-box;
+  height: 100svh;
   align-self: flex-start;
-  transform: translateY(-50%);
+  align-items: center;
+  justify-content: center;
+  padding-block: max(var(--lag-space-6), env(safe-area-inset-top)) max(var(--lag-space-6), env(safe-area-inset-bottom));
 }
 
-.lag-left-anchor-empty {
-  display: contents;
+.lag-left-anchor {
+  --lag-left-lane-width: 500px;
+  display: flex;
+  width: var(--lag-left-lane-width);
+  flex: 0 0 var(--lag-left-lane-width);
+  overflow: clip;
+  opacity: 1;
+  transition:
+    width var(--lag-motion-normal) ease,
+    flex-basis var(--lag-motion-normal) ease,
+    opacity var(--lag-motion-normal) ease;
+}
+
+.lag-left-anchor[data-context-present="false"] {
+  width: 0;
+  flex-basis: 0;
+  opacity: 0;
+  pointer-events: none;
 }
 
 .lag-left-context-grid {
@@ -393,7 +416,6 @@ body {
   padding: 8px 12px;
   border: 1px solid var(--lag-control-border);
   border-radius: var(--lag-radius-sm);
-  outline: none;
   background: var(--lag-control-bg);
   color: var(--lag-control-text);
   font-size: 0.875rem;
@@ -438,8 +460,12 @@ body {
     align-items: center;
   }
 
+  .lag-left-anchor {
+    --lag-left-lane-width: clamp(344px, 42vw, 500px);
+  }
+
   .lag-left-context {
-    width: clamp(344px, 42vw, 500px) !important;
+    width: var(--lag-left-lane-width) !important;
   }
 }
 
@@ -559,6 +585,8 @@ body {
     bottom: calc(var(--lag-space-4) + env(safe-area-inset-bottom));
     left: var(--lag-space-4);
     align-self: auto;
+    height: auto !important;
+    padding-block: 0 !important;
     z-index: 500000;
     width: auto !important;
     transform: none !important;
@@ -638,8 +666,12 @@ body {
   }
 
   .lag-left-anchor {
+    --lag-left-lane-width: clamp(280px, calc(100vw - 32px), 344px);
     position: static;
-    transform: none;
+    top: auto;
+    height: auto;
+    align-self: auto;
+    padding-block: 0;
   }
 
   .lag-panel-frame {
@@ -657,7 +689,7 @@ body {
   }
 
   .lag-left-context {
-    width: clamp(280px, calc(100vw - 32px), 344px) !important;
+    width: var(--lag-left-lane-width) !important;
     min-height: min(420px, calc(100svh - 156px)) !important;
     height: calc(100svh - 156px) !important;
   }
@@ -701,6 +733,7 @@ body {
   .lag-theme-option,
   .lag-theme-preview,
   .lag-orb-label,
+  .lag-left-anchor,
   .lag-left-context,
   .lag-utility-button,
   .lag-utility-drawer,

--- a/app/globals.css
+++ b/app/globals.css
@@ -270,8 +270,18 @@ body {
 
 .lag-left-context {
   flex: 0 0 auto;
+  display: flex;
+  height: min(680px, calc(100svh - 120px));
+  min-height: min(420px, calc(100svh - 120px));
+  max-height: calc(100svh - 120px);
+  flex-direction: column;
   border-radius: var(--lag-radius-md);
   backdrop-filter: blur(16px);
+}
+
+.lag-left-context > :last-child {
+  min-height: 0;
+  overflow-y: auto;
 }
 
 .lag-left-anchor,
@@ -538,18 +548,20 @@ body {
     min-width: 100% !important;
     align-items: center;
     gap: var(--lag-space-3) !important;
-    padding: var(--lag-space-4) var(--lag-space-4) 140px !important;
+    padding: var(--lag-space-4) var(--lag-space-4) calc(140px + env(safe-area-inset-bottom)) !important;
   }
 
   .lag-orb-column {
     display: block;
     position: fixed !important;
+    top: auto !important;
     right: var(--lag-space-4);
-    bottom: var(--lag-space-4);
+    bottom: calc(var(--lag-space-4) + env(safe-area-inset-bottom));
     left: var(--lag-space-4);
+    align-self: auto;
     z-index: 500000;
     width: auto !important;
-    transform: none;
+    transform: none !important;
   }
 
   .lag-orb-nav {
@@ -646,14 +658,14 @@ body {
 
   .lag-left-context {
     width: clamp(280px, calc(100vw - 32px), 344px) !important;
-    min-height: 420px !important;
+    min-height: min(420px, calc(100svh - 156px)) !important;
     height: calc(100svh - 156px) !important;
   }
 
   .lag-utility-drawer {
     width: calc(100vw - 32px) !important;
     height: auto !important;
-    max-height: calc(100svh - 128px) !important;
+    max-height: calc(100dvh - 112px - env(safe-area-inset-bottom) - max(16px, env(safe-area-inset-top))) !important;
   }
 
   .lag-notification-dropdown {

--- a/app/globals.css
+++ b/app/globals.css
@@ -162,6 +162,7 @@ body {
 
 .lag-workspace {
   padding: var(--lag-space-6);
+  scroll-padding-inline: 24px;
   background-color: color-mix(in srgb, var(--lag-workspace) 94%, transparent);
   border: 1px solid var(--lag-border);
   border-radius: var(--lag-radius-lg);
@@ -273,6 +274,18 @@ body {
   backdrop-filter: blur(16px);
 }
 
+.lag-left-anchor,
+.lag-orb-column {
+  position: sticky;
+  top: 50svh;
+  align-self: flex-start;
+  transform: translateY(-50%);
+}
+
+.lag-left-anchor-empty {
+  display: contents;
+}
+
 .lag-left-context-grid {
   background-image:
     linear-gradient(color-mix(in srgb, var(--lag-divider) 40%, transparent) 1px, transparent 1px),
@@ -346,6 +359,14 @@ body {
   letter-spacing: 0.06em;
 }
 
+.lag-notification-trigger {
+  overflow: visible;
+}
+
+.lag-utility-drag-handle {
+  user-select: none;
+}
+
 .lag-utility-drawer {
   border-radius: var(--lag-radius-md);
 }
@@ -371,6 +392,30 @@ body {
 
 .lag-role-control:hover {
   background: var(--lag-control-hover-bg);
+}
+
+.lag-semantic-controls label {
+  color: var(--lag-text-2) !important;
+}
+
+.lag-semantic-controls :where(input, select, textarea):not(:disabled):hover,
+.lag-semantic-controls :where(button:not(.lag-panel-card), summary):not(:disabled):hover {
+  background-color: var(--lag-control-hover-bg) !important;
+  border-color: var(--lag-focus) !important;
+}
+
+.lag-add-control {
+  display: inline-flex;
+  padding: 7px 10px;
+  border: 1px solid var(--lag-control-border);
+  border-radius: var(--lag-radius-sm);
+  background: var(--lag-control-bg);
+  color: var(--lag-control-text);
+  list-style: none;
+}
+
+.lag-utility-drag-handle button {
+  cursor: pointer;
 }
 
 .lag-orb-label {
@@ -482,6 +527,11 @@ body {
 }
 
 @media (max-width: 767px) {
+  .lag-app-surface {
+    scroll-padding-left: calc(env(safe-area-inset-left) + 48px);
+    scroll-padding-right: calc(env(safe-area-inset-right) + 24px);
+  }
+
   .lag-app-shell {
     display: flex !important;
     width: max-content;
@@ -499,6 +549,7 @@ body {
     left: var(--lag-space-4);
     z-index: 500000;
     width: auto !important;
+    transform: none;
   }
 
   .lag-orb-nav {
@@ -567,15 +618,16 @@ body {
   }
 
   .lag-settings-route {
-    width: 100% !important;
+    width: max-content !important;
   }
 
   .lag-settings-shell {
-    width: 100%;
+    width: auto;
   }
 
-  .lag-settings-route > :first-child {
-    display: none;
+  .lag-left-anchor {
+    position: static;
+    transform: none;
   }
 
   .lag-panel-frame {
@@ -599,19 +651,12 @@ body {
   }
 
   .lag-utility-drawer {
-    top: var(--lag-space-4) !important;
-    right: var(--lag-space-4) !important;
-    bottom: 112px;
     width: calc(100vw - 32px) !important;
     height: auto !important;
     max-height: calc(100svh - 128px) !important;
   }
 
   .lag-notification-dropdown {
-    position: fixed !important;
-    top: auto !important;
-    right: var(--lag-space-4) !important;
-    bottom: 112px;
     width: calc(100vw - 32px) !important;
   }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 
 import { AuthProvider } from "@/features/auth/AuthContext";
+import { AuthenticatedThemeBootstrap } from "@/features/theme/AuthenticatedThemeBootstrap";
 import { ThemeProvider } from "@/features/theme/ThemeProvider";
 import { THEME_BOOTSTRAP_SCRIPT } from "@/features/theme/theme";
 import { ToastProvider } from "@/context/ToastContext";
@@ -34,6 +35,7 @@ export default function RootLayout({
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
         <AuthProvider>
           <ThemeProvider>
+            <AuthenticatedThemeBootstrap />
             <ToastProvider>{children}</ToastProvider>
           </ThemeProvider>
         </AuthProvider>

--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -101,10 +101,12 @@ describe("Home shell에서 feature surface를 routing할 때", () => {
     expect(css).toContain("flex: 0 0 auto");
     expect(css).toContain("width: clamp(280px, calc(100vw - 32px), 344px)");
     expect(css).toContain("text-overflow: ellipsis");
-    expect(css).toMatch(/\.lag-left-anchor,[\s\S]*\.lag-orb-column\s*{[^}]*position:\s*sticky;[^}]*top:\s*50svh;/);
+    expect(css).toMatch(/\.lag-left-anchor,[\s\S]*\.lag-orb-column\s*{[^}]*position:\s*sticky;[^}]*top:\s*0;[^}]*height:\s*100svh;[^}]*align-items:\s*center;/);
+    expect(css).not.toContain("translateY(-50%)");
+    expect(css).not.toContain("display: contents");
     expect(css).toMatch(/@media \(max-width: 767px\)[\s\S]*\.lag-orb-column\s*{[^}]*position:\s*fixed !important;[^}]*top:\s*auto !important;[^}]*bottom:\s*calc\(var\(--lag-space-4\) \+ env\(safe-area-inset-bottom\)\)/);
-    expect(css).toMatch(/\.lag-left-context\s*{[^}]*height:\s*min\(680px, calc\(100svh - 120px\)\);[^}]*max-height:\s*calc\(100svh - 120px\)/);
-    expect(css).toMatch(/\.lag-left-context > :last-child\s*{[^}]*overflow-y:\s*auto/);
+    expect(css).toMatch(/\.lag-left-context\s*{[^}]*height:\s*min\(680px, calc\(100svh[^}]*max-height:\s*calc\(100svh/);
+    expect(css).toMatch(/\.lag-left-context-content\s*{[^}]*overflow-y:\s*auto/);
     expect(page).toContain('className="lag-app-shell mx-auto flex w-full min-w-max items-start"');
   });
 

--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -101,6 +101,8 @@ describe("Home shell에서 feature surface를 routing할 때", () => {
     expect(css).toContain("flex: 0 0 auto");
     expect(css).toContain("width: clamp(280px, calc(100vw - 32px), 344px)");
     expect(css).toContain("text-overflow: ellipsis");
+    expect(css).toMatch(/\.lag-left-anchor,[\s\S]*\.lag-orb-column\s*{[^}]*position:\s*sticky;[^}]*top:\s*50svh;/);
+    expect(page).toContain('className="lag-app-shell mx-auto flex w-full min-w-max items-start"');
   });
 
   describe("인증된 player가 처음 진입하면", () => {
@@ -289,6 +291,12 @@ describe("Home shell에서 feature surface를 routing할 때", () => {
       fireEvent.click(screen.getByRole("button", { name: "Options" }));
 
       expect(screen.getByTestId("settings-shell")).toHaveTextContent("Canonical Settings");
+    });
+
+    it("mobile CSS가 parent System stage를 삭제하지 않는다", () => {
+      const css = readFileSync("app/globals.css", "utf8");
+      expect(css).not.toMatch(/\.lag-settings-route\s*>\s*:first-child\s*{[\s\S]*?display:\s*none/);
+      expect(css).toContain("width: max-content !important");
     });
   });
 

--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -102,6 +102,9 @@ describe("Home shell에서 feature surface를 routing할 때", () => {
     expect(css).toContain("width: clamp(280px, calc(100vw - 32px), 344px)");
     expect(css).toContain("text-overflow: ellipsis");
     expect(css).toMatch(/\.lag-left-anchor,[\s\S]*\.lag-orb-column\s*{[^}]*position:\s*sticky;[^}]*top:\s*50svh;/);
+    expect(css).toMatch(/@media \(max-width: 767px\)[\s\S]*\.lag-orb-column\s*{[^}]*position:\s*fixed !important;[^}]*top:\s*auto !important;[^}]*bottom:\s*calc\(var\(--lag-space-4\) \+ env\(safe-area-inset-bottom\)\)/);
+    expect(css).toMatch(/\.lag-left-context\s*{[^}]*height:\s*min\(680px, calc\(100svh - 120px\)\);[^}]*max-height:\s*calc\(100svh - 120px\)/);
+    expect(css).toMatch(/\.lag-left-context > :last-child\s*{[^}]*overflow-y:\s*auto/);
     expect(page).toContain('className="lag-app-shell mx-auto flex w-full min-w-max items-start"');
   });
 
@@ -204,6 +207,21 @@ describe("Home shell에서 feature surface를 routing할 때", () => {
 
       expect(screen.getByTestId("certification-shell")).toBeInTheDocument();
       expect(screen.queryByRole("button", { name: "Cloud" })).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Player child stage를 전환하거나 내부 detail을 선택하면", () => {
+    it("Player root/menu DOM instance를 계속 유지한다", () => {
+      render(<Home />);
+      fireEvent.click(screen.getByRole("button", { name: "Player" }));
+      const root = screen.getByTestId("right-panels");
+
+      fireEvent.click(screen.getByRole("button", { name: "Title" }));
+      expect(screen.getByTestId("right-panels")).toBe(root);
+      fireEvent.click(screen.getByRole("button", { name: "Select Mock Title" }));
+      expect(screen.getByTestId("right-panels")).toBe(root);
+      fireEvent.click(screen.getByRole("button", { name: "Credentials" }));
+      expect(screen.getByTestId("right-panels")).toBe(root);
     });
   });
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -750,11 +750,11 @@ export default function Home() {
       className="lag-app-surface h-screen overflow-auto"
     >
       <main
-        className="lag-app-shell mx-auto flex w-full min-w-max items-center"
+        className="lag-app-shell mx-auto flex w-full min-w-max items-start"
         style={{
           minHeight: "100vh",
           gap: UI_CONSTS.layout.columnGap,
-          paddingTop: UI_CONSTS.layout.pagePaddingY + UI_CONSTS.layout.visualCenterOffsetY,
+          paddingTop: UI_CONSTS.layout.pagePaddingY,
           paddingBottom: UI_CONSTS.layout.pagePaddingY,
           paddingLeft: UI_CONSTS.layout.pagePaddingX,
           paddingRight: UI_CONSTS.layout.canvasEndPaddingX,
@@ -775,7 +775,7 @@ export default function Home() {
           zIndex={getSurfaceZIndex("left-context", SURFACE_GROUP_BASE_Z.left)}
         />
 
-        <div className="lag-orb-column shrink-0" style={{ width: UI_CONSTS.layout.centerWidth, position: "relative" }}>
+        <div className="lag-orb-column shrink-0" style={{ width: UI_CONSTS.layout.centerWidth }}>
           <div className="lag-utility-cluster" style={{ zIndex: getSurfaceZIndex("orb-nav", SURFACE_GROUP_BASE_Z.nav) + 1 }}>
             <SocialUtilityHub />
             <NotificationBell />
@@ -883,7 +883,7 @@ export default function Home() {
               />
               {selectedSubByMain.inventory === "gear"
                 ? <GearShell />
-                : <InventoryShell surface={selectedSubByMain.inventory === "items" ? "items" : "inbox"} />}
+                : <InventoryShell key={selectedSubByMain.inventory} surface={selectedSubByMain.inventory === "items" ? "items" : "inbox"} />}
             </div>
           ) : selectedMain === "lifelog" && selectedSubByMain.lifelog === "journal" ? (
             <div className="flex w-fit items-center gap-3">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -28,7 +28,7 @@ import SocialUtilityHub from "@/features/social/SocialUtilityHub";
 import SettingsShell from "@/features/system/settings/SettingsShell";
 import { useRoles } from "@/features/role/useRoles";
 import { usePanScroll } from "@/shared/hooks/usePanScroll";
-import { useStageCamera } from "@/shared/hooks/useStageCamera";
+import { requestStageFocus, useStageCamera } from "@/shared/hooks/useStageCamera";
 import { MOCK_CHARACTER_SHEET } from "@/features/player/mock";
 import {
   DEFAULT_SUB_SELECTIONS,
@@ -560,6 +560,14 @@ export default function Home() {
     }
   };
 
+  const closeFeatureSubmenu = (main: "player" | "inventory") => {
+    setSelectedSubByMain((prev) => ({ ...prev, [main]: null }));
+    clearDetailSelectionsForMain(main);
+    setActiveFormPanel(null);
+    setEditingItemId(null);
+    requestStageFocus(`${main}-stage-0`, "center");
+  };
+
   // ─── Form panel helpers ────────────────────────────────────────────────────
 
   const openForm = (
@@ -582,7 +590,17 @@ export default function Home() {
     });
   };
 
-  const handlePanelBack = () => {
+  const handlePanelBack = (panelIndex: number) => {
+    if (selectedMain === "skills" && !activeFormPanel) {
+      if (panelIndex > 1) updateDetailSelections({ skills: null });
+      else {
+        setSelectedSubByMain((prev) => ({ ...prev, skills: null }));
+        updateDetailSelections({ skills: null });
+      }
+      requestStageFocus(`skills-stage-${Math.max(0, panelIndex - 1)}`, "center");
+      return;
+    }
+
     const wasEditing = editingItemId !== null;
     setActiveFormPanel(null);
     setEditingItemId(null);
@@ -744,6 +762,23 @@ export default function Home() {
 
   if (isLoading || !isAuthenticated || !playerId) return null;
 
+  const playerSurface = selectedSubByMain.player === "growth"
+    ? <GrowthShell onBack={() => closeFeatureSubmenu("player")} />
+    : selectedSubByMain.player === "achievement"
+      ? <AchievementShell onBack={() => closeFeatureSubmenu("player")} />
+      : selectedSubByMain.player === "credentials"
+        ? <CertificationShell onBack={() => closeFeatureSubmenu("player")} />
+        : selectedSubByMain.player === "title"
+          ? <TitleShell onBack={() => closeFeatureSubmenu("player")} />
+          : selectedSubByMain.player === "interests"
+            ? <HobbyShell onBack={() => closeFeatureSubmenu("player")} />
+            : null;
+  const inventorySurface = selectedSubByMain.inventory === "gear"
+    ? <GearShell onBack={() => closeFeatureSubmenu("inventory")} />
+    : selectedSubByMain.inventory === "items" || selectedSubByMain.inventory === "inbox"
+      ? <InventoryShell onBack={() => closeFeatureSubmenu("inventory")} surface={selectedSubByMain.inventory} />
+      : null;
+
   return (
     <div
       ref={viewportRef}
@@ -810,55 +845,14 @@ export default function Home() {
               }}
               onOpenRole={handleRoleSelect}
             />
-          ) : selectedMain === "player" && selectedSubByMain.player === "growth" ? (
+          ) : selectedMain === "player" ? (
             <div className="flex w-fit items-center gap-3">
               <RightPanels
                 selectedMain="player"
                 panelStack={panelStack.slice(0, 1)}
-                panelStackKey="player-growth-menu"
                 onPanelItemSelect={handlePanelItemSelect}
               />
-              <GrowthShell />
-            </div>
-          ) : selectedMain === "player" && selectedSubByMain.player === "achievement" ? (
-            <div className="flex w-fit items-center gap-3">
-              <RightPanels
-                selectedMain="player"
-                panelStack={panelStack.slice(0, 1)}
-                panelStackKey="player-achievement-menu"
-                onPanelItemSelect={handlePanelItemSelect}
-              />
-              <AchievementShell />
-            </div>
-          ) : selectedMain === "player" && selectedSubByMain.player === "credentials" ? (
-            <div className="flex w-fit items-center gap-3">
-              <RightPanels
-                selectedMain="player"
-                panelStack={panelStack.slice(0, 1)}
-                panelStackKey="player-certification-menu"
-                onPanelItemSelect={handlePanelItemSelect}
-              />
-              <CertificationShell />
-            </div>
-          ) : selectedMain === "player" && selectedSubByMain.player === "title" ? (
-            <div className="flex w-fit items-center gap-3">
-              <RightPanels
-                selectedMain="player"
-                panelStack={panelStack.slice(0, 1)}
-                panelStackKey="player-title-menu"
-                onPanelItemSelect={handlePanelItemSelect}
-              />
-              <TitleShell />
-            </div>
-          ) : selectedMain === "player" && selectedSubByMain.player === "interests" ? (
-            <div className="flex w-fit items-center gap-3">
-              <RightPanels
-                selectedMain="player"
-                panelStack={panelStack.slice(0, 1)}
-                panelStackKey="player-hobby-menu"
-                onPanelItemSelect={handlePanelItemSelect}
-              />
-              <HobbyShell />
+              {playerSurface}
             </div>
           ) : selectedMain === "role" ? (
             <div className="flex w-fit items-center gap-3">
@@ -873,24 +867,20 @@ export default function Home() {
             </div>
           ) : selectedMain === "quests" ? (
             <JourneyShell initialSurface={selectedSubByMain.quests as QuestsSubId | null} />
-          ) : selectedMain === "inventory" && selectedSubByMain.inventory ? (
+          ) : selectedMain === "inventory" ? (
             <div className="flex w-fit items-center gap-3">
               <RightPanels
                 selectedMain="inventory"
                 panelStack={panelStack.slice(0, 1)}
-                panelStackKey="inventory-real-menu"
                 onPanelItemSelect={handlePanelItemSelect}
               />
-              {selectedSubByMain.inventory === "gear"
-                ? <GearShell />
-                : <InventoryShell key={selectedSubByMain.inventory} surface={selectedSubByMain.inventory === "items" ? "items" : "inbox"} />}
+              {inventorySurface}
             </div>
           ) : selectedMain === "lifelog" && selectedSubByMain.lifelog === "journal" ? (
             <div className="flex w-fit items-center gap-3">
               <RightPanels
                 selectedMain="lifelog"
                 panelStack={panelStack.slice(0, 1)}
-                panelStackKey="lifelog-journal-menu"
                 onPanelItemSelect={handlePanelItemSelect}
               />
               <JournalShell roles={roleState.roles} rolesLoading={roleState.isLoading} rolesError={roleState.error} />
@@ -900,7 +890,6 @@ export default function Home() {
               <RightPanels
                 selectedMain="lifelog"
                 panelStack={panelStack.slice(0, 1)}
-                panelStackKey="lifelog-collection-menu"
                 onPanelItemSelect={handlePanelItemSelect}
               />
               <CollectionShell />
@@ -910,26 +899,24 @@ export default function Home() {
               <RightPanels
                 selectedMain="lifelog"
                 panelStack={panelStack.slice(0, 1)}
-                panelStackKey="lifelog-exercise-menu"
                 onPanelItemSelect={handlePanelItemSelect}
               />
               <ExerciseShell />
             </div>
           ) : selectedMain === "lifelog" && selectedSubByMain.lifelog === "media" ? (
             <div className="flex w-fit items-center gap-3">
-              <RightPanels selectedMain="lifelog" panelStack={panelStack.slice(0, 1)} panelStackKey="lifelog-media-menu" onPanelItemSelect={handlePanelItemSelect} />
+              <RightPanels selectedMain="lifelog" panelStack={panelStack.slice(0, 1)} onPanelItemSelect={handlePanelItemSelect} />
               <MediaShell />
             </div>
           ) : selectedMain === "system" && selectedSubByMain.system === "options" ? (
             <div className="lag-settings-route flex w-fit items-center gap-3">
-              <RightPanels selectedMain="system" panelStack={panelStack.slice(0, 1)} panelStackKey="system-settings-menu" onPanelItemSelect={handlePanelItemSelect} />
+              <RightPanels selectedMain="system" panelStack={panelStack.slice(0, 1)} onPanelItemSelect={handlePanelItemSelect} />
               <SettingsShell />
             </div>
           ) : (
             <RightPanels
               selectedMain={selectedMain}
               panelStack={panelStack}
-              panelStackKey={selectedMain}
               onPanelFocus={(panelIndex) => bringSurfaceToFront(`panel-slot-${panelIndex}`)}
               getPanelZIndex={(panelIndex) =>
                 getSurfaceZIndex(`panel-slot-${panelIndex}`, SURFACE_GROUP_BASE_Z.panels, panelIndex * 10)

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -789,8 +789,6 @@ export default function Home() {
         style={{
           minHeight: "100vh",
           gap: UI_CONSTS.layout.columnGap,
-          paddingTop: UI_CONSTS.layout.pagePaddingY,
-          paddingBottom: UI_CONSTS.layout.pagePaddingY,
           paddingLeft: UI_CONSTS.layout.pagePaddingX,
           paddingRight: UI_CONSTS.layout.canvasEndPaddingX,
         }}

--- a/features/inventory/GearShell.test.tsx
+++ b/features/inventory/GearShell.test.tsx
@@ -61,7 +61,10 @@ describe("Gear surface를 사용할 때", () => {
   describe("여러 Weapon slot 중 target을 선택해 교체하면", () => {
     it("명시한 empty slot과 candidate를 확인한 뒤 실제 slotId로 equip한다", () => {
       render(<GearShell />);
+      expect(document.querySelector('[data-stage-key="inventory-gear-parts"]')).toBeInTheDocument();
+      expect(document.querySelector('[data-stage-key="inventory-gear-slots"]')).not.toBeInTheDocument();
       fireEvent.click(screen.getByRole("button", { name: /Weapon/ }));
+      expect(document.querySelector('[data-stage-key="inventory-gear-slots"]')).toBeInTheDocument();
       fireEvent.click(screen.getByRole("button", { name: /Main Hand/ }));
       fireEvent.click(screen.getByRole("button", { name: /New Blade/ }));
       fireEvent.click(screen.getByRole("button", { name: "Equip" }));
@@ -78,6 +81,7 @@ describe("Gear surface를 사용할 때", () => {
       expect(hook.current.equip).not.toHaveBeenCalled();
 
       fireEvent.click(screen.getByRole("button", { name: /Off Hand/ }));
+      fireEvent.click(screen.getByRole("button", { name: /New Blade/ }));
       fireEvent.click(screen.getByRole("button", { name: "Equip" }));
 
       expect(window.confirm).toHaveBeenCalledWith("Replace Current Blade in Off Hand with New Blade?");

--- a/features/inventory/GearShell.tsx
+++ b/features/inventory/GearShell.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import { AnimatePresence } from "framer-motion";
 
 import { INVENTORY_GEAR_PARTS } from "@/entities/nav";
 import type { InventoryGearPartId } from "@/entities/nav";
 import { SAO } from "@/shared/design/tokens";
 import PanelCard from "@/shared/ui/PanelCard";
+import PanelStage from "@/shared/ui/PanelStage";
 import { PanelFrame } from "@/widgets/right-panels/ui/PanelFrame";
 import { GoldRow, InfoCard } from "@/widgets/right-panels/ui/Rows";
 import { actionBtnStyle } from "@/widgets/right-panels/ui/styles";
@@ -57,8 +59,9 @@ export default function GearShell() {
   }, [candidates, selectedItemInstanceId]);
 
   return (
-    <div className="relative flex min-w-0 w-fit flex-row flex-nowrap items-center gap-3" data-testid="gear-shell">
-      <PanelFrame title="Gear Parts" depth={3}>
+    <div className="lag-panel-rail relative" data-testid="gear-shell">
+      <PanelStage stageKey="inventory-gear-parts">
+        <PanelFrame title="Gear Parts" depth={3}>
         <div className="space-y-2">
           {INVENTORY_GEAR_PARTS.map((item, index) => (
             <PanelCard
@@ -75,10 +78,13 @@ export default function GearShell() {
             />
           ))}
         </div>
-      </PanelFrame>
+        </PanelFrame>
+      </PanelStage>
 
-      {part ? (
-        <PanelFrame title="Equipment Slots" depth={2}>
+      <AnimatePresence initial={false}>
+        {part ? (
+          <PanelStage stageKey="inventory-gear-slots" focusKey={part} index={1}>
+            <PanelFrame title="Equipment Slots" depth={2} contentKey={part}>
           <div className="space-y-3">
             {queries.equipment.loading && queries.equipment.data.length === 0 ? <InfoCard>Loading Equipment...</InfoCard> : null}
             {queries.equipment.error ? <ErrorState text={queries.equipment.error} retry={() => void queries.equipment.reload()} /> : null}
@@ -96,16 +102,23 @@ export default function GearShell() {
                       : `${slot.slotCode} · ${item?.itemName} · ${item?.rarity}`}
                   selected={selectedSlotId === slot.slotId}
                   index={index}
-                  onClick={() => setSelectedSlotId(slot.slotId)}
+                  onClick={() => {
+                    setSelectedSlotId(slot.slotId);
+                    setSelectedItemInstanceId(null);
+                  }}
                 />
               ))}
             </div>
           </div>
-        </PanelFrame>
-      ) : null}
+            </PanelFrame>
+          </PanelStage>
+        ) : null}
+      </AnimatePresence>
 
-      {part ? (
-        <PanelFrame title="Inventory Candidates" depth={1}>
+      <AnimatePresence initial={false}>
+        {part ? (
+          <PanelStage stageKey="inventory-gear-candidates" focusKey={part} index={2}>
+            <PanelFrame title="Inventory Candidates" depth={1} contentKey={part}>
           <div className="space-y-3">
             {queries.inventory.loading && queries.inventory.data.entries.length === 0 ? <InfoCard>Loading Inventory candidates...</InfoCard> : null}
             {queries.inventory.error ? <ErrorState text={queries.inventory.error} retry={() => void queries.inventory.reload()} /> : null}
@@ -124,11 +137,15 @@ export default function GearShell() {
               ))}
             </div>
           </div>
-        </PanelFrame>
-      ) : null}
+            </PanelFrame>
+          </PanelStage>
+        ) : null}
+      </AnimatePresence>
 
-      {selectedSlot ? (
-        <PanelFrame title="Gear Action" depth={0}>
+      <AnimatePresence initial={false}>
+        {selectedSlot ? (
+          <PanelStage stageKey="inventory-gear-action" focusKey={`${selectedSlot.slot.slotId}-${selectedCandidate?.itemInstanceId ?? "none"}`} index={3}>
+            <PanelFrame title="Gear Action" depth={0} contentKey={`${selectedSlot.slot.slotId}-${selectedCandidate?.itemInstanceId ?? "none"}`}>
           <div className="space-y-2 px-3">
             <InfoCard>{selectedSlot.slot.slotName}</InfoCard>
             <GoldRow>Slot ID: {selectedSlot.slot.slotId}</GoldRow>
@@ -169,8 +186,10 @@ export default function GearShell() {
               ) : null}
             </div>
           </div>
-        </PanelFrame>
-      ) : null}
+            </PanelFrame>
+          </PanelStage>
+        ) : null}
+      </AnimatePresence>
     </div>
   );
 }

--- a/features/inventory/GearShell.tsx
+++ b/features/inventory/GearShell.tsx
@@ -6,9 +6,10 @@ import { AnimatePresence } from "framer-motion";
 import { INVENTORY_GEAR_PARTS } from "@/entities/nav";
 import type { InventoryGearPartId } from "@/entities/nav";
 import { SAO } from "@/shared/design/tokens";
+import { requestStageFocus } from "@/shared/hooks/useStageCamera";
 import PanelCard from "@/shared/ui/PanelCard";
 import PanelStage from "@/shared/ui/PanelStage";
-import { PanelFrame } from "@/widgets/right-panels/ui/PanelFrame";
+import { BackButton, PanelFrame } from "@/widgets/right-panels/ui/PanelFrame";
 import { GoldRow, InfoCard } from "@/widgets/right-panels/ui/Rows";
 import { actionBtnStyle } from "@/widgets/right-panels/ui/styles";
 import { candidatesForGearPart, getEquipCompatibility, slotsForGearPart } from "./model";
@@ -33,7 +34,7 @@ function ErrorState({ text, retry }: { text: string; retry: () => void }) {
   );
 }
 
-export default function GearShell() {
+export default function GearShell({ onBack }: { onBack?: () => void }) {
   const queries = useEquipmentQueries();
   const [part, setPart] = useState<InventoryGearPartId | null>(null);
   const [selectedSlotId, setSelectedSlotId] = useState<number | null>(null);
@@ -61,7 +62,7 @@ export default function GearShell() {
   return (
     <div className="lag-panel-rail relative" data-testid="gear-shell">
       <PanelStage stageKey="inventory-gear-parts">
-        <PanelFrame title="Gear Parts" depth={3}>
+        <PanelFrame title="Gear Parts" depth={3} backButton={onBack ? <BackButton label="Back to Inventory" onClick={onBack} /> : undefined}>
         <div className="space-y-2">
           {INVENTORY_GEAR_PARTS.map((item, index) => (
             <PanelCard
@@ -84,7 +85,12 @@ export default function GearShell() {
       <AnimatePresence initial={false}>
         {part ? (
           <PanelStage stageKey="inventory-gear-slots" focusKey={part} index={1}>
-            <PanelFrame title="Equipment Slots" depth={2} contentKey={part}>
+            <PanelFrame title="Equipment Slots" depth={2} contentKey={part} backButton={<BackButton label="Back to Gear Parts" onClick={() => {
+              setPart(null);
+              setSelectedSlotId(null);
+              setSelectedItemInstanceId(null);
+              requestStageFocus("inventory-gear-parts", "center");
+            }} />}>
           <div className="space-y-3">
             {queries.equipment.loading && queries.equipment.data.length === 0 ? <InfoCard>Loading Equipment...</InfoCard> : null}
             {queries.equipment.error ? <ErrorState text={queries.equipment.error} retry={() => void queries.equipment.reload()} /> : null}
@@ -118,7 +124,12 @@ export default function GearShell() {
       <AnimatePresence initial={false}>
         {part ? (
           <PanelStage stageKey="inventory-gear-candidates" focusKey={part} index={2}>
-            <PanelFrame title="Inventory Candidates" depth={1} contentKey={part}>
+            <PanelFrame title="Inventory Candidates" depth={1} contentKey={part} backButton={<BackButton label="Back to Gear Parts" onClick={() => {
+              setPart(null);
+              setSelectedSlotId(null);
+              setSelectedItemInstanceId(null);
+              requestStageFocus("inventory-gear-parts", "center");
+            }} />}>
           <div className="space-y-3">
             {queries.inventory.loading && queries.inventory.data.entries.length === 0 ? <InfoCard>Loading Inventory candidates...</InfoCard> : null}
             {queries.inventory.error ? <ErrorState text={queries.inventory.error} retry={() => void queries.inventory.reload()} /> : null}
@@ -145,7 +156,11 @@ export default function GearShell() {
       <AnimatePresence initial={false}>
         {selectedSlot ? (
           <PanelStage stageKey="inventory-gear-action" focusKey={`${selectedSlot.slot.slotId}-${selectedCandidate?.itemInstanceId ?? "none"}`} index={3}>
-            <PanelFrame title="Gear Action" depth={0} contentKey={`${selectedSlot.slot.slotId}-${selectedCandidate?.itemInstanceId ?? "none"}`}>
+            <PanelFrame title="Gear Action" depth={0} contentKey={`${selectedSlot.slot.slotId}-${selectedCandidate?.itemInstanceId ?? "none"}`} backButton={<BackButton label="Back to Inventory Candidates" onClick={() => {
+              setSelectedSlotId(null);
+              setSelectedItemInstanceId(null);
+              requestStageFocus("inventory-gear-candidates", "center");
+            }} />}>
           <div className="space-y-2 px-3">
             <InfoCard>{selectedSlot.slot.slotName}</InfoCard>
             <GoldRow>Slot ID: {selectedSlot.slot.slotId}</GoldRow>

--- a/features/inventory/InventoryShell.test.tsx
+++ b/features/inventory/InventoryShell.test.tsx
@@ -75,6 +75,8 @@ describe("Inventory Items와 Inbox surface를 사용할 때", () => {
       api.getInventoryApi.mockReturnValue(response.promise);
       render(<InventoryShell surface="items" />);
       expect(screen.getByText("Loading Items...")).toBeInTheDocument();
+      expect(document.querySelector('[data-stage-key="inventory-items-list"]')).toBeInTheDocument();
+      expect(document.querySelector('[data-stage-key="inventory-items-detail"]')).not.toBeInTheDocument();
 
       await act(async () => {
         response.resolve(inventory);
@@ -82,6 +84,7 @@ describe("Inventory Items와 Inbox surface를 사용할 때", () => {
       });
       fireEvent.click(await screen.findByRole("button", { name: /Server Sword/ }));
 
+      expect(document.querySelector('[data-stage-key="inventory-items-detail"]')).toBeInTheDocument();
       expect(screen.getByText("Item instance ID: 501")).toBeInTheDocument();
       expect(screen.getByText("Durability: 0")).toBeInTheDocument();
       expect(screen.getByText(/Instance attrs:.*"atk":12/)).toBeInTheDocument();

--- a/features/inventory/InventoryShell.test.tsx
+++ b/features/inventory/InventoryShell.test.tsx
@@ -2,6 +2,7 @@ import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { InventoryEntriesResponse, InventoryEntry, MailboxEntriesResponse, MailEntry } from "@/shared/api/types";
+import { STAGE_FOCUS_EVENT } from "@/shared/hooks/useStageCamera";
 import InventoryShell from "./InventoryShell";
 
 const api = vi.hoisted(() => ({
@@ -33,6 +34,7 @@ const item: InventoryEntry = {
   durability: 0,
   instanceAttrs: { atk: 12 },
 };
+const secondItem: InventoryEntry = { ...item, itemInstanceId: 502, slotIndex: 3, itemId: 102, itemName: "Second Sword" };
 
 const mail: MailEntry = {
   mailId: 701,
@@ -99,6 +101,36 @@ describe("Inventory Items와 Inbox surface를 사용할 때", () => {
       fireEvent.click(screen.getByRole("button", { name: "Retry" }));
 
       expect(await screen.findByText("No Items.")).toBeInTheDocument();
+    });
+
+    it("item 교체는 detail frame을 유지하고 Back은 list를 focus하며 submenu 전환은 stale detail을 닫는다", async () => {
+      api.getInventoryApi.mockResolvedValue({ entries: [item, secondItem] });
+      const focus = vi.fn();
+      const onBack = vi.fn();
+      window.addEventListener(STAGE_FOCUS_EVENT, focus);
+      const view = render(<InventoryShell surface="items" onBack={onBack} />);
+      const entries = await screen.findAllByTestId("inventory-entry");
+
+      fireEvent.click(entries[0]);
+      const detail = document.querySelector('[data-stage-key="inventory-items-detail"]');
+      expect(detail).toBeInTheDocument();
+      fireEvent.click(entries[1]);
+      expect(document.querySelector('[data-stage-key="inventory-items-detail"]')).toBe(detail);
+      expect(screen.getByText("Item instance ID: 502")).toBeInTheDocument();
+
+      focus.mockClear();
+      fireEvent.click(screen.getByRole("button", { name: "Back to Items" }));
+      await waitFor(() => expect(document.querySelector('[data-stage-key="inventory-items-detail"]')).not.toBeInTheDocument());
+      expect(focus.mock.calls.at(-1)?.[0]).toMatchObject({ detail: { key: "inventory-items-list", align: "center" } });
+      fireEvent.click(screen.getByRole("button", { name: "Back to Inventory" }));
+      expect(onBack).toHaveBeenCalledTimes(1);
+
+      fireEvent.click(entries[0]);
+      view.rerender(<InventoryShell surface="inbox" onBack={onBack} />);
+      expect(document.querySelector('[data-stage-key="inventory-inbox-detail"]:not([aria-hidden="true"])')).not.toBeInTheDocument();
+      view.rerender(<InventoryShell surface="items" onBack={onBack} />);
+      expect(document.querySelector('[data-stage-key="inventory-items-detail"]:not([aria-hidden="true"])')).not.toBeInTheDocument();
+      window.removeEventListener(STAGE_FOCUS_EVENT, focus);
     });
   });
 

--- a/features/inventory/InventoryShell.tsx
+++ b/features/inventory/InventoryShell.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 import { useState } from "react";
+import { AnimatePresence } from "framer-motion";
 
 import type { InventoryEntry, MailEntry } from "@/shared/api/types";
 import { SAO } from "@/shared/design/tokens";
 import PanelCard from "@/shared/ui/PanelCard";
+import PanelStage from "@/shared/ui/PanelStage";
 import { PanelFrame } from "@/widgets/right-panels/ui/PanelFrame";
 import { GoldRow, InfoCard } from "@/widgets/right-panels/ui/Rows";
 import { actionBtnStyle } from "@/widgets/right-panels/ui/styles";
@@ -89,8 +91,9 @@ export default function InventoryShell({ surface }: { surface: InventorySurface 
   const query = items ? queries.inventory : queries.mailbox;
 
   return (
-    <div className="relative flex min-w-0 w-fit flex-row flex-nowrap items-center gap-3" data-testid="inventory-shell">
-      <PanelFrame title={items ? "Items" : "Inbox"} depth={1}>
+    <div className="lag-panel-rail relative" data-testid="inventory-shell">
+      <PanelStage stageKey={`inventory-${surface}-list`}>
+        <PanelFrame title={items ? "Items" : "Inbox"} depth={1}>
         <div className="space-y-3">
           {query.loading && query.data.entries.length === 0 ? <InfoCard>Loading {items ? "Items" : "Inbox"}...</InfoCard> : null}
           {query.error ? <ErrorState text={query.error} retry={() => void query.reload()} /> : null}
@@ -122,25 +125,30 @@ export default function InventoryShell({ surface }: { surface: InventorySurface 
               ))}
           </div>
         </div>
-      </PanelFrame>
+        </PanelFrame>
+      </PanelStage>
 
-      <PanelFrame title={items ? "Item Detail" : "Mail Detail"} depth={0}>
-        {items && !selectedItem ? <InfoCard>Select an Item.</InfoCard> : null}
-        {!items && !selectedMail ? <InfoCard>Select mail.</InfoCard> : null}
-        {items && selectedItem ? <ItemDetail item={selectedItem} /> : null}
-        {!items && selectedMail ? (
-          <MailDetail
-            mail={selectedMail}
-            pending={queries.pendingKey !== null}
-            onClaim={() => {
-              if (window.confirm(`Claim ${selectedMail.itemName} x${selectedMail.quantity}?`)) void queries.claimMail(selectedMail);
-            }}
-            onDelete={() => {
-              if (window.confirm(`Delete ${selectedMail.itemName} mail?`)) void queries.deleteMail(selectedMail);
-            }}
-          />
+      <AnimatePresence initial={false}>
+        {selectedItem || selectedMail ? (
+          <PanelStage stageKey={`inventory-${surface}-detail`} focusKey={selectedItemInstanceId ?? selectedMailId} index={1}>
+            <PanelFrame title={items ? "Item Detail" : "Mail Detail"} depth={0} contentKey={selectedItemInstanceId ?? selectedMailId ?? undefined}>
+              {items && selectedItem ? <ItemDetail item={selectedItem} /> : null}
+              {!items && selectedMail ? (
+                <MailDetail
+                  mail={selectedMail}
+                  pending={queries.pendingKey !== null}
+                  onClaim={() => {
+                    if (window.confirm(`Claim ${selectedMail.itemName} x${selectedMail.quantity}?`)) void queries.claimMail(selectedMail);
+                  }}
+                  onDelete={() => {
+                    if (window.confirm(`Delete ${selectedMail.itemName} mail?`)) void queries.deleteMail(selectedMail);
+                  }}
+                />
+              ) : null}
+            </PanelFrame>
+          </PanelStage>
         ) : null}
-      </PanelFrame>
+      </AnimatePresence>
     </div>
   );
 }

--- a/features/inventory/InventoryShell.tsx
+++ b/features/inventory/InventoryShell.tsx
@@ -1,13 +1,14 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { AnimatePresence } from "framer-motion";
 
 import type { InventoryEntry, MailEntry } from "@/shared/api/types";
 import { SAO } from "@/shared/design/tokens";
+import { requestStageFocus } from "@/shared/hooks/useStageCamera";
 import PanelCard from "@/shared/ui/PanelCard";
 import PanelStage from "@/shared/ui/PanelStage";
-import { PanelFrame } from "@/widgets/right-panels/ui/PanelFrame";
+import { BackButton, PanelFrame } from "@/widgets/right-panels/ui/PanelFrame";
 import { GoldRow, InfoCard } from "@/widgets/right-panels/ui/Rows";
 import { actionBtnStyle } from "@/widgets/right-panels/ui/styles";
 import { useInventoryQueries } from "./useInventoryQueries";
@@ -81,19 +82,24 @@ function MailDetail({ mail, pending, onClaim, onDelete }: { mail: MailEntry; pen
   );
 }
 
-export default function InventoryShell({ surface }: { surface: InventorySurface }) {
+export default function InventoryShell({ surface, onBack }: { surface: InventorySurface; onBack?: () => void }) {
   const queries = useInventoryQueries();
   const [selectedItemInstanceId, setSelectedItemInstanceId] = useState<number | null>(null);
   const [selectedMailId, setSelectedMailId] = useState<number | null>(null);
-  const selectedItem = queries.inventory.data.entries.find(({ itemInstanceId }) => itemInstanceId === selectedItemInstanceId) ?? null;
-  const selectedMail = queries.mailbox.data.entries.find(({ mailId }) => mailId === selectedMailId) ?? null;
   const items = surface === "items";
+  const selectedItem = items ? queries.inventory.data.entries.find(({ itemInstanceId }) => itemInstanceId === selectedItemInstanceId) ?? null : null;
+  const selectedMail = items ? null : queries.mailbox.data.entries.find(({ mailId }) => mailId === selectedMailId) ?? null;
   const query = items ? queries.inventory : queries.mailbox;
+
+  useEffect(() => {
+    setSelectedItemInstanceId(null);
+    setSelectedMailId(null);
+  }, [surface]);
 
   return (
     <div className="lag-panel-rail relative" data-testid="inventory-shell">
       <PanelStage stageKey={`inventory-${surface}-list`}>
-        <PanelFrame title={items ? "Items" : "Inbox"} depth={1}>
+        <PanelFrame title={items ? "Items" : "Inbox"} depth={1} backButton={onBack ? <BackButton label="Back to Inventory" onClick={onBack} /> : undefined}>
         <div className="space-y-3">
           {query.loading && query.data.entries.length === 0 ? <InfoCard>Loading {items ? "Items" : "Inbox"}...</InfoCard> : null}
           {query.error ? <ErrorState text={query.error} retry={() => void query.reload()} /> : null}
@@ -131,7 +137,11 @@ export default function InventoryShell({ surface }: { surface: InventorySurface 
       <AnimatePresence initial={false}>
         {selectedItem || selectedMail ? (
           <PanelStage stageKey={`inventory-${surface}-detail`} focusKey={selectedItemInstanceId ?? selectedMailId} index={1}>
-            <PanelFrame title={items ? "Item Detail" : "Mail Detail"} depth={0} contentKey={selectedItemInstanceId ?? selectedMailId ?? undefined}>
+            <PanelFrame title={items ? "Item Detail" : "Mail Detail"} depth={0} contentKey={selectedItemInstanceId ?? selectedMailId ?? undefined} backButton={<BackButton label={`Back to ${items ? "Items" : "Inbox"}`} onClick={() => {
+              setSelectedItemInstanceId(null);
+              setSelectedMailId(null);
+              requestStageFocus(`inventory-${surface}-list`, "center");
+            }} />}>
               {items && selectedItem ? <ItemDetail item={selectedItem} /> : null}
               {!items && selectedMail ? (
                 <MailDetail

--- a/features/lifelog/CollectionShell.tsx
+++ b/features/lifelog/CollectionShell.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { AnimatePresence } from "framer-motion";
 
 import {
   COLLECTION_CATEGORIES,
@@ -10,6 +11,7 @@ import {
 } from "@/shared/api/types";
 import { INPUT_STYLE, SAO } from "@/shared/design/tokens";
 import PanelCard from "@/shared/ui/PanelCard";
+import PanelStage from "@/shared/ui/PanelStage";
 import { PanelFrame } from "@/widgets/right-panels/ui/PanelFrame";
 import { GoldRow, InfoCard } from "@/widgets/right-panels/ui/Rows";
 import { useCollectionQueries } from "./useCollectionQueries";
@@ -141,8 +143,9 @@ export default function CollectionShell() {
   const nextDisabled = collections.list.loading || collections.list.items.length < collections.params.size;
 
   return (
-    <div className="relative flex min-w-0 w-fit flex-row flex-nowrap items-center gap-3" data-testid="collection-shell">
-      <PanelFrame title="Collection Search" depth={2}>
+    <div className="lag-panel-rail relative" data-testid="collection-shell">
+      <PanelStage stageKey="lifelog-collection-search">
+        <PanelFrame title="Collection Search" depth={2}>
         <div className="space-y-3 px-3">
           <form className="space-y-2" onSubmit={(event) => {
             event.preventDefault();
@@ -163,9 +166,11 @@ export default function CollectionShell() {
             <CreateForm pending={pending} create={collections.create} />
           </details>
         </div>
-      </PanelFrame>
+        </PanelFrame>
+      </PanelStage>
 
-      <PanelFrame title="Collections" depth={1}>
+      <PanelStage stageKey="lifelog-collection-list" index={1}>
+        <PanelFrame title="Collections" depth={1}>
         <div className="space-y-3">
           {collections.list.loading && collections.list.items.length === 0 ? <InfoCard>Loading Collections...</InfoCard> : null}
           {collections.list.error ? <ErrorState message={collections.list.error} retry={() => void collections.list.reload()} /> : null}
@@ -190,21 +195,27 @@ export default function CollectionShell() {
             <button type="button" disabled={nextDisabled} style={buttonStyle} onClick={() => collections.changePage(collections.params.page + 1)}>Next</button>
           </div>
         </div>
-      </PanelFrame>
+        </PanelFrame>
+      </PanelStage>
 
-      <PanelFrame title="Collection Detail" depth={0}>
-        {!collections.selectedId ? <InfoCard>Select a Collection.</InfoCard> : null}
-        {collections.detail.loading && !collections.detail.data ? <InfoCard>Loading Collection...</InfoCard> : null}
-        {collections.detail.error ? <ErrorState message={collections.detail.error} retry={() => void collections.detail.retry()} /> : null}
-        {collections.detail.data ? (
-          <CollectionDetail
-            item={collections.detail.data}
-            pending={pending}
-            update={(body) => collections.update(collections.detail.data!.id, body)}
-            remove={() => collections.remove(collections.detail.data!.id)}
-          />
+      <AnimatePresence initial={false}>
+        {collections.selectedId ? (
+          <PanelStage stageKey="lifelog-collection-detail" focusKey={collections.selectedId} index={2}>
+            <PanelFrame title="Collection Detail" depth={0} contentKey={collections.selectedId}>
+              {collections.detail.loading && !collections.detail.data ? <InfoCard>Loading Collection...</InfoCard> : null}
+              {collections.detail.error ? <ErrorState message={collections.detail.error} retry={() => void collections.detail.retry()} /> : null}
+              {collections.detail.data ? (
+                <CollectionDetail
+                  item={collections.detail.data}
+                  pending={pending}
+                  update={(body) => collections.update(collections.detail.data!.id, body)}
+                  remove={() => collections.remove(collections.detail.data!.id)}
+                />
+              ) : null}
+            </PanelFrame>
+          </PanelStage>
         ) : null}
-      </PanelFrame>
+      </AnimatePresence>
     </div>
   );
 }

--- a/features/lifelog/ExerciseShell.tsx
+++ b/features/lifelog/ExerciseShell.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { AnimatePresence } from "framer-motion";
 
 import {
   EXERCISE_CATEGORIES,
@@ -11,6 +12,7 @@ import {
 } from "@/shared/api/types";
 import { INPUT_STYLE, SAO } from "@/shared/design/tokens";
 import PanelCard from "@/shared/ui/PanelCard";
+import PanelStage from "@/shared/ui/PanelStage";
 import { PanelFrame } from "@/widgets/right-panels/ui/PanelFrame";
 import { GoldRow, InfoCard } from "@/widgets/right-panels/ui/Rows";
 import { useExerciseQueries } from "./useExerciseQueries";
@@ -141,8 +143,9 @@ export default function ExerciseShell() {
   const nextDisabled = exercises.list.loading || exercises.list.items.length < exercises.params.size;
 
   return (
-    <div className="relative flex min-w-0 w-fit flex-row flex-nowrap items-center gap-3" data-testid="exercise-shell">
-      <PanelFrame title="Exercise Search" depth={2}>
+    <div className="lag-panel-rail relative" data-testid="exercise-shell">
+      <PanelStage stageKey="lifelog-exercise-search">
+        <PanelFrame title="Exercise Search" depth={2}>
         <div className="space-y-3 px-3">
           <form className="space-y-2" onSubmit={(event) => {
             event.preventDefault();
@@ -164,9 +167,11 @@ export default function ExerciseShell() {
             <CreateForm pending={pending} create={exercises.create} />
           </details>
         </div>
-      </PanelFrame>
+        </PanelFrame>
+      </PanelStage>
 
-      <PanelFrame title="Exercises" depth={1}>
+      <PanelStage stageKey="lifelog-exercise-list" index={1}>
+        <PanelFrame title="Exercises" depth={1}>
         <div className="space-y-3">
           {exercises.list.loading && exercises.list.items.length === 0 ? <InfoCard>Loading Exercises...</InfoCard> : null}
           {exercises.list.error ? <ErrorState message={exercises.list.error} retry={() => void exercises.list.reload()} /> : null}
@@ -183,14 +188,20 @@ export default function ExerciseShell() {
             <button type="button" disabled={nextDisabled} style={buttonStyle} onClick={() => exercises.changePage(exercises.params.page + 1)}>Next</button>
           </div>
         </div>
-      </PanelFrame>
+        </PanelFrame>
+      </PanelStage>
 
-      <PanelFrame title="Exercise Detail" depth={0}>
-        {!exercises.selectedId ? <InfoCard>Select an Exercise.</InfoCard> : null}
-        {exercises.detail.loading && !exercises.detail.data ? <InfoCard>Loading Exercise...</InfoCard> : null}
-        {exercises.detail.error ? <ErrorState message={exercises.detail.error} retry={() => void exercises.detail.retry()} /> : null}
-        {exercises.detail.data ? <ExerciseDetail item={exercises.detail.data} pending={pending} update={(body) => exercises.update(exercises.detail.data!.id, body)} remove={() => exercises.remove(exercises.detail.data!.id)} /> : null}
-      </PanelFrame>
+      <AnimatePresence initial={false}>
+        {exercises.selectedId ? (
+          <PanelStage stageKey="lifelog-exercise-detail" focusKey={exercises.selectedId} index={2}>
+            <PanelFrame title="Exercise Detail" depth={0} contentKey={exercises.selectedId}>
+              {exercises.detail.loading && !exercises.detail.data ? <InfoCard>Loading Exercise...</InfoCard> : null}
+              {exercises.detail.error ? <ErrorState message={exercises.detail.error} retry={() => void exercises.detail.retry()} /> : null}
+              {exercises.detail.data ? <ExerciseDetail item={exercises.detail.data} pending={pending} update={(body) => exercises.update(exercises.detail.data!.id, body)} remove={() => exercises.remove(exercises.detail.data!.id)} /> : null}
+            </PanelFrame>
+          </PanelStage>
+        ) : null}
+      </AnimatePresence>
     </div>
   );
 }

--- a/features/lifelog/JournalShell.tsx
+++ b/features/lifelog/JournalShell.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useRef, useState } from "react";
+import { AnimatePresence } from "framer-motion";
 
 import { COLLECTION_CATEGORIES } from "@/shared/api/types";
 import type {
@@ -18,6 +19,7 @@ import type {
 } from "@/shared/api/types";
 import { INPUT_STYLE, SAO } from "@/shared/design/tokens";
 import PanelCard from "@/shared/ui/PanelCard";
+import PanelStage from "@/shared/ui/PanelStage";
 import { PanelFrame } from "@/widgets/right-panels/ui/PanelFrame";
 import { GoldRow, InfoCard } from "@/widgets/right-panels/ui/Rows";
 import { useJournalQueries } from "./useJournalQueries";
@@ -325,8 +327,9 @@ export default function JournalShell({ roles, rolesLoading = false, rolesError =
   const nextDisabled = loading || page.totalPages === 0 || journal.params.page + 1 >= page.totalPages;
 
   return (
-    <div className="relative flex min-w-0 w-fit flex-row flex-nowrap items-center gap-3" data-testid="journal-shell">
-      <PanelFrame title="Journal Filters" depth={2}>
+    <div className="lag-panel-rail relative" data-testid="journal-shell">
+      <PanelStage stageKey="lifelog-journal-filters">
+        <PanelFrame title="Journal Filters" depth={2}>
         <div className="space-y-3 px-3">
           <details>
             <summary className="cursor-pointer text-xs" style={{ color: SAO.color.text.gold }}>Quick Record</summary>
@@ -363,9 +366,11 @@ export default function JournalShell({ roles, rolesLoading = false, rolesError =
           {rolesLoading ? <InfoCard>Loading Roles...</InfoCard> : null}
           {rolesError ? <p role="alert" className="text-xs" style={{ color: SAO.color.action.red }}>Role filter unavailable: {rolesError}</p> : null}
         </div>
-      </PanelFrame>
+        </PanelFrame>
+      </PanelStage>
 
-      <PanelFrame title="Journal" depth={1}>
+      <PanelStage stageKey="lifelog-journal-list" index={1}>
+        <PanelFrame title="Journal" depth={1}>
         <div className="space-y-3">
           {loading ? <InfoCard>Loading Journal...</InfoCard> : null}
           {error ? <ErrorState text={error} retry={() => void journal.list.reload()} /> : null}
@@ -402,28 +407,34 @@ export default function JournalShell({ roles, rolesLoading = false, rolesError =
           </div>
           <p className="px-3 text-xs" style={{ color: SAO.color.text.label }}>{page.totalElements} total</p>
         </div>
-      </PanelFrame>
+        </PanelFrame>
+      </PanelStage>
 
-      <PanelFrame title={detail ? `${detail.sourceType} Journal Detail` : "Journal Detail"} depth={0}>
-        {!journal.selectedLifeLogId ? <InfoCard>Select a Journal entry.</InfoCard> : null}
-        {journal.detail.loading && !detail ? <InfoCard>Loading Journal detail...</InfoCard> : null}
-        {journal.detail.error && !detail ? <ErrorState text={journal.detail.error} retry={journal.detail.retry} /> : null}
-        {detail ? (
-          <div className="space-y-3 px-3">
-            {journal.detail.error ? <p role="alert" className="text-xs" style={{ color: SAO.color.action.red }}>{journal.detail.error}</p> : null}
-            <InfoCard>Journal entry #{detail.lifeLogId}</InfoCard>
-            <GoldRow>Source type: {detail.sourceType}</GoldRow>
-            <GoldRow>Recorded at: {detail.recordedAt}</GoldRow>
-            {detail.subtype ? <GoldRow>Subtype: {detail.subtype}</GoldRow> : null}
-            {detail.entryMode ? <GoldRow>Entry mode: {detail.entryMode}</GoldRow> : null}
-            {detail.reflectionScope ? <GoldRow>Reflection scope: {detail.reflectionScope}</GoldRow> : null}
-            {detail.periodKey ? <GoldRow>Period: {detail.periodKey}</GoldRow> : null}
-            {detail.primaryRoleId !== null ? <GoldRow>{roleContext(detail.primaryRoleId, roles)}</GoldRow> : null}
-            {detail.roleEventId !== null ? <GoldRow>Event context #{detail.roleEventId}</GoldRow> : null}
-            <SourceDetail detail={detail} />
-          </div>
+      <AnimatePresence initial={false}>
+        {journal.selectedLifeLogId ? (
+          <PanelStage stageKey="lifelog-journal-detail" focusKey={journal.selectedLifeLogId} index={2}>
+            <PanelFrame title={detail ? `${detail.sourceType} Journal Detail` : "Journal Detail"} depth={0} contentKey={journal.selectedLifeLogId}>
+              {journal.detail.loading && !detail ? <InfoCard>Loading Journal detail...</InfoCard> : null}
+              {journal.detail.error && !detail ? <ErrorState text={journal.detail.error} retry={journal.detail.retry} /> : null}
+              {detail ? (
+                <div className="space-y-3 px-3">
+                  {journal.detail.error ? <p role="alert" className="text-xs" style={{ color: SAO.color.action.red }}>{journal.detail.error}</p> : null}
+                  <InfoCard>Journal entry #{detail.lifeLogId}</InfoCard>
+                  <GoldRow>Source type: {detail.sourceType}</GoldRow>
+                  <GoldRow>Recorded at: {detail.recordedAt}</GoldRow>
+                  {detail.subtype ? <GoldRow>Subtype: {detail.subtype}</GoldRow> : null}
+                  {detail.entryMode ? <GoldRow>Entry mode: {detail.entryMode}</GoldRow> : null}
+                  {detail.reflectionScope ? <GoldRow>Reflection scope: {detail.reflectionScope}</GoldRow> : null}
+                  {detail.periodKey ? <GoldRow>Period: {detail.periodKey}</GoldRow> : null}
+                  {detail.primaryRoleId !== null ? <GoldRow>{roleContext(detail.primaryRoleId, roles)}</GoldRow> : null}
+                  {detail.roleEventId !== null ? <GoldRow>Event context #{detail.roleEventId}</GoldRow> : null}
+                  <SourceDetail detail={detail} />
+                </div>
+              ) : null}
+            </PanelFrame>
+          </PanelStage>
         ) : null}
-      </PanelFrame>
+      </AnimatePresence>
     </div>
   );
 }

--- a/features/lifelog/MediaShell.test.tsx
+++ b/features/lifelog/MediaShell.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { readFileSync } from "node:fs";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { MEDIA_CATEGORIES, MEDIA_STATUSES, type MediaInfo } from "@/shared/api/types";
@@ -58,5 +59,30 @@ describe("Media source surface를 사용할 때", () => {
     await waitFor(() => expect(api.updateMediaApi).toHaveBeenLastCalledWith(51, { tags: [] }));
     fireEvent.click(completeEntry);
     expect(screen.getByRole("button", { name: "Advance +1" })).toBeDisabled();
+  });
+
+  it("select filter는 즉시, title query는 debounce하고 filter 변경 시 detail을 닫는다", async () => {
+    render(<MediaShell />);
+    const entry = (await screen.findAllByTestId("media-entry"))[0];
+    expect(document.querySelector('[data-stage-key="lifelog-media-detail"]')).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Search" })).not.toBeInTheDocument();
+
+    fireEvent.click(entry);
+    expect(document.querySelector('[data-stage-key="lifelog-media-detail"]')).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText("Category filter"), { target: { value: "BOOK" } });
+    await waitFor(() => expect(document.querySelector('[data-stage-key="lifelog-media-detail"]')).not.toBeInTheDocument());
+    await waitFor(() => expect(api.searchMediaApi).toHaveBeenLastCalledWith({ category: "BOOK", page: 0, size: 20 }));
+
+    const calls = api.searchMediaApi.mock.calls.length;
+    fireEvent.change(screen.getByLabelText("Title search"), { target: { value: "Architecture" } });
+    expect(api.searchMediaApi).toHaveBeenCalledTimes(calls);
+    await waitFor(() => expect(api.searchMediaApi).toHaveBeenLastCalledWith({ category: "BOOK", titleLike: "Architecture", page: 0, size: 20 }));
+  });
+
+  it("uses semantic controls for Add Media without a new theme palette", () => {
+    const source = readFileSync("features/lifelog/MediaShell.tsx", "utf8");
+    expect(source).toContain("SEMANTIC_CONTROL_STYLE");
+    expect(source).toContain("lag-add-control");
+    expect(source).not.toContain("INPUT_STYLE");
   });
 });

--- a/features/lifelog/MediaShell.tsx
+++ b/features/lifelog/MediaShell.tsx
@@ -1,15 +1,18 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import { AnimatePresence } from "framer-motion";
 
 import { MEDIA_CATEGORIES, MEDIA_STATUSES, type MediaCategory, type MediaCreateRequest, type MediaInfo, type MediaStatus, type MediaUpdateRequest } from "@/shared/api/types";
-import { INPUT_STYLE, SAO } from "@/shared/design/tokens";
+import { SEMANTIC_CONTROL_STYLE, SAO } from "@/shared/design/tokens";
 import PanelCard from "@/shared/ui/PanelCard";
+import PanelStage from "@/shared/ui/PanelStage";
 import { PanelFrame } from "@/widgets/right-panels/ui/PanelFrame";
 import { GoldRow, InfoCard } from "@/widgets/right-panels/ui/Rows";
 import { useMediaQueries } from "./useMediaQueries";
 
-const buttonStyle = { border: `1px solid ${SAO.color.border.panel}`, background: SAO.color.bg.inset, color: SAO.color.text.secondary, borderRadius: SAO.radius.panel, padding: "7px 10px", fontSize: "0.68rem", letterSpacing: "0.08em" } as const;
+const buttonStyle = { border: "1px solid var(--lag-control-border)", background: "var(--lag-control-bg)", color: "var(--lag-control-text)", borderRadius: "var(--lag-radius-sm)", padding: "7px 10px", fontSize: "0.68rem", letterSpacing: "0.08em" } as const;
+const controlStyle = SEMANTIC_CONTROL_STYLE;
 const text = (form: FormData, key: string) => String(form.get(key) ?? "").trim();
 const number = (form: FormData, key: string) => text(form, key) === "" ? undefined : Number(text(form, key));
 const tags = (form: FormData) => text(form, "tags").split(",").map((tag) => tag.trim()).filter(Boolean);
@@ -19,7 +22,7 @@ function ErrorState({ message, retry }: { message: string; retry: () => void }) 
 }
 
 function Select({ name, label, values, optional = false, disabled = false, defaultValue = "" }: { name: string; label: string; values: readonly string[]; optional?: boolean; disabled?: boolean; defaultValue?: string }) {
-  return <label className="block text-xs" style={{ color: SAO.color.text.label }}>{label}<select name={name} aria-label={label} defaultValue={defaultValue} required={!optional} disabled={disabled} style={INPUT_STYLE}><option value="">{optional ? "Preserve..." : "Select..."}</option>{values.map((value) => <option key={value}>{value}</option>)}</select></label>;
+  return <label className="block text-xs" style={{ color: SAO.color.text.label }}>{label}<select name={name} aria-label={label} defaultValue={defaultValue} required={!optional} disabled={disabled} style={controlStyle}><option value="">{optional ? "Preserve..." : "Select..."}</option>{values.map((value) => <option key={value}>{value}</option>)}</select></label>;
 }
 
 function CreateForm({ pending, create }: { pending: boolean; create: (body: MediaCreateRequest) => Promise<boolean> }) {
@@ -35,12 +38,12 @@ function CreateForm({ pending, create }: { pending: boolean; create: (body: Medi
     if (saved) element.reset();
   }}>
     <Select name="category" label="Create category" values={MEDIA_CATEGORIES} disabled={pending} />
-    <label className="block text-xs" style={{ color: SAO.color.text.label }}>Title<input name="title" required disabled={pending} style={INPUT_STYLE} /></label>
-    <label className="block text-xs" style={{ color: SAO.color.text.label }}>Original title<input name="originalTitle" disabled={pending} style={INPUT_STYLE} /></label>
-    <label className="block text-xs" style={{ color: SAO.color.text.label }}>Current episode<input name="currentEpisode" type="number" min="0" disabled={pending} style={INPUT_STYLE} /></label>
-    <label className="block text-xs" style={{ color: SAO.color.text.label }}>Total episode<input name="totalEpisode" type="number" min="1" disabled={pending} style={INPUT_STYLE} /></label>
+    <label className="block text-xs" style={{ color: SAO.color.text.label }}>Title<input name="title" required disabled={pending} style={controlStyle} /></label>
+    <label className="block text-xs" style={{ color: SAO.color.text.label }}>Original title<input name="originalTitle" disabled={pending} style={controlStyle} /></label>
+    <label className="block text-xs" style={{ color: SAO.color.text.label }}>Current episode<input name="currentEpisode" type="number" min="0" disabled={pending} style={controlStyle} /></label>
+    <label className="block text-xs" style={{ color: SAO.color.text.label }}>Total episode<input name="totalEpisode" type="number" min="1" disabled={pending} style={controlStyle} /></label>
     <Select name="status" label="Create status" values={MEDIA_STATUSES} disabled={pending} />
-    <label className="block text-xs" style={{ color: SAO.color.text.label }}>Tags, comma separated<input name="tags" disabled={pending} style={INPUT_STYLE} /></label>
+    <label className="block text-xs" style={{ color: SAO.color.text.label }}>Tags, comma separated<input name="tags" disabled={pending} style={controlStyle} /></label>
     <button type="submit" disabled={pending} style={buttonStyle}>{pending ? "Saving..." : "Create Media"}</button>
   </form>;
 }
@@ -49,7 +52,7 @@ function Detail({ item, pending, update, remove, rate, advance, markStatus, rewa
   return <div className="space-y-3 px-3">
     <InfoCard>{item.title}</InfoCard><GoldRow>Media source #{item.id}</GoldRow><GoldRow>Category: {item.category}</GoldRow><GoldRow>Original title: {item.originalTitle ?? "Not recorded"}</GoldRow><GoldRow>Progress: {item.currentEpisode}/{item.totalEpisode}</GoldRow><GoldRow>Status: {item.status}</GoldRow><GoldRow>Rating: {item.rating ?? "Not rated"}</GoldRow><GoldRow>Tags: {item.tags.length ? item.tags.join(", ") : "Not recorded"}</GoldRow><GoldRow>Rewatch count: {item.rewatchCount}</GoldRow><GoldRow>Started: {item.startedOn ?? "Not recorded"}</GoldRow><GoldRow>Finished: {item.finishedOn ?? "Not recorded"}</GoldRow><GoldRow>Created: {item.createdAt}</GoldRow><GoldRow>Updated: {item.updatedAt}</GoldRow>
     <form key={`${item.id}-${item.rating}`} className="space-y-2" aria-label="Rate Media" onSubmit={(event) => { event.preventDefault(); const score = number(new FormData(event.currentTarget), "score"); if (score !== undefined) void rate(score); }}>
-      <label className="block text-xs" style={{ color: SAO.color.text.label }}>Rating score<input name="score" aria-label="Rating score" type="number" min="0" max="5" step="0.1" defaultValue={item.rating ?? ""} required disabled={pending} style={INPUT_STYLE} /></label>
+      <label className="block text-xs" style={{ color: SAO.color.text.label }}>Rating score<input name="score" aria-label="Rating score" type="number" min="0" max="5" step="0.1" defaultValue={item.rating ?? ""} required disabled={pending} style={controlStyle} /></label>
       <button type="submit" disabled={pending} style={buttonStyle}>Rate</button>
     </form>
     <div className="flex flex-wrap gap-2"><button type="button" disabled={pending || item.status === "COMPLETED" || item.currentEpisode === item.totalEpisode} style={buttonStyle} onClick={() => void advance()}>Advance +1</button><button type="button" disabled={pending} style={buttonStyle} onClick={() => void rewatch()}>Rewatch</button></div>
@@ -63,7 +66,7 @@ function Detail({ item, pending, update, remove, rate, advance, markStatus, rewa
       const title = text(form, "title"); const originalTitle = text(form, "originalTitle"); const currentEpisode = number(form, "currentEpisode"); const totalEpisode = number(form, "totalEpisode"); const mediaTags = tags(form); const category = text(form, "category"); const status = text(form, "status");
       void update({ ...(category ? { category: category as MediaCategory } : {}), ...(title ? { title } : {}), ...(originalTitle ? { originalTitle } : {}), ...(currentEpisode !== undefined ? { currentEpisode } : {}), ...(totalEpisode !== undefined ? { totalEpisode } : {}), ...(status ? { status: status as MediaStatus } : {}), ...(mediaTags.length ? { tags: mediaTags } : {}) });
     }}>
-      <Select name="category" label="Update category" values={MEDIA_CATEGORIES} optional disabled={pending} /><label className="block text-xs" style={{ color: SAO.color.text.label }}>Update title<input name="title" disabled={pending} style={INPUT_STYLE} /></label><label className="block text-xs" style={{ color: SAO.color.text.label }}>Update original title<input name="originalTitle" disabled={pending} style={INPUT_STYLE} /></label><label className="block text-xs" style={{ color: SAO.color.text.label }}>Update current episode<input name="currentEpisode" type="number" min="0" disabled={pending} style={INPUT_STYLE} /></label><label className="block text-xs" style={{ color: SAO.color.text.label }}>Update total episode<input name="totalEpisode" type="number" min="1" disabled={pending} style={INPUT_STYLE} /></label><Select name="status" label="Update status" values={MEDIA_STATUSES} optional disabled={pending} /><label className="block text-xs" style={{ color: SAO.color.text.label }}>Update tags<input name="tags" disabled={pending} style={INPUT_STYLE} /></label>
+      <Select name="category" label="Update category" values={MEDIA_CATEGORIES} optional disabled={pending} /><label className="block text-xs" style={{ color: SAO.color.text.label }}>Update title<input name="title" disabled={pending} style={controlStyle} /></label><label className="block text-xs" style={{ color: SAO.color.text.label }}>Update original title<input name="originalTitle" disabled={pending} style={controlStyle} /></label><label className="block text-xs" style={{ color: SAO.color.text.label }}>Update current episode<input name="currentEpisode" type="number" min="0" disabled={pending} style={controlStyle} /></label><label className="block text-xs" style={{ color: SAO.color.text.label }}>Update total episode<input name="totalEpisode" type="number" min="1" disabled={pending} style={controlStyle} /></label><Select name="status" label="Update status" values={MEDIA_STATUSES} optional disabled={pending} /><label className="block text-xs" style={{ color: SAO.color.text.label }}>Update tags<input name="tags" disabled={pending} style={controlStyle} /></label>
       <p className="text-xs" style={{ color: SAO.color.text.label }}>Untouched blank fields preserve current values.</p>
       <div className="flex flex-wrap gap-2"><button type="submit" disabled={pending} style={buttonStyle}>Update Media</button><button type="button" disabled={pending || item.originalTitle === null} style={buttonStyle} onClick={() => void update({ originalTitle: "" })}>Clear Original Title</button><button type="button" disabled={pending || item.tags.length === 0} style={buttonStyle} onClick={() => void update({ tags: [] })}>Clear Tags</button><button type="button" disabled={pending} style={buttonStyle} onClick={() => { if (window.confirm(`Delete ${item.title}?`)) void remove(); }}>Delete</button></div>
     </form>
@@ -73,10 +76,103 @@ function Detail({ item, pending, update, remove, rate, advance, markStatus, rewa
 export default function MediaShell() {
   const media = useMediaQueries();
   const [category, setCategory] = useState<MediaCategory | "">(""); const [status, setStatus] = useState<MediaStatus | "">(""); const [titleLike, setTitleLike] = useState("");
+  const searchTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pending = media.pendingMutation !== null; const nextDisabled = media.list.loading || media.list.items.length < media.params.size;
-  return <div className="relative flex min-w-0 w-fit flex-row flex-nowrap items-center gap-3" data-testid="media-shell">
-    <PanelFrame title="Media Search" depth={2}><div className="space-y-3 px-3"><form className="space-y-2" onSubmit={(event) => { event.preventDefault(); media.search(category || undefined, status || undefined, titleLike); }}><label className="block text-xs" style={{ color: SAO.color.text.label }}>Category filter<select aria-label="Category filter" value={category} onChange={(event) => setCategory(event.target.value as MediaCategory | "")} style={INPUT_STYLE}><option value="">All Categories</option>{MEDIA_CATEGORIES.map((value) => <option key={value}>{value}</option>)}</select></label><label className="block text-xs" style={{ color: SAO.color.text.label }}>Status filter<select aria-label="Status filter" value={status} onChange={(event) => setStatus(event.target.value as MediaStatus | "")} style={INPUT_STYLE}><option value="">All Statuses</option>{MEDIA_STATUSES.map((value) => <option key={value}>{value}</option>)}</select></label><label className="block text-xs" style={{ color: SAO.color.text.label }}>Title search<input aria-label="Title search" value={titleLike} onChange={(event) => setTitleLike(event.target.value)} style={INPUT_STYLE} /></label><button type="submit" style={buttonStyle}>Search</button></form><details><summary className="cursor-pointer text-xs" style={{ color: SAO.color.text.gold }}>Add Media</summary><CreateForm pending={pending} create={media.create} /></details></div></PanelFrame>
-    <PanelFrame title="Media" depth={1}><div className="space-y-3">{media.list.loading && !media.list.items.length ? <InfoCard>Loading Media...</InfoCard> : null}{media.list.error ? <ErrorState message={media.list.error} retry={() => void media.list.reload()} /> : null}{!media.list.loading && !media.list.error && !media.list.items.length ? <InfoCard>No Media.</InfoCard> : null}{media.mutationError ? <p role="alert" className="px-3 text-xs" style={{ color: SAO.color.action.red }}>{media.mutationError}</p> : null}<div className="space-y-2">{media.list.items.map((item, index) => <PanelCard key={item.id} label={item.title} slotLabel={item.category.slice(0, 2)} subtitle={`${item.status} · ${item.currentEpisode}/${item.totalEpisode}`} selected={media.selectedId === item.id} index={index} onClick={() => media.select(item.id)} />)}</div><div className="flex items-center justify-between gap-2 px-3"><button type="button" disabled={media.list.loading || media.params.page === 0} style={buttonStyle} onClick={() => media.changePage(media.params.page - 1)}>Previous</button><span className="text-xs" style={{ color: SAO.color.text.label }}>Page {media.params.page + 1}</span><button type="button" disabled={nextDisabled} style={buttonStyle} onClick={() => media.changePage(media.params.page + 1)}>Next</button></div></div></PanelFrame>
-    <PanelFrame title="Media Detail" depth={0}>{media.detail ? <Detail item={media.detail} pending={pending} update={(body) => media.update(media.detail!.id, body)} remove={() => media.remove(media.detail!.id)} rate={(score) => media.rate(media.detail!.id, score)} advance={() => media.advance(media.detail!.id)} markStatus={(next) => media.markStatus(media.detail!.id, next)} rewatch={() => media.rewatch(media.detail!.id)} /> : <InfoCard>Select a Media source.</InfoCard>}</PanelFrame>
-  </div>;
+
+  useEffect(() => () => {
+    if (searchTimer.current) clearTimeout(searchTimer.current);
+  }, []);
+
+  const searchImmediately = (nextCategory: MediaCategory | "", nextStatus: MediaStatus | "") => {
+    if (searchTimer.current) clearTimeout(searchTimer.current);
+    media.search(nextCategory || undefined, nextStatus || undefined, titleLike);
+  };
+
+  const changeTitle = (value: string) => {
+    setTitleLike(value);
+    if (searchTimer.current) clearTimeout(searchTimer.current);
+    searchTimer.current = setTimeout(() => media.search(category || undefined, status || undefined, value), 200);
+  };
+
+  return (
+    <div className="lag-panel-rail lag-semantic-controls relative" data-testid="media-shell">
+      <PanelStage stageKey="lifelog-media-search">
+        <PanelFrame title="Media Search" depth={2}>
+          <div className="space-y-3 px-3">
+            <div className="space-y-2">
+              <label className="block text-xs" style={{ color: SAO.color.text.label }}>
+                Category filter
+                <select
+                  aria-label="Category filter"
+                  value={category}
+                  onChange={(event) => {
+                    const next = event.target.value as MediaCategory | "";
+                    setCategory(next);
+                    searchImmediately(next, status);
+                  }}
+                  style={controlStyle}
+                >
+                  <option value="">All Categories</option>
+                  {MEDIA_CATEGORIES.map((value) => <option key={value}>{value}</option>)}
+                </select>
+              </label>
+              <label className="block text-xs" style={{ color: SAO.color.text.label }}>
+                Status filter
+                <select
+                  aria-label="Status filter"
+                  value={status}
+                  onChange={(event) => {
+                    const next = event.target.value as MediaStatus | "";
+                    setStatus(next);
+                    searchImmediately(category, next);
+                  }}
+                  style={controlStyle}
+                >
+                  <option value="">All Statuses</option>
+                  {MEDIA_STATUSES.map((value) => <option key={value}>{value}</option>)}
+                </select>
+              </label>
+              <label className="block text-xs" style={{ color: SAO.color.text.label }}>
+                Title search
+                <input aria-label="Title search" value={titleLike} onChange={(event) => changeTitle(event.target.value)} style={controlStyle} />
+              </label>
+            </div>
+            <details>
+              <summary className="lag-add-control cursor-pointer text-xs">Add Media</summary>
+              <CreateForm pending={pending} create={media.create} />
+            </details>
+          </div>
+        </PanelFrame>
+      </PanelStage>
+
+      <PanelStage stageKey="lifelog-media-list" index={1}>
+        <PanelFrame title="Media" depth={1}>
+          <div className="space-y-3">
+            {media.list.loading && !media.list.items.length ? <InfoCard>Loading Media...</InfoCard> : null}
+            {media.list.error ? <ErrorState message={media.list.error} retry={() => void media.list.reload()} /> : null}
+            {!media.list.loading && !media.list.error && !media.list.items.length ? <InfoCard>No Media.</InfoCard> : null}
+            {media.mutationError ? <p role="alert" className="px-3 text-xs" style={{ color: SAO.color.action.red }}>{media.mutationError}</p> : null}
+            <div className="space-y-2">
+              {media.list.items.map((item, index) => <PanelCard key={item.id} label={item.title} slotLabel={item.category.slice(0, 2)} subtitle={`${item.status} · ${item.currentEpisode}/${item.totalEpisode}`} selected={media.selectedId === item.id} index={index} onClick={() => media.select(item.id)} />)}
+            </div>
+            <div className="flex items-center justify-between gap-2 px-3">
+              <button type="button" disabled={media.list.loading || media.params.page === 0} style={buttonStyle} onClick={() => media.changePage(media.params.page - 1)}>Previous</button>
+              <span className="text-xs" style={{ color: SAO.color.text.label }}>Page {media.params.page + 1}</span>
+              <button type="button" disabled={nextDisabled} style={buttonStyle} onClick={() => media.changePage(media.params.page + 1)}>Next</button>
+            </div>
+          </div>
+        </PanelFrame>
+      </PanelStage>
+
+      <AnimatePresence initial={false}>
+        {media.detail ? (
+          <PanelStage stageKey="lifelog-media-detail" focusKey={media.detail.id} index={2}>
+            <PanelFrame title="Media Detail" depth={0} contentKey={media.detail.id}>
+              <Detail item={media.detail} pending={pending} update={(body) => media.update(media.detail!.id, body)} remove={() => media.remove(media.detail!.id)} rate={(score) => media.rate(media.detail!.id, score)} advance={() => media.advance(media.detail!.id)} markStatus={(next) => media.markStatus(media.detail!.id, next)} rewatch={() => media.rewatch(media.detail!.id)} />
+            </PanelFrame>
+          </PanelStage>
+        ) : null}
+      </AnimatePresence>
+    </div>
+  );
 }

--- a/features/lifelog/useCollectionQueries.ts
+++ b/features/lifelog/useCollectionQueries.ts
@@ -93,12 +93,14 @@ export function useCollectionQueries() {
   }, [loadDetail]);
 
   const search = (category?: CollectionCategory, titleLike?: string) => {
+    clearSelection();
     listRequestId.current += 1;
     paramsRef.current = { page: 0, size: paramsRef.current.size, category, titleLike: titleLike?.trim() || undefined };
     setParams(paramsRef.current);
   };
 
   const changePage = (page: number) => {
+    clearSelection();
     listRequestId.current += 1;
     paramsRef.current = { ...paramsRef.current, page: Math.max(0, page) };
     setParams(paramsRef.current);

--- a/features/lifelog/useExerciseQueries.test.tsx
+++ b/features/lifelog/useExerciseQueries.test.tsx
@@ -43,6 +43,13 @@ describe("Exercise query/mutation state를 관리할 때", () => {
   });
 
   it("create reload 후 returned ID를 fetch/select하고 update reload, delete clear를 수행한다", async () => {
+    api.searchExercisesApi.mockReset()
+      .mockResolvedValueOnce([first])
+      .mockResolvedValueOnce([first])
+      .mockResolvedValueOnce([first])
+      .mockResolvedValueOnce([created, first])
+      .mockResolvedValueOnce([updated, first])
+      .mockResolvedValueOnce([first]);
     const { result } = renderHook(() => useExerciseQueries());
     await waitFor(() => expect(result.current.list.items).toEqual([first]));
     act(() => result.current.search("RUNNING", "2026-08-01", "2026-08-14"));

--- a/features/lifelog/useExerciseQueries.ts
+++ b/features/lifelog/useExerciseQueries.ts
@@ -57,6 +57,7 @@ export function useExerciseQueries() {
       const next = await searchExercisesApi(paramsRef.current);
       if (requestId !== listRequestId.current) return undefined;
       setItems(next);
+      if (selectedIdRef.current !== null && !next.some(({ id }) => id === selectedIdRef.current)) clearSelection();
       return next;
     } catch (caught) {
       if (requestId === listRequestId.current) setListError(message(caught, "Unable to load Exercises."));
@@ -64,7 +65,7 @@ export function useExerciseQueries() {
     } finally {
       if (requestId === listRequestId.current) setListLoading(false);
     }
-  }, []);
+  }, [clearSelection]);
 
   useEffect(() => { void reload(); }, [params, reload]);
 
@@ -92,12 +93,14 @@ export function useExerciseQueries() {
   }, [loadDetail]);
 
   const search = (category?: ExerciseCategory, from?: string, to?: string) => {
+    clearSelection();
     listRequestId.current += 1;
     paramsRef.current = { page: 0, size: paramsRef.current.size, category, from: from || undefined, to: to || undefined };
     setParams(paramsRef.current);
   };
 
   const changePage = (page: number) => {
+    clearSelection();
     listRequestId.current += 1;
     paramsRef.current = { ...paramsRef.current, page: Math.max(0, page) };
     setParams(paramsRef.current);
@@ -107,7 +110,7 @@ export function useExerciseQueries() {
     key: string,
     request: () => Promise<T>,
     onResponse?: (result: T) => void,
-    onReload?: (result: T) => void,
+    onReload?: (result: T, next: ExerciseInfo[]) => void,
   ): Promise<boolean> => {
     if (mutationLocked.current) return false;
     mutationLocked.current = true;
@@ -116,7 +119,8 @@ export function useExerciseQueries() {
     try {
       const result = await request();
       onResponse?.(result);
-      if (await reload()) onReload?.(result);
+      const next = await reload();
+      if (next) onReload?.(result, next);
       else setMutationError("Exercise changed, but the authoritative list could not be reloaded.");
       return true;
     } catch (caught) {
@@ -133,7 +137,7 @@ export function useExerciseQueries() {
     "create",
     () => createExerciseApi(body),
     undefined,
-    ({ id }) => select(id),
+    ({ id }, next) => { if (next.some((item) => item.id === id)) select(id); },
   );
 
   const update = (id: number, body: ExerciseUpdateRequest) => mutate(

--- a/features/lifelog/useJournalQueries.ts
+++ b/features/lifelog/useJournalQueries.ts
@@ -159,18 +159,21 @@ export function useJournalQueries() {
   };
 
   const changeRoleFilter = (primaryRoleId?: number) => {
+    clearSelection();
     listRequestId.current += 1;
     paramsRef.current = { ...paramsRef.current, primaryRoleId, page: 0 };
     setParams(paramsRef.current);
   };
 
   const changeSubtypeFilter = (subtype?: JournalSubtype) => {
+    clearSelection();
     listRequestId.current += 1;
     paramsRef.current = { ...paramsRef.current, subtype, page: 0 };
     setParams(paramsRef.current);
   };
 
   const changePage = (page: number) => {
+    clearSelection();
     listRequestId.current += 1;
     paramsRef.current = { ...paramsRef.current, page };
     setParams(paramsRef.current);

--- a/features/lifelog/useMediaQueries.test.tsx
+++ b/features/lifelog/useMediaQueries.test.tsx
@@ -41,6 +41,24 @@ describe("Media query/mutation state를 관리할 때", () => {
     expect(result.current.list.items).toEqual([first]);
   });
 
+  it("ignores a stale server-backed search response", async () => {
+    let resolveStale!: (items: MediaInfo[]) => void;
+    const stale = new Promise<MediaInfo[]>((resolve) => { resolveStale = resolve; });
+    api.searchMediaApi.mockReset()
+      .mockResolvedValueOnce([first])
+      .mockReturnValueOnce(stale)
+      .mockResolvedValueOnce([created]);
+    const { result } = renderHook(() => useMediaQueries());
+    await waitFor(() => expect(result.current.list.items).toEqual([first]));
+
+    act(() => result.current.search("ANIME", undefined, "old"));
+    act(() => result.current.search("ANIME", undefined, "new"));
+    await waitFor(() => expect(result.current.list.items).toEqual([created]));
+    await act(async () => { resolveStale([first]); await stale; });
+
+    expect(result.current.list.items).toEqual([created]);
+  });
+
   it("create ID는 reload row만 선택하고 PATCH response/reload를 적용하며 selected delete를 clear한다", async () => {
     const { result } = renderHook(() => useMediaQueries());
     await waitFor(() => expect(result.current.list.items).toEqual([first]));

--- a/features/notification/NotificationBell.test.tsx
+++ b/features/notification/NotificationBell.test.tsx
@@ -68,10 +68,13 @@ describe("NotificationBell canonical surface", () => {
 
   it("uses dual-theme semantic surfaces without the fixed dark/gold container", () => {
     const source = readFileSync("features/notification/NotificationBell.tsx", "utf8");
+    const css = readFileSync("app/globals.css", "utf8");
 
     expect(source).toContain("lag-utility-button");
     expect(source).toContain("lag-notification-dropdown");
+    expect(source).toContain("notificationPopupPosition");
     expect(source).toContain("var(--lag-control-bg)");
+    expect(css).toMatch(/\.lag-notification-trigger\s*{[\s\S]*?overflow:\s*visible/);
     expect(source).not.toMatch(/rgba\(|#[0-9a-fA-F]{3,8}/);
   });
 });

--- a/features/notification/NotificationBell.test.tsx
+++ b/features/notification/NotificationBell.test.tsx
@@ -75,6 +75,9 @@ describe("NotificationBell canonical surface", () => {
     expect(source).toContain("notificationPopupPosition");
     expect(source).toContain("var(--lag-control-bg)");
     expect(css).toMatch(/\.lag-notification-trigger\s*{[\s\S]*?overflow:\s*visible/);
+    expect(source).toContain('maxHeight: "calc(100dvh - 32px)"');
+    expect(source).toContain('className="lag-notification-list"');
+    expect(source).toContain("minHeight: 0, flex: 1, overflowY: \"auto\"");
     expect(source).not.toMatch(/rgba\(|#[0-9a-fA-F]{3,8}/);
   });
 });

--- a/features/notification/NotificationBell.tsx
+++ b/features/notification/NotificationBell.tsx
@@ -154,10 +154,13 @@ export function NotificationBell() {
               borderRadius: "var(--lag-radius-md)",
               zIndex: 600100,
               overflow: "hidden",
+              maxHeight: "calc(100dvh - 32px)",
+              display: "flex",
+              flexDirection: "column",
               visibility: popupPosition ? "visible" : "hidden",
             }}
           >
-            <header style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8, padding: "9px 14px 8px", background: "var(--lag-panel-2)", borderBottom: "1px solid var(--lag-divider)" }}>
+            <header style={{ display: "flex", flexShrink: 0, alignItems: "center", justifyContent: "space-between", gap: 8, padding: "9px 14px 8px", background: "var(--lag-panel-2)", borderBottom: "1px solid var(--lag-divider)" }}>
               <span style={{ fontSize: 10, fontWeight: 700, color: "var(--lag-text)", letterSpacing: "0.1em" }}>NOTIFICATIONS</span>
               <button type="button" disabled={state.markAllPending} onClick={() => void state.markAllRead()} style={{ fontSize: 9, color: "var(--lag-text-2)", background: "none", border: 0, cursor: "pointer", opacity: state.markAllPending ? 0.45 : 1 }}>{state.markAllPending ? "Saving..." : "모두 읽음"}</button>
             </header>
@@ -166,7 +169,7 @@ export function NotificationBell() {
             {state.inboxError ? <div style={{ padding: "8px 14px" }}><p role="alert" style={{ fontSize: 10, color: "var(--lag-state-error)" }}>{state.inboxError}</p><button type="button" className="lag-button-secondary" onClick={() => void state.inboxRetry()} style={{ fontSize: 9 }}>Retry</button></div> : null}
             {state.mutationError ? <p role="alert" style={{ padding: "8px 14px", fontSize: 10, color: "var(--lag-state-error)" }}>{state.mutationError}</p> : null}
 
-            <div style={{ maxHeight: 360, overflowY: "auto" }}>
+            <div className="lag-notification-list" style={{ maxHeight: 360, minHeight: 0, flex: 1, overflowY: "auto" }}>
               {state.inboxLoading ? <p style={{ padding: "24px 14px", textAlign: "center", fontSize: 11, color: "var(--lag-text-2)" }}>Loading...</p> : null}
               {!state.inboxLoading && state.inboxLoaded && state.inbox.length === 0 ? <p style={{ padding: "24px 14px", textAlign: "center", fontSize: 11, color: "var(--lag-text-2)" }}>알림이 없습니다</p> : null}
               {state.inbox.map((notification) => <NotificationRow key={notification.id} notification={notification} pending={state.pendingId === notification.id} onMarkRead={(id) => void state.markRead(id)} />)}

--- a/features/notification/NotificationBell.tsx
+++ b/features/notification/NotificationBell.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import { AnimatePresence, motion } from "framer-motion";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 
 import type { NotificationInfo, NotificationType } from "@/shared/api/types";
+import { notificationPopupPosition, type FloatingPosition } from "@/shared/lib/viewport";
+import UtilityPortal from "@/shared/ui/UtilityPortal";
 import { useNotifications } from "./useNotifications";
 
 const TYPE_META: Record<NotificationType, { color: string; icon: string; label: string }> = {
@@ -60,11 +62,40 @@ export function NotificationBell() {
   const state = useNotifications();
   const [open, setOpen] = useState(false);
   const panelRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const popupRef = useRef<HTMLDivElement>(null);
+  const [popupPosition, setPopupPosition] = useState<FloatingPosition | null>(null);
+
+  const placePopup = useCallback(() => {
+    const anchor = triggerRef.current?.getBoundingClientRect();
+    const popup = popupRef.current?.getBoundingClientRect();
+    if (!anchor || !popup) return;
+    setPopupPosition(notificationPopupPosition(
+      anchor,
+      { width: popup.width, height: popup.height },
+      { width: window.innerWidth, height: window.innerHeight },
+    ));
+  }, []);
+
+  useLayoutEffect(() => {
+    if (!open) return;
+    placePopup();
+    const observer = typeof ResizeObserver === "undefined" || !popupRef.current
+      ? null
+      : new ResizeObserver(placePopup);
+    if (popupRef.current) observer?.observe(popupRef.current);
+    window.addEventListener("resize", placePopup);
+    return () => {
+      observer?.disconnect();
+      window.removeEventListener("resize", placePopup);
+    };
+  }, [open, placePopup]);
 
   useEffect(() => {
     if (!open) return;
     const close = (event: MouseEvent) => {
-      if (panelRef.current && !panelRef.current.contains(event.target as Node)) setOpen(false);
+      const target = event.target as Node;
+      if (!panelRef.current?.contains(target) && !popupRef.current?.contains(target)) setOpen(false);
     };
     document.addEventListener("mousedown", close);
     return () => document.removeEventListener("mousedown", close);
@@ -78,6 +109,7 @@ export function NotificationBell() {
   return (
     <div ref={panelRef} style={{ position: "relative" }}>
       <motion.button
+        ref={triggerRef}
         type="button"
         onClick={toggle}
         whileHover={{ scale: 1.08 }}
@@ -85,7 +117,7 @@ export function NotificationBell() {
         aria-label={`알림 ${state.unreadCount}건`}
         aria-expanded={open}
         title="Notifications"
-        className="lag-utility-button"
+        className="lag-utility-button lag-notification-trigger"
         style={{
           borderColor: state.unreadCount > 0 || open ? "var(--lag-focus)" : "var(--lag-control-border)",
           background: open ? "var(--lag-selected-surface)" : "var(--lag-control-bg)",
@@ -101,9 +133,11 @@ export function NotificationBell() {
         </AnimatePresence>
       </motion.button>
 
-      <AnimatePresence>
-        {open ? (
+      <UtilityPortal>
+        <AnimatePresence>
+          {open ? (
           <motion.div
+            ref={popupRef}
             role="dialog"
             aria-label="Notifications"
             key="notification-dropdown"
@@ -112,7 +146,16 @@ export function NotificationBell() {
             exit={{ opacity: 0, y: -6, scale: 0.97 }}
             transition={{ type: "spring", stiffness: 400, damping: 32 }}
             className="lag-notification-dropdown"
-            style={{ position: "absolute", top: 42, right: 0, width: 320, borderRadius: "var(--lag-radius-md)", zIndex: 9990, overflow: "hidden" }}
+            style={{
+              position: "fixed",
+              left: popupPosition?.x ?? 16,
+              top: popupPosition?.y ?? 16,
+              width: "min(320px, calc(100vw - 32px))",
+              borderRadius: "var(--lag-radius-md)",
+              zIndex: 600100,
+              overflow: "hidden",
+              visibility: popupPosition ? "visible" : "hidden",
+            }}
           >
             <header style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8, padding: "9px 14px 8px", background: "var(--lag-panel-2)", borderBottom: "1px solid var(--lag-divider)" }}>
               <span style={{ fontSize: 10, fontWeight: 700, color: "var(--lag-text)", letterSpacing: "0.1em" }}>NOTIFICATIONS</span>
@@ -131,8 +174,9 @@ export function NotificationBell() {
             </div>
             <div style={{ height: 2, background: "linear-gradient(90deg, transparent, var(--lag-focus), transparent)" }} />
           </motion.div>
-        ) : null}
-      </AnimatePresence>
+          ) : null}
+        </AnimatePresence>
+      </UtilityPortal>
     </div>
   );
 }

--- a/features/player/AchievementShell.test.tsx
+++ b/features/player/AchievementShell.test.tsx
@@ -22,7 +22,7 @@ describe("Current Player Achievement surface를 사용할 때", () => {
     api.getPlayerAchievementApi.mockResolvedValue(detail);
   });
 
-  it("선택 전에는 detail stage가 없고 선택 replacement identity를 바꾼다", async () => {
+  it("선택 전에는 detail stage가 없고 선택 replacement 때 frame identity를 유지한다", async () => {
     api.getPlayerAchievementsApi.mockResolvedValue([listItem, secondListItem]);
     api.getPlayerAchievementApi.mockImplementation(async (id: number) => ({ ...detail, achievementId: id }));
     render(<AchievementShell />);
@@ -31,10 +31,11 @@ describe("Current Player Achievement surface를 사용할 때", () => {
     expect(screen.queryByText("Achievement Detail")).not.toBeInTheDocument();
 
     fireEvent.click(entries[0]);
-    expect(document.querySelector('[data-stage-key="player-achievement-detail-31"]')).toBeInTheDocument();
+    const detailStage = document.querySelector('[data-stage-key="player-achievement-detail"]');
+    expect(detailStage).toBeInTheDocument();
 
     fireEvent.click(entries[1]);
-    expect(document.querySelector('[data-stage-key="player-achievement-detail-32"]')).toBeInTheDocument();
+    expect(document.querySelector('[data-stage-key="player-achievement-detail"]')).toBe(detailStage);
   });
 
   it("acquired list/detail fields와 empty state만 렌더하고 fabricated rows는 만들지 않는다", async () => {

--- a/features/player/AchievementShell.tsx
+++ b/features/player/AchievementShell.tsx
@@ -58,8 +58,8 @@ export default function AchievementShell() {
 
       <AnimatePresence initial={false} mode="popLayout">
         {achievements.selectedId ? (
-          <PanelStage key={`player-achievement-detail-${achievements.selectedId}`} stageKey={`player-achievement-detail-${achievements.selectedId}`} index={1}>
-            <PanelFrame title="Achievement Detail" depth={0}>
+          <PanelStage key="player-achievement-detail" stageKey="player-achievement-detail" focusKey={achievements.selectedId} index={1}>
+            <PanelFrame title="Achievement Detail" depth={0} contentKey={achievements.selectedId}>
               {achievements.detail.loading && !detail ? <InfoCard>Loading Achievement...</InfoCard> : null}
               {achievements.detail.error ? <ErrorState message={achievements.detail.error} retry={() => void achievements.detail.retry()} /> : null}
               {detail ? (

--- a/features/player/AchievementShell.tsx
+++ b/features/player/AchievementShell.tsx
@@ -4,7 +4,8 @@ import { AnimatePresence } from "framer-motion";
 
 import PanelCard from "@/shared/ui/PanelCard";
 import PanelStage from "@/shared/ui/PanelStage";
-import { PanelFrame } from "@/widgets/right-panels/ui/PanelFrame";
+import { requestStageFocus } from "@/shared/hooks/useStageCamera";
+import { BackButton, PanelFrame } from "@/widgets/right-panels/ui/PanelFrame";
 import { GoldRow, InfoCard } from "@/widgets/right-panels/ui/Rows";
 import { useAchievementQueries } from "./useAchievementQueries";
 
@@ -27,14 +28,14 @@ function ErrorState({ message, retry }: { message: string; retry: () => void }) 
   );
 }
 
-export default function AchievementShell() {
+export default function AchievementShell({ onBack }: { onBack?: () => void }) {
   const achievements = useAchievementQueries();
   const detail = achievements.detail.data;
 
   return (
     <div className="lag-panel-rail relative" data-testid="achievement-shell">
       <PanelStage stageKey="player-achievement-list">
-        <PanelFrame title="Acquired Achievements" depth={1}>
+        <PanelFrame title="Acquired Achievements" depth={1} backButton={onBack ? <BackButton label="Back to Player" onClick={onBack} /> : undefined}>
         <div className="space-y-3">
           {achievements.list.loading && achievements.list.items.length === 0 ? <InfoCard>Loading Achievements...</InfoCard> : null}
           {achievements.list.error ? <ErrorState message={achievements.list.error} retry={() => void achievements.list.reload()} /> : null}
@@ -59,7 +60,10 @@ export default function AchievementShell() {
       <AnimatePresence initial={false} mode="popLayout">
         {achievements.selectedId ? (
           <PanelStage key="player-achievement-detail" stageKey="player-achievement-detail" focusKey={achievements.selectedId} index={1}>
-            <PanelFrame title="Achievement Detail" depth={0} contentKey={achievements.selectedId}>
+            <PanelFrame title="Achievement Detail" depth={0} contentKey={achievements.selectedId} backButton={<BackButton label="Back to Acquired Achievements" onClick={() => {
+              achievements.clearSelection();
+              requestStageFocus("player-achievement-list", "center");
+            }} />}>
               {achievements.detail.loading && !detail ? <InfoCard>Loading Achievement...</InfoCard> : null}
               {achievements.detail.error ? <ErrorState message={achievements.detail.error} retry={() => void achievements.detail.retry()} /> : null}
               {detail ? (

--- a/features/player/CertificationShell.test.tsx
+++ b/features/player/CertificationShell.test.tsx
@@ -1,8 +1,9 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { readFileSync } from "node:fs";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { CertificationCatalogInfo, PlayerCertificationInfo } from "@/shared/api/types";
+import { STAGE_FOCUS_EVENT } from "@/shared/hooks/useStageCamera";
 import CertificationShell from "./CertificationShell";
 
 const api = vi.hoisted(() => ({
@@ -24,6 +25,7 @@ const catalog: CertificationCatalogInfo[] = [
 ];
 const owned: PlayerCertificationInfo = { ...catalog[0], acquiredDate: null, expiresDate: null, grantedAt: "2026-08-01T00:00:00Z" };
 const reloaded = { ...owned, expiresDate: "2027-08-01" };
+const devopsOwned: PlayerCertificationInfo = { ...catalog[1], acquiredDate: "2026-08-10", expiresDate: null, grantedAt: "2026-08-10T00:00:00Z" };
 
 describe("Certification management surface를 사용할 때", () => {
   beforeEach(() => {
@@ -59,8 +61,49 @@ describe("Certification management surface를 사용할 때", () => {
 
   it("uses v7 semantic control tokens instead of the legacy input palette", () => {
     const source = readFileSync("features/player/CertificationShell.tsx", "utf8");
+    const styles = readFileSync("shared/design/styles.ts", "utf8");
+    const semanticControl = styles.slice(styles.indexOf("SEMANTIC_CONTROL_STYLE"), styles.indexOf("INPUT_FOCUS_STYLE"));
     expect(source).toContain("SEMANTIC_CONTROL_STYLE");
     expect(source).toContain("var(--lag-control-bg)");
     expect(source).not.toContain("INPUT_STYLE");
+    expect(semanticControl).not.toContain("outline");
+  });
+
+  it("catalog category를 즉시 필터링하고 제외된 detail을 닫은 뒤 list에 focus한다", async () => {
+    api.getPlayerCertificationsApi.mockReset().mockResolvedValue([owned, devopsOwned]);
+    const focus = vi.fn();
+    window.addEventListener(STAGE_FOCUS_EVENT, focus);
+    render(<CertificationShell />);
+
+    const entries = await screen.findAllByTestId("certification-entry");
+    fireEvent.click(entries[0]);
+    expect(document.querySelector('[data-stage-key="player-certification-detail"]')).toBeInTheDocument();
+    focus.mockClear();
+
+    fireEvent.change(screen.getByLabelText("Certification category"), { target: { value: "DevOps" } });
+    const list = document.querySelector('[data-stage-key="player-certification-list"]') as HTMLElement;
+    expect(within(list).queryByText(/AWS/)).not.toBeInTheDocument();
+    expect(within(list).getByText(/Kubernetes/)).toBeInTheDocument();
+    await waitFor(() => expect(document.querySelector('[data-stage-key="player-certification-detail"]')).not.toBeInTheDocument());
+    expect(focus.mock.calls.at(-1)?.[0]).toMatchObject({ detail: { key: "player-certification-list" } });
+
+    fireEvent.change(screen.getByLabelText("Certification category"), { target: { value: "ALL" } });
+    expect(within(list).getByText(/AWS/)).toBeInTheDocument();
+    expect(within(list).getByText(/Kubernetes/)).toBeInTheDocument();
+    expect(screen.getByLabelText("Certification")).not.toBe(screen.getByLabelText("Certification category"));
+    window.removeEventListener(STAGE_FOCUS_EVENT, focus);
+  });
+
+  it("detail Back은 선택을 닫고 list stage로 복귀한다", async () => {
+    const focus = vi.fn();
+    window.addEventListener(STAGE_FOCUS_EVENT, focus);
+    render(<CertificationShell />);
+    fireEvent.click(await screen.findByTestId("certification-entry"));
+
+    fireEvent.click(screen.getByRole("button", { name: "Back to My Certifications" }));
+
+    await waitFor(() => expect(document.querySelector('[data-stage-key="player-certification-detail"]')).not.toBeInTheDocument());
+    expect(focus.mock.calls.at(-1)?.[0]).toMatchObject({ detail: { key: "player-certification-list", align: "center" } });
+    window.removeEventListener(STAGE_FOCUS_EVENT, focus);
   });
 });

--- a/features/player/CertificationShell.test.tsx
+++ b/features/player/CertificationShell.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { readFileSync } from "node:fs";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { CertificationCatalogInfo, PlayerCertificationInfo } from "@/shared/api/types";
@@ -54,5 +55,12 @@ describe("Certification management surface를 사용할 때", () => {
     expect(api.updatePlayerCertificationApi.mock.calls[0][1]).not.toHaveProperty("acquiredDate");
     expect(api.updatePlayerCertificationApi.mock.calls[0][1]).not.toEqual(expect.objectContaining({ expiresDate: "" }));
     expect(screen.getByText("Blank dates preserve current values; dates cannot be cleared.")).toBeInTheDocument();
+  });
+
+  it("uses v7 semantic control tokens instead of the legacy input palette", () => {
+    const source = readFileSync("features/player/CertificationShell.tsx", "utf8");
+    expect(source).toContain("SEMANTIC_CONTROL_STYLE");
+    expect(source).toContain("var(--lag-control-bg)");
+    expect(source).not.toContain("INPUT_STYLE");
   });
 });

--- a/features/player/CertificationShell.tsx
+++ b/features/player/CertificationShell.tsx
@@ -1,13 +1,14 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { AnimatePresence } from "framer-motion";
 
 import type { PlayerCertificationDatesRequest } from "@/shared/api/types";
 import { SEMANTIC_CONTROL_STYLE } from "@/shared/design/tokens";
+import { requestStageFocus } from "@/shared/hooks/useStageCamera";
 import PanelCard from "@/shared/ui/PanelCard";
 import PanelStage from "@/shared/ui/PanelStage";
-import { PanelFrame } from "@/widgets/right-panels/ui/PanelFrame";
+import { BackButton, PanelFrame } from "@/widgets/right-panels/ui/PanelFrame";
 import { GoldRow, InfoCard } from "@/widgets/right-panels/ui/Rows";
 import { useCertificationQueries } from "./useCertificationQueries";
 
@@ -43,21 +44,47 @@ function ErrorState({ message, retry }: { message: string; retry: () => void }) 
   );
 }
 
-export default function CertificationShell() {
+export default function CertificationShell({ onBack }: { onBack?: () => void }) {
   const certifications = useCertificationQueries();
   const [catalogId, setCatalogId] = useState("");
+  const [category, setCategory] = useState("ALL");
   const pending = certifications.pendingMutation !== null;
   const available = certifications.catalog.items.filter((item) => !certifications.owned.items.some((owned) => owned.certificationId === item.certificationId));
-  const selected = certifications.selected;
+  const categories = [...new Set(certifications.catalog.items.map((item) => item.category))].sort();
+  const filteredOwned = category === "ALL"
+    ? certifications.owned.items
+    : certifications.owned.items.filter((item) => item.category === category);
+  const selectedCertification = certifications.selected;
+  const clearSelection = certifications.clearSelection;
+  const selected = selectedCertification && (category === "ALL" || selectedCertification.category === category)
+    ? selectedCertification
+    : null;
+
+  useEffect(() => {
+    if (selectedCertification && !selected) clearSelection();
+  }, [clearSelection, selected, selectedCertification]);
+
+  const changeCategory = (next: string) => {
+    setCategory(next);
+    if (selectedCertification && next !== "ALL" && selectedCertification.category !== next) clearSelection();
+  };
 
   return (
     <div className="lag-panel-rail lag-semantic-controls relative" data-testid="certification-shell">
       <PanelStage stageKey="player-certification-catalog">
-        <PanelFrame title="Certification Catalog" depth={2}>
+        <PanelFrame title="Certification Catalog" depth={2} backButton={onBack ? <BackButton label="Back to Player" onClick={onBack} /> : undefined}>
         <div className="space-y-3 px-3">
           {certifications.catalog.loading && certifications.catalog.items.length === 0 ? <InfoCard>Loading Certification catalog...</InfoCard> : null}
           {certifications.catalog.error ? <ErrorState message={certifications.catalog.error} retry={() => void certifications.catalog.retry()} /> : null}
           {!certifications.catalog.loading && !certifications.catalog.error ? (
+            <>
+            <label className="block text-xs" style={{ color: "var(--lag-text-2)" }}>
+              Certification category
+              <select aria-label="Certification category" value={category} onChange={(event) => changeCategory(event.target.value)} style={SEMANTIC_CONTROL_STYLE}>
+                <option value="ALL">All categories</option>
+                {categories.map((item) => <option key={item} value={item}>{item}</option>)}
+              </select>
+            </label>
             <form className="space-y-2" onSubmit={async (event) => {
               event.preventDefault();
               const element = event.currentTarget;
@@ -78,20 +105,22 @@ export default function CertificationShell() {
               <label className="block text-xs" style={{ color: "var(--lag-text-2)" }}>Expires date<input name="expiresDate" type="date" disabled={pending} style={SEMANTIC_CONTROL_STYLE} /></label>
               <button type="submit" disabled={pending || available.length === 0} style={buttonStyle}>{pending ? "Working..." : "Register Certification"}</button>
             </form>
+            </>
           ) : null}
         </div>
         </PanelFrame>
       </PanelStage>
 
-      <PanelStage stageKey="player-certification-list" index={1}>
-        <PanelFrame title="My Certifications" depth={1}>
+      <PanelStage stageKey="player-certification-list" focusKey={category} index={1}>
+        <PanelFrame title="My Certifications" depth={1} backButton={onBack ? <BackButton label="Back to Player" onClick={onBack} /> : undefined}>
         <div className="space-y-3">
           {certifications.owned.loading && certifications.owned.items.length === 0 ? <InfoCard>Loading Certifications...</InfoCard> : null}
           {certifications.owned.error ? <ErrorState message={certifications.owned.error} retry={() => void certifications.owned.reload()} /> : null}
           {!certifications.owned.loading && !certifications.owned.error && certifications.owned.items.length === 0 ? <InfoCard>No owned Certifications.</InfoCard> : null}
+          {!certifications.owned.loading && !certifications.owned.error && certifications.owned.items.length > 0 && filteredOwned.length === 0 ? <InfoCard>No matching Certifications.</InfoCard> : null}
           {certifications.mutationError ? <p role="alert" className="px-3 text-xs" style={{ color: "var(--lag-state-error)" }}>{certifications.mutationError}</p> : null}
           <div className="space-y-2">
-            {certifications.owned.items.map((item, index) => (
+            {filteredOwned.map((item, index) => (
               <PanelCard key={item.certificationId} label={item.name} slotLabel={item.category.slice(0, 2).toUpperCase()} subtitle={`${item.issuer} · Acquired: ${item.acquiredDate ?? "Not recorded"}`} selected={certifications.selectedId === item.certificationId} index={index} onClick={() => certifications.select(item.certificationId)} />
             ))}
           </div>
@@ -102,7 +131,10 @@ export default function CertificationShell() {
       <AnimatePresence initial={false} mode="popLayout">
         {selected ? (
           <PanelStage key="player-certification-detail" stageKey="player-certification-detail" focusKey={selected.certificationId} index={2}>
-            <PanelFrame title="Certification Detail" depth={0} contentKey={selected.certificationId}>
+            <PanelFrame title="Certification Detail" depth={0} contentKey={selected.certificationId} backButton={<BackButton label="Back to My Certifications" onClick={() => {
+              clearSelection();
+              requestStageFocus("player-certification-list", "center");
+            }} />}>
               <div className="space-y-3 px-3">
             <InfoCard>{selected.name}</InfoCard>
             <GoldRow>Issuer: {selected.issuer}</GoldRow>

--- a/features/player/CertificationShell.tsx
+++ b/features/player/CertificationShell.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { AnimatePresence } from "framer-motion";
 
 import type { PlayerCertificationDatesRequest } from "@/shared/api/types";
-import { INPUT_STYLE, SAO } from "@/shared/design/tokens";
+import { SEMANTIC_CONTROL_STYLE } from "@/shared/design/tokens";
 import PanelCard from "@/shared/ui/PanelCard";
 import PanelStage from "@/shared/ui/PanelStage";
 import { PanelFrame } from "@/widgets/right-panels/ui/PanelFrame";
@@ -12,10 +12,10 @@ import { GoldRow, InfoCard } from "@/widgets/right-panels/ui/Rows";
 import { useCertificationQueries } from "./useCertificationQueries";
 
 const buttonStyle = {
-  border: `1px solid ${SAO.color.border.panel}`,
-  background: SAO.color.bg.inset,
-  color: SAO.color.text.secondary,
-  borderRadius: SAO.radius.panel,
+  border: "1px solid var(--lag-control-border)",
+  background: "var(--lag-control-bg)",
+  color: "var(--lag-control-text)",
+  borderRadius: "var(--lag-radius-sm)",
   padding: "7px 10px",
   fontSize: "0.68rem",
   letterSpacing: "0.08em",
@@ -37,7 +37,7 @@ function dates(form: FormData): PlayerCertificationDatesRequest {
 function ErrorState({ message, retry }: { message: string; retry: () => void }) {
   return (
     <div className="space-y-2 px-3">
-      <p role="alert" className="text-xs" style={{ color: SAO.color.action.red }}>{message}</p>
+      <p role="alert" className="text-xs" style={{ color: "var(--lag-state-error)" }}>{message}</p>
       <button type="button" style={buttonStyle} onClick={retry}>Retry</button>
     </div>
   );
@@ -51,7 +51,7 @@ export default function CertificationShell() {
   const selected = certifications.selected;
 
   return (
-    <div className="lag-panel-rail relative" data-testid="certification-shell">
+    <div className="lag-panel-rail lag-semantic-controls relative" data-testid="certification-shell">
       <PanelStage stageKey="player-certification-catalog">
         <PanelFrame title="Certification Catalog" depth={2}>
         <div className="space-y-3 px-3">
@@ -67,15 +67,15 @@ export default function CertificationShell() {
                 setCatalogId("");
               }
             }}>
-              <label className="block text-xs" style={{ color: SAO.color.text.label }}>
+              <label className="block text-xs" style={{ color: "var(--lag-text-2)" }}>
                 Certification
-                <select aria-label="Certification" value={catalogId} onChange={(event) => setCatalogId(event.target.value)} required disabled={pending} style={INPUT_STYLE}>
+                <select aria-label="Certification" value={catalogId} onChange={(event) => setCatalogId(event.target.value)} required disabled={pending} style={SEMANTIC_CONTROL_STYLE}>
                   <option value="">Select...</option>
                   {available.map((item) => <option key={item.certificationId} value={item.certificationId}>{item.name} · {item.issuer}</option>)}
                 </select>
               </label>
-              <label className="block text-xs" style={{ color: SAO.color.text.label }}>Acquired date<input name="acquiredDate" type="date" disabled={pending} style={INPUT_STYLE} /></label>
-              <label className="block text-xs" style={{ color: SAO.color.text.label }}>Expires date<input name="expiresDate" type="date" disabled={pending} style={INPUT_STYLE} /></label>
+              <label className="block text-xs" style={{ color: "var(--lag-text-2)" }}>Acquired date<input name="acquiredDate" type="date" disabled={pending} style={SEMANTIC_CONTROL_STYLE} /></label>
+              <label className="block text-xs" style={{ color: "var(--lag-text-2)" }}>Expires date<input name="expiresDate" type="date" disabled={pending} style={SEMANTIC_CONTROL_STYLE} /></label>
               <button type="submit" disabled={pending || available.length === 0} style={buttonStyle}>{pending ? "Working..." : "Register Certification"}</button>
             </form>
           ) : null}
@@ -89,7 +89,7 @@ export default function CertificationShell() {
           {certifications.owned.loading && certifications.owned.items.length === 0 ? <InfoCard>Loading Certifications...</InfoCard> : null}
           {certifications.owned.error ? <ErrorState message={certifications.owned.error} retry={() => void certifications.owned.reload()} /> : null}
           {!certifications.owned.loading && !certifications.owned.error && certifications.owned.items.length === 0 ? <InfoCard>No owned Certifications.</InfoCard> : null}
-          {certifications.mutationError ? <p role="alert" className="px-3 text-xs" style={{ color: SAO.color.action.red }}>{certifications.mutationError}</p> : null}
+          {certifications.mutationError ? <p role="alert" className="px-3 text-xs" style={{ color: "var(--lag-state-error)" }}>{certifications.mutationError}</p> : null}
           <div className="space-y-2">
             {certifications.owned.items.map((item, index) => (
               <PanelCard key={item.certificationId} label={item.name} slotLabel={item.category.slice(0, 2).toUpperCase()} subtitle={`${item.issuer} · Acquired: ${item.acquiredDate ?? "Not recorded"}`} selected={certifications.selectedId === item.certificationId} index={index} onClick={() => certifications.select(item.certificationId)} />
@@ -101,8 +101,8 @@ export default function CertificationShell() {
 
       <AnimatePresence initial={false} mode="popLayout">
         {selected ? (
-          <PanelStage key={`player-certification-detail-${selected.certificationId}`} stageKey={`player-certification-detail-${selected.certificationId}`} index={2}>
-            <PanelFrame title="Certification Detail" depth={0}>
+          <PanelStage key="player-certification-detail" stageKey="player-certification-detail" focusKey={selected.certificationId} index={2}>
+            <PanelFrame title="Certification Detail" depth={0} contentKey={selected.certificationId}>
               <div className="space-y-3 px-3">
             <InfoCard>{selected.name}</InfoCard>
             <GoldRow>Issuer: {selected.issuer}</GoldRow>
@@ -115,9 +115,9 @@ export default function CertificationShell() {
               const body = dates(new FormData(event.currentTarget));
               if (Object.keys(body).length > 0) void certifications.update(selected.certificationId, body);
             }}>
-              <label className="block text-xs" style={{ color: SAO.color.text.label }}>New acquired date<input name="acquiredDate" type="date" disabled={pending} style={INPUT_STYLE} /></label>
-              <label className="block text-xs" style={{ color: SAO.color.text.label }}>New expires date<input name="expiresDate" type="date" disabled={pending} style={INPUT_STYLE} /></label>
-              <p className="text-xs" style={{ color: SAO.color.text.label }}>Blank dates preserve current values; dates cannot be cleared.</p>
+              <label className="block text-xs" style={{ color: "var(--lag-text-2)" }}>New acquired date<input name="acquiredDate" type="date" disabled={pending} style={SEMANTIC_CONTROL_STYLE} /></label>
+              <label className="block text-xs" style={{ color: "var(--lag-text-2)" }}>New expires date<input name="expiresDate" type="date" disabled={pending} style={SEMANTIC_CONTROL_STYLE} /></label>
+              <p className="text-xs" style={{ color: "var(--lag-text-2)" }}>Blank dates preserve current values; dates cannot be cleared.</p>
               <div className="flex gap-2">
                 <button type="submit" disabled={pending} style={{ ...buttonStyle, flex: 1 }}>{pending ? "Working..." : "Update Dates"}</button>
                 <button type="button" disabled={pending} style={buttonStyle} onClick={() => {

--- a/features/player/GrowthShell.tsx
+++ b/features/player/GrowthShell.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { PanelFrame } from "@/widgets/right-panels/ui/PanelFrame";
+import { BackButton, PanelFrame } from "@/widgets/right-panels/ui/PanelFrame";
 import { GoldRow, InfoCard } from "@/widgets/right-panels/ui/Rows";
 import PanelStage from "@/shared/ui/PanelStage";
 import { useGrowthQuery } from "./useGrowthQuery";
@@ -10,7 +10,7 @@ const CORE_STATS = [
   ["INT", "intel"], ["VIT", "vit"], ["LUC", "luc"],
 ] as const;
 
-export default function GrowthShell() {
+export default function GrowthShell({ onBack }: { onBack?: () => void }) {
   const growth = useGrowthQuery();
   const current = growth.data?.current;
   const changes = growth.data?.recentExpChanges ?? [];
@@ -18,7 +18,7 @@ export default function GrowthShell() {
   return (
     <div className="lag-panel-rail relative" data-testid="growth-shell">
       <PanelStage stageKey="player-growth-current">
-        <PanelFrame title="Current Growth" depth={1}>
+        <PanelFrame title="Current Growth" depth={1} backButton={onBack ? <BackButton label="Back to Player" onClick={onBack} /> : undefined}>
         <div className="space-y-2 px-3">
           {growth.loading && !growth.data ? <InfoCard>Loading Growth...</InfoCard> : null}
           {growth.error ? <><p role="alert" className="text-xs text-red-400">{growth.error}</p><button type="button" onClick={() => void growth.retry()}>Retry</button></> : null}

--- a/features/player/GrowthShell.tsx
+++ b/features/player/GrowthShell.tsx
@@ -2,6 +2,7 @@
 
 import { PanelFrame } from "@/widgets/right-panels/ui/PanelFrame";
 import { GoldRow, InfoCard } from "@/widgets/right-panels/ui/Rows";
+import PanelStage from "@/shared/ui/PanelStage";
 import { useGrowthQuery } from "./useGrowthQuery";
 
 const CORE_STATS = [
@@ -15,8 +16,9 @@ export default function GrowthShell() {
   const changes = growth.data?.recentExpChanges ?? [];
 
   return (
-    <div className="relative flex min-w-0 w-fit flex-row flex-nowrap items-center gap-3" data-testid="growth-shell">
-      <PanelFrame title="Current Growth" depth={1}>
+    <div className="lag-panel-rail relative" data-testid="growth-shell">
+      <PanelStage stageKey="player-growth-current">
+        <PanelFrame title="Current Growth" depth={1}>
         <div className="space-y-2 px-3">
           {growth.loading && !growth.data ? <InfoCard>Loading Growth...</InfoCard> : null}
           {growth.error ? <><p role="alert" className="text-xs text-red-400">{growth.error}</p><button type="button" onClick={() => void growth.retry()}>Retry</button></> : null}
@@ -28,9 +30,11 @@ export default function GrowthShell() {
             {Object.entries(current.extraStats).map(([name, value]) => <GoldRow key={name}>{name}: {value}</GoldRow>)}
           </> : null}
         </div>
-      </PanelFrame>
+        </PanelFrame>
+      </PanelStage>
 
-      <PanelFrame title="Recent EXP Changes" depth={0}>
+      <PanelStage stageKey="player-growth-history" index={1}>
+        <PanelFrame title="Recent EXP Changes" depth={0}>
         <div className="space-y-3 px-3">
           {growth.data && changes.length === 0 ? <InfoCard>No recent EXP changes.</InfoCard> : null}
           {changes.map((change) => (
@@ -48,7 +52,8 @@ export default function GrowthShell() {
             </InfoCard>
           ))}
         </div>
-      </PanelFrame>
+        </PanelFrame>
+      </PanelStage>
     </div>
   );
 }

--- a/features/player/HobbyShell.tsx
+++ b/features/player/HobbyShell.tsx
@@ -7,7 +7,8 @@ import type { HobbyStatus, PlayerHobbyMutationRequest } from "@/shared/api/types
 import { INPUT_STYLE, SAO } from "@/shared/design/tokens";
 import PanelCard from "@/shared/ui/PanelCard";
 import PanelStage from "@/shared/ui/PanelStage";
-import { PanelFrame } from "@/widgets/right-panels/ui/PanelFrame";
+import { requestStageFocus } from "@/shared/hooks/useStageCamera";
+import { BackButton, PanelFrame } from "@/widgets/right-panels/ui/PanelFrame";
 import { GoldRow, InfoCard } from "@/widgets/right-panels/ui/Rows";
 import { useHobbyQueries } from "./useHobbyQueries";
 
@@ -41,7 +42,7 @@ function ErrorState({ message, retry }: { message: string; retry: () => void }) 
   return <div className="space-y-2 px-3"><p role="alert" className="text-xs" style={{ color: SAO.color.action.red }}>{message}</p><button type="button" style={buttonStyle} onClick={retry}>Retry</button></div>;
 }
 
-export default function HobbyShell() {
+export default function HobbyShell({ onBack }: { onBack?: () => void }) {
   const hobbies = useHobbyQueries();
   const [catalogId, setCatalogId] = useState("");
   const pending = hobbies.pendingMutation !== null;
@@ -51,7 +52,7 @@ export default function HobbyShell() {
   return (
     <div className="lag-panel-rail relative" data-testid="hobby-shell">
       <PanelStage stageKey="player-hobby-catalog">
-        <PanelFrame title="Hobby Catalog" depth={2}>
+        <PanelFrame title="Hobby Catalog" depth={2} backButton={onBack ? <BackButton label="Back to Player" onClick={onBack} /> : undefined}>
         <div className="space-y-3 px-3">
           {hobbies.catalog.loading && hobbies.catalog.items.length === 0 ? <InfoCard>Loading Hobby catalog...</InfoCard> : null}
           {hobbies.catalog.error ? <ErrorState message={hobbies.catalog.error} retry={() => void hobbies.catalog.retry()} /> : null}
@@ -76,7 +77,7 @@ export default function HobbyShell() {
       </PanelStage>
 
       <PanelStage stageKey="player-hobby-list" index={1}>
-        <PanelFrame title="My Hobbies" depth={1}>
+        <PanelFrame title="My Hobbies" depth={1} backButton={onBack ? <BackButton label="Back to Player" onClick={onBack} /> : undefined}>
         <div className="space-y-3">
           {hobbies.owned.loading && hobbies.owned.items.length === 0 ? <InfoCard>Loading Hobbies...</InfoCard> : null}
           {hobbies.owned.error ? <ErrorState message={hobbies.owned.error} retry={() => void hobbies.owned.reload()} /> : null}
@@ -90,7 +91,10 @@ export default function HobbyShell() {
       <AnimatePresence initial={false} mode="popLayout">
         {selected ? (
           <PanelStage key="player-hobby-detail" stageKey="player-hobby-detail" focusKey={selected.hobbyId} index={2}>
-            <PanelFrame title="Hobby Detail" depth={0} contentKey={selected.hobbyId}>
+            <PanelFrame title="Hobby Detail" depth={0} contentKey={selected.hobbyId} backButton={<BackButton label="Back to My Hobbies" onClick={() => {
+              hobbies.clearSelection();
+              requestStageFocus("player-hobby-list", "center");
+            }} />}>
               <div className="space-y-3 px-3">
             <InfoCard>{selected.customName}</InfoCard>
             <GoldRow>Hobby: {selected.name}</GoldRow><GoldRow>Category: {selected.category}</GoldRow><GoldRow>Status: {selected.status}</GoldRow><GoldRow>Proficiency: {selected.proficiency}/100</GoldRow><GoldRow>Started: {selected.startedOn ?? "Not recorded"}</GoldRow><GoldRow>XP: {selected.xp}</GoldRow><InfoCard label="Detail">{selected.detail ?? "Not recorded"}</InfoCard>

--- a/features/player/HobbyShell.tsx
+++ b/features/player/HobbyShell.tsx
@@ -89,8 +89,8 @@ export default function HobbyShell() {
 
       <AnimatePresence initial={false} mode="popLayout">
         {selected ? (
-          <PanelStage key={`player-hobby-detail-${selected.hobbyId}`} stageKey={`player-hobby-detail-${selected.hobbyId}`} index={2}>
-            <PanelFrame title="Hobby Detail" depth={0}>
+          <PanelStage key="player-hobby-detail" stageKey="player-hobby-detail" focusKey={selected.hobbyId} index={2}>
+            <PanelFrame title="Hobby Detail" depth={0} contentKey={selected.hobbyId}>
               <div className="space-y-3 px-3">
             <InfoCard>{selected.customName}</InfoCard>
             <GoldRow>Hobby: {selected.name}</GoldRow><GoldRow>Category: {selected.category}</GoldRow><GoldRow>Status: {selected.status}</GoldRow><GoldRow>Proficiency: {selected.proficiency}/100</GoldRow><GoldRow>Started: {selected.startedOn ?? "Not recorded"}</GoldRow><GoldRow>XP: {selected.xp}</GoldRow><InfoCard label="Detail">{selected.detail ?? "Not recorded"}</InfoCard>

--- a/features/player/TitleShell.test.tsx
+++ b/features/player/TitleShell.test.tsx
@@ -26,7 +26,7 @@ describe("Title surface와 routing을 사용할 때", () => {
     api.getPlayerTitlesApi.mockResolvedValue([title]);
   });
 
-  it("선택 전에는 detail stage가 없고 선택 교체 시 transition identity를 바꾼다", async () => {
+  it("선택 전에는 detail stage가 없고 선택 교체 시 frame identity를 유지한다", async () => {
     api.getPlayerTitlesApi.mockResolvedValue([title, secondTitle]);
     render(<TitleShell />);
 
@@ -34,10 +34,12 @@ describe("Title surface와 routing을 사용할 때", () => {
     expect(screen.queryByText("Title Detail")).not.toBeInTheDocument();
 
     fireEvent.click(entries[0]);
-    expect(document.querySelector('[data-stage-key="player-title-detail-1"]')).toBeInTheDocument();
+    const detailStage = document.querySelector('[data-stage-key="player-title-detail"]');
+    expect(detailStage).toBeInTheDocument();
 
     fireEvent.click(entries[1]);
-    expect(document.querySelector('[data-stage-key="player-title-detail-2"]')).toBeInTheDocument();
+    expect(document.querySelector('[data-stage-key="player-title-detail"]')).toBe(detailStage);
+    expect(screen.getByText("Beater")).toBeInTheDocument();
   });
 
   it("acquired fields와 representative marker를 표시하고 fabricated state는 만들지 않는다", async () => {

--- a/features/player/TitleShell.test.tsx
+++ b/features/player/TitleShell.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { PlayerTitleInfo } from "@/shared/api/types";
@@ -31,7 +31,7 @@ describe("Title surface와 routing을 사용할 때", () => {
     render(<TitleShell />);
 
     const entries = await screen.findAllByTestId("title-entry");
-    expect(screen.queryByText("Title Detail")).not.toBeInTheDocument();
+    expect(document.querySelector('[data-stage-key="player-title-detail"]')).not.toBeInTheDocument();
 
     fireEvent.click(entries[0]);
     const detailStage = document.querySelector('[data-stage-key="player-title-detail"]');
@@ -39,7 +39,7 @@ describe("Title surface와 routing을 사용할 때", () => {
 
     fireEvent.click(entries[1]);
     expect(document.querySelector('[data-stage-key="player-title-detail"]')).toBe(detailStage);
-    expect(screen.getByText("Beater")).toBeInTheDocument();
+    expect(within(detailStage as HTMLElement).getByText("Beater")).toBeInTheDocument();
   });
 
   it("acquired fields와 representative marker를 표시하고 fabricated state는 만들지 않는다", async () => {

--- a/features/player/TitleShell.tsx
+++ b/features/player/TitleShell.tsx
@@ -64,8 +64,8 @@ export default function TitleShell() {
 
       <AnimatePresence initial={false} mode="popLayout">
         {selected ? (
-          <PanelStage key={`player-title-detail-${selected.titleId}`} stageKey={`player-title-detail-${selected.titleId}`} index={1}>
-            <PanelFrame title="Title Detail" depth={0}>
+          <PanelStage key="player-title-detail" stageKey="player-title-detail" focusKey={selected.titleId} index={1}>
+            <PanelFrame title="Title Detail" depth={0} contentKey={selected.titleId}>
               <div className="space-y-3 px-3">
                 <InfoCard>{selected.name}</InfoCard>
                 <GoldRow>Code: {selected.code}</GoldRow>

--- a/features/player/TitleShell.tsx
+++ b/features/player/TitleShell.tsx
@@ -4,7 +4,8 @@ import { AnimatePresence } from "framer-motion";
 
 import PanelCard from "@/shared/ui/PanelCard";
 import PanelStage from "@/shared/ui/PanelStage";
-import { PanelFrame } from "@/widgets/right-panels/ui/PanelFrame";
+import { requestStageFocus } from "@/shared/hooks/useStageCamera";
+import { BackButton, PanelFrame } from "@/widgets/right-panels/ui/PanelFrame";
 import { GoldRow, InfoCard } from "@/widgets/right-panels/ui/Rows";
 import { useTitleQueries } from "./useTitleQueries";
 
@@ -27,7 +28,7 @@ function ErrorState({ message, retry }: { message: string; retry: () => void }) 
   );
 }
 
-export default function TitleShell() {
+export default function TitleShell({ onBack }: { onBack?: () => void }) {
   const titles = useTitleQueries();
   const selected = titles.selected;
   const representative = titles.representativeTitleId;
@@ -36,7 +37,7 @@ export default function TitleShell() {
   return (
     <div className="lag-panel-rail relative" data-testid="title-shell">
       <PanelStage stageKey="player-title-list">
-        <PanelFrame title="Acquired Titles" depth={1}>
+        <PanelFrame title="Acquired Titles" depth={1} backButton={onBack ? <BackButton label="Back to Player" onClick={onBack} /> : undefined}>
         <div className="space-y-3">
           {titles.player.loading && !titles.player.data ? <InfoCard>Loading Current Player...</InfoCard> : null}
           {titles.player.error ? <ErrorState message={titles.player.error} retry={() => void titles.player.reload()} /> : null}
@@ -65,7 +66,10 @@ export default function TitleShell() {
       <AnimatePresence initial={false} mode="popLayout">
         {selected ? (
           <PanelStage key="player-title-detail" stageKey="player-title-detail" focusKey={selected.titleId} index={1}>
-            <PanelFrame title="Title Detail" depth={0} contentKey={selected.titleId}>
+            <PanelFrame title="Title Detail" depth={0} contentKey={selected.titleId} backButton={<BackButton label="Back to Acquired Titles" onClick={() => {
+              titles.clearSelection();
+              requestStageFocus("player-title-list", "center");
+            }} />}>
               <div className="space-y-3 px-3">
                 <InfoCard>{selected.name}</InfoCard>
                 <GoldRow>Code: {selected.code}</GoldRow>

--- a/features/player/useAchievementQueries.ts
+++ b/features/player/useAchievementQueries.ts
@@ -60,6 +60,15 @@ export function useAchievementQueries() {
     void loadDetail(achievementId);
   }, [loadDetail]);
 
+  const clearSelection = () => {
+    detailRequestId.current += 1;
+    selectedIdRef.current = null;
+    setSelectedId(null);
+    setDetail(null);
+    setDetailError(null);
+    setDetailLoading(false);
+  };
+
   return {
     list: { items, loading: listLoading, error: listError, reload },
     detail: {
@@ -70,5 +79,6 @@ export function useAchievementQueries() {
     },
     selectedId,
     select,
+    clearSelection,
   };
 }

--- a/features/player/useCertificationQueries.ts
+++ b/features/player/useCertificationQueries.ts
@@ -73,6 +73,11 @@ export function useCertificationQueries() {
     setSelectedId(certificationId);
   };
 
+  const clearSelection = useCallback(() => {
+    selectedIdRef.current = null;
+    setSelectedId(null);
+  }, []);
+
   const mutate = async <T,>(
     key: string,
     request: () => Promise<T>,
@@ -131,6 +136,7 @@ export function useCertificationQueries() {
     selectedId,
     selected: owned.find((item) => item.certificationId === selectedId) ?? null,
     select,
+    clearSelection,
     pendingMutation,
     mutationError,
     register,

--- a/features/player/useHobbyQueries.ts
+++ b/features/player/useHobbyQueries.ts
@@ -67,6 +67,11 @@ export function useHobbyQueries() {
     setSelectedId(hobbyId);
   };
 
+  const clearSelection = () => {
+    selectedIdRef.current = null;
+    setSelectedId(null);
+  };
+
   const mutate = async (key: string, request: () => Promise<unknown>, afterReload?: (next: PlayerHobbyInfo[]) => void): Promise<boolean> => {
     if (mutationLocked.current) return false;
     mutationLocked.current = true;
@@ -132,6 +137,7 @@ export function useHobbyQueries() {
     selectedId,
     selected: owned.find((item) => item.hobbyId === selectedId) ?? null,
     select,
+    clearSelection,
     pendingMutation,
     mutationError,
     register,

--- a/features/player/useTitleQueries.ts
+++ b/features/player/useTitleQueries.ts
@@ -58,6 +58,8 @@ export function useTitleQueries() {
     if (titles.some((title) => title.titleId === titleId)) setSelectedId(titleId);
   };
 
+  const clearSelection = () => setSelectedId(null);
+
   const setRepresentative = async (titleId: number): Promise<boolean> => {
     if (mutationLocked.current || player?.representativeTitleId === titleId || !titles.some((title) => title.titleId === titleId)) return false;
     mutationLocked.current = true;
@@ -87,6 +89,7 @@ export function useTitleQueries() {
     selectedId,
     selected: titles.find((title) => title.titleId === selectedId) ?? null,
     select,
+    clearSelection,
     pendingMutation,
     mutationError,
     setRepresentative,

--- a/features/quests/JourneyShell.test.tsx
+++ b/features/quests/JourneyShell.test.tsx
@@ -123,12 +123,12 @@ describe("Journey에서 Quest와 QuestRoute를 볼 때", () => {
       expect(screen.getByRole("button", { name: /Current/ })).toBeInTheDocument();
       expect(document.querySelector('[data-stage-key="journey-root"]')).toBeInTheDocument();
       expect(document.querySelector('[data-stage-key="journey-list"]')).not.toBeInTheDocument();
-      expect(document.querySelector('[data-stage-key*="detail-"]')).not.toBeInTheDocument();
+      expect(document.querySelector('[data-stage-key="journey-detail"]')).not.toBeInTheDocument();
 
       fireEvent.click(screen.getByRole("button", { name: /Current/ }));
       expect(await screen.findByText(/In Progress · 1\/3/)).toBeInTheDocument();
       expect(document.querySelector('[data-stage-key="journey-list"]')).toBeInTheDocument();
-      expect(document.querySelector('[data-stage-key*="detail-"]')).not.toBeInTheDocument();
+      expect(document.querySelector('[data-stage-key="journey-detail"]')).not.toBeInTheDocument();
     });
   });
 

--- a/features/quests/JourneyShell.test.tsx
+++ b/features/quests/JourneyShell.test.tsx
@@ -122,12 +122,12 @@ describe("Journey에서 Quest와 QuestRoute를 볼 때", () => {
 
       expect(screen.getByRole("button", { name: /Current/ })).toBeInTheDocument();
       expect(document.querySelector('[data-stage-key="journey-root"]')).toBeInTheDocument();
-      expect(document.querySelector('[data-stage-key^="journey-list-"]')).not.toBeInTheDocument();
+      expect(document.querySelector('[data-stage-key="journey-list"]')).not.toBeInTheDocument();
       expect(document.querySelector('[data-stage-key*="detail-"]')).not.toBeInTheDocument();
 
       fireEvent.click(screen.getByRole("button", { name: /Current/ }));
       expect(await screen.findByText(/In Progress · 1\/3/)).toBeInTheDocument();
-      expect(document.querySelector('[data-stage-key="journey-list-current"]')).toBeInTheDocument();
+      expect(document.querySelector('[data-stage-key="journey-list"]')).toBeInTheDocument();
       expect(document.querySelector('[data-stage-key*="detail-"]')).not.toBeInTheDocument();
     });
   });
@@ -327,7 +327,7 @@ describe("Journey에서 Quest와 QuestRoute를 볼 때", () => {
       fireEvent.click(await screen.findByRole("button", { name: /기록으로 시작하기/ }));
 
       expect(await screen.findByText("Current Step Detail: 첫 흔적 남기기 · READY_TO_ADVANCE")).toBeInTheDocument();
-      expect(document.querySelector('[data-stage-key^="journey-route-detail-"] .lag-panel-body')).toHaveClass("lag-panel-body");
+      expect(document.querySelector('[data-stage-key="journey-detail"] .lag-panel-body')).toHaveClass("lag-panel-body");
       expect(api.getMyQuestRouteApi).toHaveBeenCalledWith(selectedRoute.id);
       expect(api.getQuestRouteApi).not.toHaveBeenCalled();
     });

--- a/features/quests/JourneyShell.tsx
+++ b/features/quests/JourneyShell.tsx
@@ -353,7 +353,7 @@ export default function JourneyShell({ initialSurface = "current" }: { initialSu
     );
   };
 
-  const detailStageKey = surface === "current" && selectedAcceptance
+  const detailContentKey = surface === "current" && selectedAcceptance
     ? `journey-current-detail-${selectedAcceptance.id}`
     : surface === "catalog" && selectedBlueprint
       ? `journey-catalog-detail-${selectedBlueprint.code}`
@@ -375,8 +375,8 @@ export default function JourneyShell({ initialSurface = "current" }: { initialSu
 
       <AnimatePresence initial={false}>
         {surface ? (
-          <PanelStage key={`journey-list-${surface}`} stageKey={`journey-list-${surface}`} index={1}>
-            <PanelFrame title={SUBMENUS_BY_MAIN.quests.find((item) => item.id === surface)?.label ?? "Journey"} depth={1}>
+          <PanelStage key="journey-list" stageKey="journey-list" focusKey={surface} index={1}>
+            <PanelFrame title={SUBMENUS_BY_MAIN.quests.find((item) => item.id === surface)?.label ?? "Journey"} depth={1} contentKey={surface}>
               {surface === "current" ? renderCurrentList() : surface === "catalog" ? renderCatalogList() : renderRouteList()}
             </PanelFrame>
           </PanelStage>
@@ -384,9 +384,9 @@ export default function JourneyShell({ initialSurface = "current" }: { initialSu
       </AnimatePresence>
 
       <AnimatePresence initial={false} mode="popLayout">
-        {detailStageKey ? (
-          <PanelStage key={detailStageKey} stageKey={detailStageKey} index={2}>
-            <PanelFrame title={surface === "current" ? selectedAcceptance?.title ?? "Quest Detail" : surface === "catalog" ? selectedBlueprint?.title ?? "Catalog Detail" : selectedRoute?.title ?? "Route Detail"} depth={0}>
+        {detailContentKey ? (
+          <PanelStage key="journey-detail" stageKey="journey-detail" focusKey={detailContentKey} index={2}>
+            <PanelFrame title={surface === "current" ? selectedAcceptance?.title ?? "Quest Detail" : surface === "catalog" ? selectedBlueprint?.title ?? "Catalog Detail" : selectedRoute?.title ?? "Route Detail"} depth={0} contentKey={detailContentKey}>
               {surface === "current" ? renderCurrentDetail() : surface === "catalog" ? renderCatalogDetail() : renderRouteDetail()}
             </PanelFrame>
           </PanelStage>

--- a/features/role/RoleShell.tsx
+++ b/features/role/RoleShell.tsx
@@ -452,13 +452,16 @@ export default function RoleShell({
 }) {
   const router = useRouter();
   const [surface, setSurface] = useState<RoleSurface | null>(null);
+  const [surfaceRoleId, setSurfaceRoleId] = useState<number | null>(null);
   const [editingRoleId, setEditingRoleId] = useState<number | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
   const selectedRole = roles.find(({ id }) => id === selectedRoleId) ?? null;
   const editingRole = selectedRole?.id === editingRoleId;
+  const activeSurface = selectedRole?.id === surfaceRoleId ? surface : null;
 
   useEffect(() => {
     setSurface(null);
+    setSurfaceRoleId(null);
     setEditingRoleId((current) => current === selectedRoleId ? current : null);
   }, [selectedRoleId]);
 
@@ -510,11 +513,11 @@ export default function RoleShell({
 
       <AnimatePresence initial={false}>
         {selectedRole ? (
-          <PanelStage key={`role-surfaces-${selectedRole.id}`} stageKey={`role-surfaces-${selectedRole.id}`} index={1}>
-            <PanelFrame title={selectedRole.name} depth={1}>
+          <PanelStage key="role-surfaces" stageKey="role-surfaces" focusKey={selectedRole.id} index={1}>
+            <PanelFrame title={selectedRole.name} depth={1} contentKey={selectedRole.id}>
               <div className="grid gap-1">
                 {ROLE_SURFACES.map((item, index) => (
-                  <PanelCard key={item.id} label={item.label} slotLabel={item.slotLabel} selected={surface === item.id} index={index} onClick={() => { setSurface(item.id); setEditingRoleId(null); }} />
+                  <PanelCard key={item.id} label={item.label} slotLabel={item.slotLabel} selected={activeSurface === item.id} index={index} onClick={() => { setSurface(item.id); setSurfaceRoleId(selectedRole.id); setEditingRoleId(null); }} />
                 ))}
               </div>
             </PanelFrame>
@@ -523,13 +526,13 @@ export default function RoleShell({
       </AnimatePresence>
 
       <AnimatePresence initial={false} mode="popLayout">
-        {selectedRole && (editingRole || surface) ? (
-          <PanelStage key={editingRole ? `role-edit-${selectedRole.id}` : `role-${selectedRole.id}-${surface}`} stageKey={editingRole ? `role-edit-${selectedRole.id}` : `role-${selectedRole.id}-${surface}`} index={2}>
-            <PanelFrame title={editingRole ? "Edit Role" : ROLE_SURFACES.find(({ id }) => id === surface)?.label ?? "Role"} depth={0}>
+        {selectedRole && (editingRole || activeSurface) ? (
+          <PanelStage key="role-detail" stageKey="role-detail" focusKey={`${selectedRole.id}-${editingRole ? "edit" : activeSurface}`} index={2}>
+            <PanelFrame title={editingRole ? "Edit Role" : ROLE_SURFACES.find(({ id }) => id === activeSurface)?.label ?? "Role"} depth={0} contentKey={`${selectedRole.id}-${editingRole ? "edit" : activeSurface}`}>
               {editingRole ? (
                 <RoleEditForm role={selectedRole} onSaved={async () => { await onRefresh(); setEditingRoleId(null); }} onCancel={() => setEditingRoleId(null)} />
-              ) : surface === "overview" ? <Overview role={selectedRole} />
-                : surface === "relations" ? <RelationsSurface roleId={selectedRole.id} />
+              ) : activeSurface === "overview" ? <Overview role={selectedRole} />
+                : activeSurface === "relations" ? <RelationsSurface roleId={selectedRole.id} />
                   : <EventsSurface roleId={selectedRole.id} />}
             </PanelFrame>
           </PanelStage>

--- a/features/social/ConnectionsDrawer.test.tsx
+++ b/features/social/ConnectionsDrawer.test.tsx
@@ -9,6 +9,8 @@ describe("Connections utility drawer surface", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     connectionsMock.reset();
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: 1200 });
+    Object.defineProperty(window, "innerHeight", { configurable: true, value: 800 });
   });
 
   it("opens outside OrbNav and renders only canonical peer fields and directional actions", async () => {
@@ -44,5 +46,22 @@ describe("Connections utility drawer surface", () => {
     await waitFor(() => expect(screen.queryByText("followings failed")).not.toBeInTheDocument());
     expect(followings).toHaveBeenCalledTimes(2);
     expect(followers).toHaveBeenCalledTimes(1);
+  });
+
+  it("drags by the shared header handle and re-clamps after viewport resize", () => {
+    render(<ConnectionsDrawer />);
+    fireEvent.click(screen.getByRole("button", { name: "Connections" }));
+    const dialog = screen.getByRole("dialog", { name: "Current Player Connections" });
+    dialog.getBoundingClientRect = () => ({ left: 0, right: 420, top: 0, bottom: 500, width: 420, height: 500, x: 0, y: 0, toJSON: () => ({}) });
+    const handle = dialog.querySelector("header")!;
+
+    fireEvent.pointerDown(handle, { button: 0, clientX: 100, clientY: 100 });
+    fireEvent.pointerMove(window, { clientX: -500, clientY: 1200 });
+    expect(dialog).toHaveStyle({ left: "16px", top: "284px" });
+
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: 900 });
+    Object.defineProperty(window, "innerHeight", { configurable: true, value: 650 });
+    fireEvent.resize(window);
+    expect(dialog).toHaveStyle({ left: "16px", top: "134px" });
   });
 });

--- a/features/social/ConnectionsDrawer.test.tsx
+++ b/features/social/ConnectionsDrawer.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { readFileSync } from "node:fs";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import * as api from "./api";
@@ -56,12 +57,34 @@ describe("Connections utility drawer surface", () => {
     const handle = dialog.querySelector("header")!;
 
     fireEvent.pointerDown(handle, { button: 0, clientX: 100, clientY: 100 });
-    fireEvent.pointerMove(window, { clientX: -500, clientY: 1200 });
+    fireEvent.pointerMove(window, { clientX: -2000, clientY: 1200 });
     expect(dialog).toHaveStyle({ left: "16px", top: "284px" });
 
     Object.defineProperty(window, "innerWidth", { configurable: true, value: 900 });
     Object.defineProperty(window, "innerHeight", { configurable: true, value: 650 });
     fireEvent.resize(window);
     expect(dialog).toHaveStyle({ left: "16px", top: "134px" });
+  });
+
+  it("initializes the first desktop portal position after the dialog ref mounts", async () => {
+    const rect = vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue({ left: 0, right: 420, top: 0, bottom: 500, width: 420, height: 500, x: 0, y: 0, toJSON: () => ({}) });
+    render(<ConnectionsDrawer />);
+    fireEvent.click(screen.getByRole("button", { name: "Connections" }));
+
+    await waitFor(() => expect(screen.getByRole("dialog", { name: "Current Player Connections" })).toHaveStyle({ left: "756px", top: "24px" }));
+    rect.mockRestore();
+  });
+
+  it("keeps the mobile header above OrbNav within a dynamic viewport bound", async () => {
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: 390 });
+    Object.defineProperty(window, "innerHeight", { configurable: true, value: 520 });
+    render(<ConnectionsDrawer />);
+    fireEvent.click(screen.getByRole("button", { name: "Connections" }));
+    const dialog = screen.getByRole("dialog", { name: "Current Player Connections" });
+
+    await waitFor(() => expect(dialog.style.bottom).toContain("safe-area-inset-bottom"));
+    expect(dialog.querySelector("header")).toBeInTheDocument();
+    const css = readFileSync("app/globals.css", "utf8");
+    expect(css).toContain("max-height: calc(100dvh - 112px - env(safe-area-inset-bottom) - max(16px, env(safe-area-inset-top)))");
   });
 });

--- a/features/social/ConnectionsDrawer.test.tsx
+++ b/features/social/ConnectionsDrawer.test.tsx
@@ -83,6 +83,8 @@ describe("Connections utility drawer surface", () => {
     const dialog = screen.getByRole("dialog", { name: "Current Player Connections" });
 
     await waitFor(() => expect(dialog.style.bottom).toContain("safe-area-inset-bottom"));
+    expect(dialog.style.maxHeight).toContain("100dvh");
+    expect(dialog.style.maxHeight).toContain("safe-area-inset-top");
     expect(dialog.querySelector("header")).toBeInTheDocument();
     const css = readFileSync("app/globals.css", "utf8");
     expect(css).toContain("max-height: calc(100dvh - 112px - env(safe-area-inset-bottom) - max(16px, env(safe-area-inset-top)))");

--- a/features/social/ConnectionsDrawer.tsx
+++ b/features/social/ConnectionsDrawer.tsx
@@ -3,6 +3,8 @@
 import { useCallback, useEffect, useState } from "react";
 
 import type { ConnectionPeer } from "@/shared/api/types";
+import { useDraggableWindow } from "@/shared/hooks/useDraggableWindow";
+import UtilityPortal from "@/shared/ui/UtilityPortal";
 import { useConnectionsQueries } from "./useConnectionsQueries";
 
 const buttonStyle = {
@@ -43,6 +45,7 @@ export default function ConnectionsDrawer({ open: controlledOpen, onOpenChange, 
   const setPage = state.activeTab === "followings" ? state.setFollowingPage : state.setFollowerPage;
   const queryError = state.queryErrors[state.activeTab];
   const retry = state.activeTab === "followings" ? state.reloadFollowings : state.reloadFollowers;
+  const floating = useDraggableWindow(open);
 
   useEffect(() => {
     if (!open) return;
@@ -65,12 +68,15 @@ export default function ConnectionsDrawer({ open: controlledOpen, onOpenChange, 
       </button>
 
       {open ? (
-        <aside
+        <UtilityPortal>
+          <aside
+          ref={floating.windowRef}
           role="dialog"
           aria-label="Current Player Connections"
-          className="lag-utility-drawer fixed right-6 top-6 z-[500000] flex max-h-[calc(100vh-3rem)] w-[min(420px,calc(100vw-3rem))] flex-col overflow-hidden p-4"
+          className="lag-utility-drawer flex max-h-[calc(100vh-3rem)] w-[min(420px,calc(100vw-3rem))] flex-col overflow-hidden p-4"
+          style={floating.windowStyle}
         >
-          <header className="flex items-center justify-between gap-3">
+          <header className="lag-utility-drag-handle flex items-center justify-between gap-3" {...floating.dragHandleProps}>
             <div>
               <p className="text-[10px] uppercase tracking-[0.2em]" style={{ color: "var(--lag-text-2)" }}>Current Player</p>
               <h2 className="text-lg font-semibold tracking-[0.08em]" style={{ color: "var(--lag-text)" }}>Connections</h2>
@@ -143,7 +149,8 @@ export default function ConnectionsDrawer({ open: controlledOpen, onOpenChange, 
             <span className="text-xs" style={{ color: "var(--lag-text-2)" }}>Page {page.totalPages === 0 ? 0 : page.page + 1} of {page.totalPages}</span>
             <button type="button" disabled={pageIndex + 1 >= page.totalPages} onClick={() => setPage((current) => current + 1)} className="px-3 py-1.5 text-xs disabled:opacity-40" style={buttonStyle}>Next</button>
           </footer>
-        </aside>
+          </aside>
+        </UtilityPortal>
       ) : null}
     </>
   );

--- a/features/social/ConnectionsDrawer.tsx
+++ b/features/social/ConnectionsDrawer.tsx
@@ -76,7 +76,7 @@ export default function ConnectionsDrawer({ open: controlledOpen, onOpenChange, 
           className="lag-utility-drawer flex max-h-[calc(100vh-3rem)] w-[min(420px,calc(100vw-3rem))] flex-col overflow-hidden p-4"
           style={floating.windowStyle}
         >
-          <header className="lag-utility-drag-handle flex items-center justify-between gap-3" {...floating.dragHandleProps}>
+          <header className="lag-utility-drag-handle flex shrink-0 items-center justify-between gap-3" {...floating.dragHandleProps}>
             <div>
               <p className="text-[10px] uppercase tracking-[0.2em]" style={{ color: "var(--lag-text-2)" }}>Current Player</p>
               <h2 className="text-lg font-semibold tracking-[0.08em]" style={{ color: "var(--lag-text)" }}>Connections</h2>
@@ -144,7 +144,7 @@ export default function ConnectionsDrawer({ open: controlledOpen, onOpenChange, 
             })}
           </div>
 
-          <footer className="mt-3 flex items-center justify-between gap-3 border-t pt-3" style={{ borderColor: "var(--lag-divider)" }}>
+          <footer className="mt-3 flex shrink-0 items-center justify-between gap-3 border-t pt-3" style={{ borderColor: "var(--lag-divider)" }}>
             <button type="button" disabled={pageIndex === 0} onClick={() => setPage((current) => current - 1)} className="px-3 py-1.5 text-xs disabled:opacity-40" style={buttonStyle}>Previous</button>
             <span className="text-xs" style={{ color: "var(--lag-text-2)" }}>Page {page.totalPages === 0 ? 0 : page.page + 1} of {page.totalPages}</span>
             <button type="button" disabled={pageIndex + 1 >= page.totalPages} onClick={() => setPage((current) => current + 1)} className="px-3 py-1.5 text-xs disabled:opacity-40" style={buttonStyle}>Next</button>

--- a/features/social/chat/DirectChatDrawer.test.tsx
+++ b/features/social/chat/DirectChatDrawer.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { renderToString } from "react-dom/server";
 import { expect, it, vi } from "vitest";
 
@@ -97,4 +97,38 @@ it("uses the same bounded shared drag behavior as Connections", () => {
   fireEvent.pointerMove(window, { clientX: 2000, clientY: 2000 });
 
   expect(dialog).toHaveStyle({ left: "464px", top: "104px" });
+});
+
+it("initializes the first desktop portal position after the Chat dialog mounts", async () => {
+  Object.defineProperty(window, "innerWidth", { configurable: true, value: 1200 });
+  Object.defineProperty(window, "innerHeight", { configurable: true, value: 800 });
+  const rect = vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue({ left: 0, right: 720, top: 0, bottom: 680, width: 720, height: 680, x: 0, y: 0, toJSON: () => ({}) });
+  const chat = {
+    open: true,
+    setOpen: vi.fn(),
+    channels: [],
+    channelsLoading: false,
+    channelsError: null,
+    channelsRetry: vi.fn(),
+    selectedChannelId: null,
+    selectChannel: vi.fn(),
+    messages: [],
+    messagesLoading: false,
+    messagesError: null,
+    loadLatest: vi.fn(),
+    hasMore: false,
+    olderLoading: false,
+    loadOlder: vi.fn(),
+    draft: "",
+    setDraft: vi.fn(),
+    sending: false,
+    sendError: null,
+    send: vi.fn(),
+    openError: null,
+  } as unknown as DirectChatState;
+
+  render(<DirectChatDrawer chat={chat} />);
+
+  await waitFor(() => expect(screen.getByRole("dialog", { name: "Direct Friend Chat" })).toHaveStyle({ left: "456px", top: "24px" }));
+  rect.mockRestore();
 });

--- a/features/social/chat/DirectChatDrawer.test.tsx
+++ b/features/social/chat/DirectChatDrawer.test.tsx
@@ -62,3 +62,39 @@ it("renders an authoritative deterministic timestamp before client localization"
   expect(html).toContain(`>${createdAt}</time>`);
   localize.mockRestore();
 });
+
+it("uses the same bounded shared drag behavior as Connections", () => {
+  Object.defineProperty(window, "innerWidth", { configurable: true, value: 1200 });
+  Object.defineProperty(window, "innerHeight", { configurable: true, value: 800 });
+  const chat = {
+    open: true,
+    setOpen: vi.fn(),
+    channels: [],
+    channelsLoading: false,
+    channelsError: null,
+    channelsRetry: vi.fn(),
+    selectedChannelId: null,
+    selectChannel: vi.fn(),
+    messages: [],
+    messagesLoading: false,
+    messagesError: null,
+    loadLatest: vi.fn(),
+    hasMore: false,
+    olderLoading: false,
+    loadOlder: vi.fn(),
+    draft: "",
+    setDraft: vi.fn(),
+    sending: false,
+    sendError: null,
+    send: vi.fn(),
+    openError: null,
+  } as unknown as DirectChatState;
+  render(<DirectChatDrawer chat={chat} />);
+  const dialog = screen.getByRole("dialog", { name: "Direct Friend Chat" });
+  dialog.getBoundingClientRect = () => ({ left: 0, right: 720, top: 0, bottom: 680, width: 720, height: 680, x: 0, y: 0, toJSON: () => ({}) });
+
+  fireEvent.pointerDown(dialog.querySelector("header")!, { button: 0, clientX: 20, clientY: 20 });
+  fireEvent.pointerMove(window, { clientX: 2000, clientY: 2000 });
+
+  expect(dialog).toHaveStyle({ left: "464px", top: "104px" });
+});

--- a/features/social/chat/DirectChatDrawer.tsx
+++ b/features/social/chat/DirectChatDrawer.tsx
@@ -58,7 +58,7 @@ export default function DirectChatDrawer({ chat, onOpen }: { chat: DirectChatSta
           className="lag-utility-drawer flex h-[min(680px,calc(100vh-3rem))] w-[min(720px,calc(100vw-3rem))] flex-col overflow-hidden p-4"
           style={floating.windowStyle}
         >
-          <header className="lag-utility-drag-handle flex items-center justify-between gap-3" {...floating.dragHandleProps}>
+          <header className="lag-utility-drag-handle flex shrink-0 items-center justify-between gap-3" {...floating.dragHandleProps}>
             <div>
               <p className="text-[10px] uppercase tracking-[0.2em]" style={{ color: "var(--lag-text-2)" }}>Current Player</p>
               <h2 className="text-lg font-semibold tracking-[0.08em]" style={{ color: "var(--lag-text)" }}>Direct Chat</h2>

--- a/features/social/chat/DirectChatDrawer.tsx
+++ b/features/social/chat/DirectChatDrawer.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useState } from "react";
 
 import { useAuth } from "@/features/auth/AuthContext";
+import { useDraggableWindow } from "@/shared/hooks/useDraggableWindow";
+import UtilityPortal from "@/shared/ui/UtilityPortal";
 import type { DirectChatState } from "./useDirectChat";
 
 const buttonStyle = {
@@ -22,6 +24,7 @@ export default function DirectChatDrawer({ chat, onOpen }: { chat: DirectChatSta
   const { playerId } = useAuth();
   const { open, setOpen } = chat;
   const selected = chat.channels.find(({ channelId }) => channelId === chat.selectedChannelId) ?? null;
+  const floating = useDraggableWindow(open);
 
   useEffect(() => {
     if (!open) return;
@@ -47,12 +50,15 @@ export default function DirectChatDrawer({ chat, onOpen }: { chat: DirectChatSta
       </button>
 
       {chat.open ? (
-        <aside
+        <UtilityPortal>
+          <aside
+          ref={floating.windowRef}
           role="dialog"
           aria-label="Direct Friend Chat"
-          className="lag-utility-drawer fixed right-6 top-6 z-[500000] flex h-[min(680px,calc(100vh-3rem))] w-[min(720px,calc(100vw-3rem))] flex-col overflow-hidden p-4"
+          className="lag-utility-drawer flex h-[min(680px,calc(100vh-3rem))] w-[min(720px,calc(100vw-3rem))] flex-col overflow-hidden p-4"
+          style={floating.windowStyle}
         >
-          <header className="flex items-center justify-between gap-3">
+          <header className="lag-utility-drag-handle flex items-center justify-between gap-3" {...floating.dragHandleProps}>
             <div>
               <p className="text-[10px] uppercase tracking-[0.2em]" style={{ color: "var(--lag-text-2)" }}>Current Player</p>
               <h2 className="text-lg font-semibold tracking-[0.08em]" style={{ color: "var(--lag-text)" }}>Direct Chat</h2>
@@ -113,7 +119,8 @@ export default function DirectChatDrawer({ chat, onOpen }: { chat: DirectChatSta
               )}
             </section>
           </div>
-        </aside>
+          </aside>
+        </UtilityPortal>
       ) : null}
     </>
   );

--- a/features/system/settings/SettingsShell.tsx
+++ b/features/system/settings/SettingsShell.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 
 import { useToast } from "@/context/ToastContext";
 import type { GraphicsQuality, InputPreset, SettingsView, ThemePreference, UiScale, VoiceChatMode } from "@/shared/api/types";
+import PanelStage from "@/shared/ui/PanelStage";
 import { PanelFrame } from "@/widgets/right-panels/ui/PanelFrame";
 import { GoldRow, InfoCard } from "@/widgets/right-panels/ui/Rows";
 import { actionBtnStyle } from "@/widgets/right-panels/ui/styles";
@@ -84,7 +85,8 @@ export default function SettingsShell() {
 
   return (
     <div className="lag-settings-shell">
-      <PanelFrame title="Settings" depth={1}>
+      <PanelStage stageKey="system-options" focusKey={editing ? "edit" : "summary"}>
+        <PanelFrame title="Settings" depth={1} contentKey={editing ? "edit" : "summary"}>
         <div className="space-y-3 px-3" data-testid="settings-shell">
         {settings.loading && !settings.canonical ? <InfoCard>Loading Settings...</InfoCard> : null}
         {settings.error ? (
@@ -173,7 +175,8 @@ export default function SettingsShell() {
           </form>
         ) : null}
         </div>
-      </PanelFrame>
+        </PanelFrame>
+      </PanelStage>
     </div>
   );
 }

--- a/features/system/settings/useSettings.test.tsx
+++ b/features/system/settings/useSettings.test.tsx
@@ -79,15 +79,15 @@ describe("feature-owned Settings state", () => {
     expect(result.current.saveError).toBeNull();
   });
 
-  it("lets a supported server theme override the local bootstrap cache after Settings loads", async () => {
+  it("loads the canonical form theme without changing runtime merely because Options mounted", async () => {
     localStorage.setItem(THEME_STORAGE_KEY, "ASTRAL");
     api.getSettingsApi.mockResolvedValue(response({ flagsJson: JSON.stringify({ themePreference: "WARM_BEIGE", futureFlag: "preserve" }) }));
     const { result } = renderHook(() => useSettings(), { wrapper });
 
     await waitFor(() => expect(result.current.canonical).not.toBeNull());
     expect(result.current.themePreference).toBe("WARM_BEIGE");
-    expect(document.documentElement.dataset.theme).toBe("warm-beige");
-    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe("WARM_BEIGE");
+    expect(document.documentElement.dataset.theme).toBe("astral");
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe("ASTRAL");
   });
 
   it("preserves a valid local preference when server flags omit themePreference", async () => {
@@ -102,5 +102,24 @@ describe("feature-owned Settings state", () => {
     expect(result.current.themePreference).toBe("ASTRAL");
     expect(result.current.canonical?.view.themePreference).toBe("ASTRAL");
     expect(document.documentElement.dataset.theme).toBe("astral");
+  });
+
+  it("applies a user theme choice immediately while its Settings PATCH is pending", async () => {
+    localStorage.setItem(THEME_STORAGE_KEY, "ASTRAL");
+    api.getSettingsApi.mockResolvedValue(response({ flagsJson: JSON.stringify({ themePreference: "ASTRAL" }) }));
+    let finishSave!: (settings: UserSettingsResponse) => void;
+    api.updateSettingsApi.mockReturnValue(new Promise((resolve) => { finishSave = resolve; }));
+    const { result } = renderHook(() => useSettings(), { wrapper });
+    await waitFor(() => expect(result.current.canonical).not.toBeNull());
+
+    let saving!: Promise<boolean>;
+    act(() => { saving = result.current.setThemePreference("WARM_BEIGE"); });
+    expect(document.documentElement.dataset.theme).toBe("warm-beige");
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe("WARM_BEIGE");
+
+    await act(async () => {
+      finishSave(response({ flagsJson: JSON.stringify({ themePreference: "WARM_BEIGE" }) }));
+      expect(await saving).toBe(true);
+    });
   });
 });

--- a/features/system/settings/useSettings.ts
+++ b/features/system/settings/useSettings.ts
@@ -41,7 +41,6 @@ export function useSettings() {
     setError(null);
     try {
       const parsed = withTheme(parseUserSettings(await getSettingsApi()), themePreferenceRef.current);
-      setRuntimePreference(parsed.view.themePreference);
       setCanonical(parsed);
       setDraft(parsed.view);
       setSaveError(null);
@@ -50,7 +49,7 @@ export function useSettings() {
     } finally {
       setLoading(false);
     }
-  }, [setRuntimePreference]);
+  }, []);
 
   useEffect(() => { void load(); }, [load]);
 
@@ -124,7 +123,7 @@ export function useSettings() {
     updateDraft,
     save,
     cancel,
-    themePreference: runtimePreference,
+    themePreference: draft?.themePreference ?? runtimePreference,
     themeSaving,
     themeSaveError,
     setThemePreference,

--- a/features/theme/AuthenticatedThemeBootstrap.test.tsx
+++ b/features/theme/AuthenticatedThemeBootstrap.test.tsx
@@ -1,0 +1,99 @@
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { UserSettingsResponse } from "@/shared/api/types";
+import { AuthenticatedThemeBootstrap } from "./AuthenticatedThemeBootstrap";
+import { ThemeProvider, useTheme } from "./ThemeProvider";
+import { THEME_STORAGE_KEY } from "./theme";
+
+const auth = vi.hoisted(() => ({
+  state: {
+    currentUser: null as null | { id: number },
+    session: null as null | { accessToken: string },
+    isAuthenticated: false,
+    isLoading: false,
+  },
+}));
+const api = vi.hoisted(() => ({ getSettingsApi: vi.fn() }));
+
+vi.mock("@/features/auth/AuthContext", () => ({ useAuth: () => auth.state }));
+vi.mock("@/lib/api/endpoints/settings.api", () => api);
+
+const response = (userId: number, themePreference: string): UserSettingsResponse => ({
+  userId,
+  volume: 70,
+  uiLayoutJson: null,
+  flagsJson: JSON.stringify({ themePreference }),
+  updatedAt: "2026-08-22T00:00:00Z",
+});
+
+function ThemeProbe() {
+  const { preference } = useTheme();
+  return <output>{preference}</output>;
+}
+
+function Root() {
+  return (
+    <ThemeProvider>
+      <AuthenticatedThemeBootstrap />
+      <ThemeProbe />
+    </ThemeProvider>
+  );
+}
+
+describe("authenticated theme bootstrap", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    vi.stubGlobal("matchMedia", vi.fn(() => ({ matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn() })));
+    Object.assign(auth.state, { currentUser: null, session: null, isAuthenticated: false, isLoading: false });
+  });
+
+  it("applies a supported server preference globally after Auth is ready", async () => {
+    localStorage.setItem(THEME_STORAGE_KEY, "ASTRAL");
+    Object.assign(auth.state, { currentUser: { id: 7 }, session: { accessToken: "user-7" }, isAuthenticated: true });
+    api.getSettingsApi.mockResolvedValue(response(7, "WARM_BEIGE"));
+
+    render(<Root />);
+
+    await waitFor(() => expect(screen.getByText("WARM_BEIGE")).toBeInTheDocument());
+    expect(document.documentElement.dataset.theme).toBe("warm-beige");
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe("WARM_BEIGE");
+  });
+
+  it("ignores a stale previous-session response", async () => {
+    let finishFirst!: (settings: UserSettingsResponse) => void;
+    let finishSecond!: (settings: UserSettingsResponse) => void;
+    api.getSettingsApi
+      .mockReturnValueOnce(new Promise((resolve) => { finishFirst = resolve; }))
+      .mockReturnValueOnce(new Promise((resolve) => { finishSecond = resolve; }));
+    Object.assign(auth.state, { currentUser: { id: 1 }, session: { accessToken: "user-1" }, isAuthenticated: true });
+    const { rerender } = render(<Root />);
+    await waitFor(() => expect(api.getSettingsApi).toHaveBeenCalledTimes(1));
+
+    Object.assign(auth.state, { currentUser: { id: 2 }, session: { accessToken: "user-2" } });
+    rerender(<Root />);
+    await waitFor(() => expect(api.getSettingsApi).toHaveBeenCalledTimes(2));
+    await act(async () => { finishSecond(response(2, "ASTRAL")); });
+    await waitFor(() => expect(screen.getByText("ASTRAL")).toBeInTheDocument());
+
+    await act(async () => { finishFirst(response(1, "WARM_BEIGE")); });
+    expect(screen.getByText("ASTRAL")).toBeInTheDocument();
+    expect(document.documentElement.dataset.theme).toBe("astral");
+  });
+
+  it("keeps the current visual preference and local cache on logout", async () => {
+    Object.assign(auth.state, { currentUser: { id: 7 }, session: { accessToken: "user-7" }, isAuthenticated: true });
+    api.getSettingsApi.mockResolvedValue(response(7, "ASTRAL"));
+    const { rerender } = render(<Root />);
+    await waitFor(() => expect(screen.getByText("ASTRAL")).toBeInTheDocument());
+
+    Object.assign(auth.state, { currentUser: null, session: null, isAuthenticated: false });
+    rerender(<Root />);
+
+    expect(screen.getByText("ASTRAL")).toBeInTheDocument();
+    expect(document.documentElement.dataset.theme).toBe("astral");
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe("ASTRAL");
+    expect(api.getSettingsApi).toHaveBeenCalledTimes(1);
+  });
+});

--- a/features/theme/AuthenticatedThemeBootstrap.tsx
+++ b/features/theme/AuthenticatedThemeBootstrap.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+import { useAuth } from "@/features/auth/AuthContext";
+import { getSettingsApi } from "@/lib/api/endpoints/settings.api";
+import { useTheme } from "./ThemeProvider";
+import { parseServerThemePreference } from "./theme";
+
+export function AuthenticatedThemeBootstrap() {
+  const { currentUser, session, isAuthenticated, isLoading } = useAuth();
+  const { setPreference } = useTheme();
+  const requestVersion = useRef(0);
+  const userId = currentUser?.id;
+  const sessionKey = session?.accessToken;
+
+  useEffect(() => {
+    const version = ++requestVersion.current;
+    if (isLoading || !isAuthenticated || !userId || !sessionKey) return;
+    let active = true;
+
+    void getSettingsApi()
+      .then((response) => {
+        if (!active || version !== requestVersion.current || response.userId !== userId) return;
+        const preference = parseServerThemePreference(response.flagsJson);
+        if (preference) setPreference(preference);
+      })
+      .catch(() => {
+        // The local/pre-paint cache remains authoritative until this session can hydrate.
+      });
+
+    return () => { active = false; };
+  }, [isAuthenticated, isLoading, sessionKey, setPreference, userId]);
+
+  return null;
+}

--- a/features/theme/theme.ts
+++ b/features/theme/theme.ts
@@ -10,6 +10,16 @@ export function parseThemePreference(value: unknown): ThemePreference | null {
   return value === "SYSTEM" || value === "ASTRAL" || value === "WARM_BEIGE" ? value : null;
 }
 
+export function parseServerThemePreference(flagsJson: string | null): ThemePreference | null {
+  try {
+    const flags: unknown = flagsJson === null ? {} : JSON.parse(flagsJson);
+    if (flags === null || typeof flags !== "object" || Array.isArray(flags)) return null;
+    return parseThemePreference((flags as Record<string, unknown>).themePreference);
+  } catch {
+    return null;
+  }
+}
+
 export function resolveTheme(preference: unknown, systemDark = false): EffectiveTheme {
   const supported = parseThemePreference(preference) ?? DEFAULT_THEME_PREFERENCE;
   if (supported === "SYSTEM") return systemDark ? "astral" : "warm-beige";

--- a/shared/design/styles.ts
+++ b/shared/design/styles.ts
@@ -39,6 +39,20 @@ export const INPUT_STYLE: React.CSSProperties = {
   boxSizing: 'border-box' as const,
 }
 
+/** v7 dual-theme semantic control — use on migrated authenticated surfaces. */
+export const SEMANTIC_CONTROL_STYLE: React.CSSProperties = {
+  background: 'var(--lag-control-bg)',
+  border: '1px solid var(--lag-control-border)',
+  borderRadius: 'var(--lag-radius-sm)',
+  padding: '8px 12px',
+  outline: 'none',
+  fontSize: '0.875rem',
+  letterSpacing: '0.04em',
+  color: 'var(--lag-control-text)',
+  width: '100%',
+  boxSizing: 'border-box',
+}
+
 export const INPUT_FOCUS_STYLE: React.CSSProperties = {
   background: 'rgba(218,178,55,0.12)',
   border: `1px solid ${SAO.color.border.gold}`,

--- a/shared/design/styles.ts
+++ b/shared/design/styles.ts
@@ -45,7 +45,6 @@ export const SEMANTIC_CONTROL_STYLE: React.CSSProperties = {
   border: '1px solid var(--lag-control-border)',
   borderRadius: 'var(--lag-radius-sm)',
   padding: '8px 12px',
-  outline: 'none',
   fontSize: '0.875rem',
   letterSpacing: '0.04em',
   color: 'var(--lag-control-text)',

--- a/shared/hooks/useDraggableWindow.ts
+++ b/shared/hooks/useDraggableWindow.ts
@@ -82,7 +82,15 @@ export function useDraggableWindow(open: boolean) {
     windowRef,
     dragHandleProps: { onPointerDown, style: { cursor: "move", touchAction: "none" } as const },
     windowStyle: mobile
-      ? { position: "fixed", left: 16, right: 16, bottom: "calc(112px + env(safe-area-inset-bottom))", top: "auto", zIndex: 600000 } as const
+      ? {
+          position: "fixed",
+          left: 16,
+          right: 16,
+          bottom: "calc(112px + env(safe-area-inset-bottom))",
+          top: "auto",
+          maxHeight: "calc(100dvh - 112px - env(safe-area-inset-bottom) - max(16px, env(safe-area-inset-top)))",
+          zIndex: 600000,
+        } as const
       : { position: "fixed", left: position?.x, top: position?.y, right: position ? "auto" : 24, zIndex: 600000 } as const,
   };
 }

--- a/shared/hooks/useDraggableWindow.ts
+++ b/shared/hooks/useDraggableWindow.ts
@@ -1,0 +1,82 @@
+"use client";
+
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+
+import { clampFloatingPosition, type FloatingPosition } from "@/shared/lib/viewport";
+
+const MOBILE_BREAKPOINT = 768;
+const WINDOW_PADDING = 16;
+
+export function useDraggableWindow(open: boolean) {
+  const windowRef = useRef<HTMLElement>(null);
+  const drag = useRef<{ pointerX: number; pointerY: number; origin: FloatingPosition } | null>(null);
+  const [position, setPosition] = useState<FloatingPosition | null>(null);
+  const [mobile, setMobile] = useState(false);
+
+  const clampPosition = useCallback((candidate: FloatingPosition) => {
+    const element = windowRef.current;
+    if (!element) return candidate;
+    const rect = element.getBoundingClientRect();
+    return clampFloatingPosition(
+      candidate,
+      { width: rect.width, height: rect.height },
+      { width: window.innerWidth, height: window.innerHeight },
+      WINDOW_PADDING,
+    );
+  }, []);
+
+  useLayoutEffect(() => {
+    const nextMobile = window.innerWidth < MOBILE_BREAKPOINT;
+    setMobile(nextMobile);
+    if (!open || nextMobile) return;
+    const rect = windowRef.current?.getBoundingClientRect();
+    if (rect) setPosition((current) => clampPosition(current ?? { x: window.innerWidth - rect.width - 24, y: 24 }));
+  }, [clampPosition, open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const move = (event: PointerEvent) => {
+      if (!drag.current) return;
+      setPosition(clampPosition({
+        x: drag.current.origin.x + event.clientX - drag.current.pointerX,
+        y: drag.current.origin.y + event.clientY - drag.current.pointerY,
+      }));
+    };
+    const end = () => { drag.current = null; };
+    const resize = () => {
+      drag.current = null;
+      const nextMobile = window.innerWidth < MOBILE_BREAKPOINT;
+      setMobile(nextMobile);
+      if (!nextMobile) setPosition((current) => current && clampPosition(current));
+    };
+    window.addEventListener("pointermove", move);
+    window.addEventListener("pointerup", end);
+    window.addEventListener("pointercancel", end);
+    window.addEventListener("resize", resize);
+    return () => {
+      window.removeEventListener("pointermove", move);
+      window.removeEventListener("pointerup", end);
+      window.removeEventListener("pointercancel", end);
+      window.removeEventListener("resize", resize);
+    };
+  }, [clampPosition, open]);
+
+  const onPointerDown = (event: React.PointerEvent<HTMLElement>) => {
+    if (event.button !== 0 || window.innerWidth < MOBILE_BREAKPOINT) return;
+    if ((event.target as HTMLElement).closest("button, a, input, select, textarea")) return;
+    const rect = windowRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    event.preventDefault();
+    const origin = position ?? { x: rect.left, y: rect.top };
+    drag.current = { pointerX: event.clientX, pointerY: event.clientY, origin };
+    setPosition(clampPosition(origin));
+  };
+
+  return {
+    windowRef,
+    dragHandleProps: { onPointerDown, style: { cursor: "move", touchAction: "none" } as const },
+    windowStyle: mobile
+      ? { position: "fixed", left: 16, right: 16, bottom: 112, top: "auto", zIndex: 600000 } as const
+      : { position: "fixed", left: position?.x, top: position?.y, right: position ? "auto" : 24, zIndex: 600000 } as const,
+  };
+}

--- a/shared/hooks/useDraggableWindow.ts
+++ b/shared/hooks/useDraggableWindow.ts
@@ -8,15 +8,16 @@ const MOBILE_BREAKPOINT = 768;
 const WINDOW_PADDING = 16;
 
 export function useDraggableWindow(open: boolean) {
-  const windowRef = useRef<HTMLElement>(null);
+  const elementRef = useRef<HTMLElement | null>(null);
+  const [element, setElement] = useState<HTMLElement | null>(null);
   const drag = useRef<{ pointerX: number; pointerY: number; origin: FloatingPosition } | null>(null);
   const [position, setPosition] = useState<FloatingPosition | null>(null);
   const [mobile, setMobile] = useState(false);
 
   const clampPosition = useCallback((candidate: FloatingPosition) => {
-    const element = windowRef.current;
-    if (!element) return candidate;
-    const rect = element.getBoundingClientRect();
+    const current = elementRef.current;
+    if (!current) return candidate;
+    const rect = current.getBoundingClientRect();
     return clampFloatingPosition(
       candidate,
       { width: rect.width, height: rect.height },
@@ -25,13 +26,18 @@ export function useDraggableWindow(open: boolean) {
     );
   }, []);
 
+  const windowRef = useCallback((node: HTMLElement | null) => {
+    elementRef.current = node;
+    setElement(node);
+  }, []);
+
   useLayoutEffect(() => {
     const nextMobile = window.innerWidth < MOBILE_BREAKPOINT;
     setMobile(nextMobile);
     if (!open || nextMobile) return;
-    const rect = windowRef.current?.getBoundingClientRect();
+    const rect = element?.getBoundingClientRect();
     if (rect) setPosition((current) => clampPosition(current ?? { x: window.innerWidth - rect.width - 24, y: 24 }));
-  }, [clampPosition, open]);
+  }, [clampPosition, element, open]);
 
   useEffect(() => {
     if (!open) return;
@@ -64,7 +70,7 @@ export function useDraggableWindow(open: boolean) {
   const onPointerDown = (event: React.PointerEvent<HTMLElement>) => {
     if (event.button !== 0 || window.innerWidth < MOBILE_BREAKPOINT) return;
     if ((event.target as HTMLElement).closest("button, a, input, select, textarea")) return;
-    const rect = windowRef.current?.getBoundingClientRect();
+    const rect = elementRef.current?.getBoundingClientRect();
     if (!rect) return;
     event.preventDefault();
     const origin = position ?? { x: rect.left, y: rect.top };
@@ -76,7 +82,7 @@ export function useDraggableWindow(open: boolean) {
     windowRef,
     dragHandleProps: { onPointerDown, style: { cursor: "move", touchAction: "none" } as const },
     windowStyle: mobile
-      ? { position: "fixed", left: 16, right: 16, bottom: 112, top: "auto", zIndex: 600000 } as const
+      ? { position: "fixed", left: 16, right: 16, bottom: "calc(112px + env(safe-area-inset-bottom))", top: "auto", zIndex: 600000 } as const
       : { position: "fixed", left: position?.x, top: position?.y, right: position ? "auto" : 24, zIndex: 600000 } as const,
   };
 }

--- a/shared/hooks/useStageCamera.test.ts
+++ b/shared/hooks/useStageCamera.test.ts
@@ -1,4 +1,4 @@
-import { act, renderHook } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { focusStage, requestStageFocus, stageFocusPlan, useStageCamera } from "./useStageCamera";
@@ -74,5 +74,66 @@ describe("stage camera contract", () => {
     act(() => requestStageFocus("detail", "center"));
 
     expect(scrollTo).toHaveBeenCalledWith({ left: 450, behavior: "smooth" });
+  });
+
+  it("keeps a focus request until its stage is committed and focuses it once", async () => {
+    const owner = document.createElement("div");
+    const scrollTo = vi.fn();
+    Object.defineProperties(owner, {
+      scrollTo: { configurable: true, value: scrollTo },
+      clientWidth: { configurable: true, value: 400 },
+      scrollWidth: { configurable: true, value: 900 },
+    });
+    owner.getBoundingClientRect = () => ({ left: 0, right: 400, top: 0, bottom: 600, width: 400, height: 600, x: 0, y: 0, toJSON: () => ({}) });
+    const ref = { current: owner };
+    renderHook(() => useStageCamera(ref, ref, "player"));
+
+    act(() => requestStageFocus("late-detail", "nearest"));
+    expect(scrollTo).not.toHaveBeenCalled();
+
+    const target = document.createElement("div");
+    target.dataset.stageKey = "late-detail";
+    target.getBoundingClientRect = () => ({ left: 500, right: 800, top: 0, bottom: 400, width: 300, height: 400, x: 500, y: 0, toJSON: () => ({}) });
+    act(() => owner.append(target));
+
+    await waitFor(() => expect(scrollTo).toHaveBeenCalledTimes(1));
+    expect(scrollTo).toHaveBeenCalledWith({ left: 424, behavior: "smooth" });
+  });
+
+  it("coalesces competing focus intents from one commit to the final child target", () => {
+    const frames = new Map<number, FrameRequestCallback>();
+    let frameId = 0;
+    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+      frames.set(++frameId, callback);
+      return frameId;
+    });
+    vi.stubGlobal("cancelAnimationFrame", (id: number) => frames.delete(id));
+    const owner = document.createElement("div");
+    const list = document.createElement("div");
+    const detail = document.createElement("div");
+    list.dataset.stageKey = "list";
+    detail.dataset.stageKey = "detail";
+    owner.append(list, detail);
+    const scrollTo = vi.fn();
+    Object.defineProperties(owner, {
+      scrollTo: { configurable: true, value: scrollTo },
+      clientWidth: { configurable: true, value: 400 },
+      scrollWidth: { configurable: true, value: 1200 },
+    });
+    owner.getBoundingClientRect = () => ({ left: 0, right: 400, top: 0, bottom: 600, width: 400, height: 600, x: 0, y: 0, toJSON: () => ({}) });
+    list.getBoundingClientRect = () => ({ left: 400, right: 700, top: 0, bottom: 400, width: 300, height: 400, x: 400, y: 0, toJSON: () => ({}) });
+    detail.getBoundingClientRect = () => ({ left: 720, right: 1020, top: 0, bottom: 400, width: 300, height: 400, x: 720, y: 0, toJSON: () => ({}) });
+    const ref = { current: owner };
+    renderHook(() => useStageCamera(ref, ref, "player"));
+    frames.clear();
+
+    act(() => {
+      requestStageFocus("list");
+      requestStageFocus("detail");
+    });
+    [...frames.values()].forEach((callback) => callback(0));
+
+    expect(scrollTo).toHaveBeenCalledTimes(1);
+    expect(scrollTo).toHaveBeenCalledWith({ left: 644, behavior: "smooth" });
   });
 });

--- a/shared/hooks/useStageCamera.test.ts
+++ b/shared/hooks/useStageCamera.test.ts
@@ -1,11 +1,18 @@
-import { describe, expect, it, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { focusStage, stageFocusPlan } from "./useStageCamera";
+import { focusStage, requestStageFocus, stageFocusPlan, useStageCamera } from "./useStageCamera";
 
 describe("stage camera contract", () => {
-  it("targets a newly opened stage and replacement detail identity", () => {
+  beforeEach(() => {
+    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => { callback(0); return 1; });
+    vi.stubGlobal("cancelAnimationFrame", vi.fn());
+    vi.stubGlobal("matchMedia", vi.fn(() => ({ matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn() })));
+  });
+
+  it("targets a newly opened stage while stable detail replacement uses explicit intent", () => {
     expect(stageFocusPlan(["root"], ["root", "detail-a"])).toEqual({ key: "detail-a", align: "nearest" });
-    expect(stageFocusPlan(["root", "detail-a"], ["root", "detail-b"])).toEqual({ key: "detail-b", align: "center" });
+    expect(stageFocusPlan(["root", "detail"], ["root", "detail"])).toBeNull();
   });
 
   it("returns focus to the parent when a stage closes", () => {
@@ -27,5 +34,45 @@ describe("stage camera contract", () => {
     focusStage(owner, target, "nearest", true);
 
     expect(scrollTo).toHaveBeenCalledWith({ left: 424, behavior: "auto" });
+  });
+
+  it("keeps the larger mobile leading inset when revealing a stage", () => {
+    const owner = document.createElement("div");
+    const target = document.createElement("div");
+    const scrollTo = vi.fn();
+    Object.defineProperties(owner, {
+      scrollLeft: { configurable: true, writable: true, value: 100 },
+      scrollTo: { configurable: true, value: scrollTo },
+      clientWidth: { configurable: true, value: 400 },
+      scrollWidth: { configurable: true, value: 900 },
+    });
+    owner.getBoundingClientRect = () => ({ left: 0, right: 400, top: 0, bottom: 600, width: 400, height: 600, x: 0, y: 0, toJSON: () => ({}) });
+    target.getBoundingClientRect = () => ({ left: 10, right: 310, top: 0, bottom: 400, width: 300, height: 400, x: 10, y: 0, toJSON: () => ({}) });
+
+    focusStage(owner, target, "nearest", false, { leading: 48, trailing: 24 });
+
+    expect(scrollTo).toHaveBeenCalledWith({ left: 62, behavior: "smooth" });
+  });
+
+  it("moves the camera when an existing stage sends explicit focus intent", () => {
+    const owner = document.createElement("div");
+    const target = document.createElement("div");
+    target.dataset.stageKey = "detail";
+    owner.append(target);
+    const scrollTo = vi.fn();
+    Object.defineProperties(owner, {
+      scrollTo: { configurable: true, value: scrollTo },
+      clientWidth: { configurable: true, value: 400 },
+      scrollWidth: { configurable: true, value: 900 },
+    });
+    owner.getBoundingClientRect = () => ({ left: 0, right: 400, top: 0, bottom: 600, width: 400, height: 600, x: 0, y: 0, toJSON: () => ({}) });
+    target.getBoundingClientRect = () => ({ left: 500, right: 800, top: 0, bottom: 400, width: 300, height: 400, x: 500, y: 0, toJSON: () => ({}) });
+    const ref = { current: owner };
+    renderHook(() => useStageCamera(ref, ref, "player"));
+    scrollTo.mockClear();
+
+    act(() => requestStageFocus("detail", "center"));
+
+    expect(scrollTo).toHaveBeenCalledWith({ left: 450, behavior: "smooth" });
   });
 });

--- a/shared/hooks/useStageCamera.test.ts
+++ b/shared/hooks/useStageCamera.test.ts
@@ -1,10 +1,11 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { focusStage, requestStageFocus, stageFocusPlan, useStageCamera } from "./useStageCamera";
+import { cameraInsets, cameraProfileForWidth, focusStage, requestStageFocus, stageFocusPlan, useStageCamera } from "./useStageCamera";
 
 describe("stage camera contract", () => {
   beforeEach(() => {
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: 1440 });
     vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => { callback(0); return 1; });
     vi.stubGlobal("cancelAnimationFrame", vi.fn());
     vi.stubGlobal("matchMedia", vi.fn(() => ({ matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn() })));
@@ -13,6 +14,12 @@ describe("stage camera contract", () => {
   it("targets a newly opened stage while stable detail replacement uses explicit intent", () => {
     expect(stageFocusPlan(["root"], ["root", "detail-a"])).toEqual({ key: "detail-a", align: "nearest" });
     expect(stageFocusPlan(["root", "detail"], ["root", "detail"])).toBeNull();
+  });
+
+  it("selects wide, compact, and mobile policy from viewport width", () => {
+    expect(cameraProfileForWidth(1440)).toBe("wide");
+    expect(cameraProfileForWidth(1000)).toBe("compact");
+    expect(cameraProfileForWidth(390)).toBe("mobile");
   });
 
   it("returns focus to the parent when a stage closes", () => {
@@ -33,7 +40,7 @@ describe("stage camera contract", () => {
 
     focusStage(owner, target, "nearest", true);
 
-    expect(scrollTo).toHaveBeenCalledWith({ left: 424, behavior: "auto" });
+    expect(scrollTo).toHaveBeenCalledWith({ left: 448, behavior: "auto" });
   });
 
   it("keeps the larger mobile leading inset when revealing a stage", () => {
@@ -52,6 +59,61 @@ describe("stage camera contract", () => {
     focusStage(owner, target, "nearest", false, { leading: 48, trailing: 24 });
 
     expect(scrollTo).toHaveBeenCalledWith({ left: 62, behavior: "smooth" });
+  });
+
+  it.each([
+    ["wide", 448],
+    ["compact", 428],
+    ["mobile", 436],
+  ] as const)("uses the %s composition when revealing a child", (profile, expectedLeft) => {
+    const owner = document.createElement("div");
+    const target = document.createElement("div");
+    const scrollTo = vi.fn();
+    Object.defineProperties(owner, {
+      scrollTo: { configurable: true, value: scrollTo },
+      clientWidth: { configurable: true, value: 400 },
+      scrollWidth: { configurable: true, value: 900 },
+    });
+    owner.getBoundingClientRect = () => ({ left: 0, right: 400, top: 0, bottom: 600, width: 400, height: 600, x: 0, y: 0, toJSON: () => ({}) });
+    target.getBoundingClientRect = () => ({ left: 500, right: 800, top: 0, bottom: 400, width: 300, height: 400, x: 500, y: 0, toJSON: () => ({}) });
+
+    focusStage(owner, target, "nearest", false, cameraInsets(owner, profile), profile);
+
+    expect(scrollTo).toHaveBeenCalledWith({ left: expectedLeft, behavior: "smooth" });
+  });
+
+  it("keeps useful parent context while making a wide-desktop child readable", () => {
+    const owner = document.createElement("div");
+    const target = document.createElement("div");
+    const scrollTo = vi.fn();
+    Object.defineProperties(owner, {
+      scrollTo: { configurable: true, value: scrollTo },
+      clientWidth: { configurable: true, value: 1000 },
+      scrollWidth: { configurable: true, value: 1400 },
+    });
+    owner.getBoundingClientRect = () => ({ left: 0, right: 1000, top: 0, bottom: 600, width: 1000, height: 600, x: 0, y: 0, toJSON: () => ({}) });
+    target.getBoundingClientRect = () => ({ left: 720, right: 1064, top: 0, bottom: 400, width: 344, height: 400, x: 720, y: 0, toJSON: () => ({}) });
+
+    focusStage(owner, target, "nearest", false, cameraInsets(owner, "wide"), "wide");
+
+    expect(scrollTo).toHaveBeenCalledWith({ left: 184, behavior: "smooth" });
+  });
+
+  it.each(["wide", "compact", "mobile"] as const)("centers the parent on Back under the %s profile", (profile) => {
+    const owner = document.createElement("div");
+    const target = document.createElement("div");
+    const scrollTo = vi.fn();
+    Object.defineProperties(owner, {
+      scrollTo: { configurable: true, value: scrollTo },
+      clientWidth: { configurable: true, value: 400 },
+      scrollWidth: { configurable: true, value: 900 },
+    });
+    owner.getBoundingClientRect = () => ({ left: 0, right: 400, top: 0, bottom: 600, width: 400, height: 600, x: 0, y: 0, toJSON: () => ({}) });
+    target.getBoundingClientRect = () => ({ left: 200, right: 500, top: 0, bottom: 400, width: 300, height: 400, x: 200, y: 0, toJSON: () => ({}) });
+
+    focusStage(owner, target, "center", false, cameraInsets(owner, profile), profile);
+
+    expect(scrollTo).toHaveBeenCalledWith({ left: 150, behavior: "smooth" });
   });
 
   it("moves the camera when an existing stage sends explicit focus intent", () => {
@@ -97,7 +159,7 @@ describe("stage camera contract", () => {
     act(() => owner.append(target));
 
     await waitFor(() => expect(scrollTo).toHaveBeenCalledTimes(1));
-    expect(scrollTo).toHaveBeenCalledWith({ left: 424, behavior: "smooth" });
+    expect(scrollTo).toHaveBeenCalledWith({ left: 448, behavior: "smooth" });
   });
 
   it("coalesces competing focus intents from one commit to the final child target", () => {
@@ -134,6 +196,29 @@ describe("stage camera contract", () => {
     [...frames.values()].forEach((callback) => callback(0));
 
     expect(scrollTo).toHaveBeenCalledTimes(1);
-    expect(scrollTo).toHaveBeenCalledWith({ left: 644, behavior: "smooth" });
+    expect(scrollTo).toHaveBeenCalledWith({ left: 668, behavior: "smooth" });
+  });
+
+  it("re-applies the active stage through the shared profile when the viewport resizes", async () => {
+    const owner = document.createElement("div");
+    const target = document.createElement("div");
+    target.dataset.stageKey = "root";
+    owner.append(target);
+    const scrollTo = vi.fn();
+    Object.defineProperties(owner, {
+      scrollTo: { configurable: true, value: scrollTo },
+      clientWidth: { configurable: true, value: 400 },
+      scrollWidth: { configurable: true, value: 900 },
+    });
+    owner.getBoundingClientRect = () => ({ left: 0, right: 400, top: 0, bottom: 600, width: 400, height: 600, x: 0, y: 0, toJSON: () => ({}) });
+    target.getBoundingClientRect = () => ({ left: 500, right: 800, top: 0, bottom: 400, width: 300, height: 400, x: 500, y: 0, toJSON: () => ({}) });
+    const ref = { current: owner };
+    renderHook(() => useStageCamera(ref, ref, "player"));
+    scrollTo.mockClear();
+
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: 1000 });
+    act(() => window.dispatchEvent(new Event("resize")));
+
+    await waitFor(() => expect(scrollTo).toHaveBeenCalledWith({ left: 428, behavior: "smooth" }));
   });
 });

--- a/shared/hooks/useStageCamera.ts
+++ b/shared/hooks/useStageCamera.ts
@@ -3,6 +3,14 @@
 import { useEffect, useState } from "react";
 
 type StageFocusPlan = { key: string; align: "center" | "nearest" } | null;
+type StageFocusDetail = NonNullable<StageFocusPlan>;
+
+export const STAGE_FOCUS_EVENT = "lag:stage-focus";
+
+export function requestStageFocus(key: string, align: StageFocusDetail["align"] = "nearest") {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new CustomEvent<StageFocusDetail>(STAGE_FOCUS_EVENT, { detail: { key, align } }));
+}
 
 export function stageFocusPlan(previous: string[], next: string[]): StageFocusPlan {
   const previousSet = new Set(previous);
@@ -21,25 +29,33 @@ export function focusStage(
   target: HTMLElement,
   align: "center" | "nearest",
   reducedMotion: boolean,
+  insets = cameraInsets(owner),
 ) {
   const ownerRect = owner.getBoundingClientRect();
   const targetRect = target.getBoundingClientRect();
   const targetLeft = owner.scrollLeft + targetRect.left - ownerRect.left;
-  const safe = 24;
   let left = owner.scrollLeft;
 
   if (align === "center") {
     left = targetLeft + targetRect.width / 2 - owner.clientWidth / 2;
-  } else if (targetLeft < owner.scrollLeft + safe) {
-    left = targetLeft - safe;
-  } else if (targetLeft + targetRect.width > owner.scrollLeft + owner.clientWidth - safe) {
-    left = targetLeft + targetRect.width - owner.clientWidth + safe;
+  } else if (targetLeft < owner.scrollLeft + insets.leading) {
+    left = targetLeft - insets.leading;
+  } else if (targetLeft + targetRect.width > owner.scrollLeft + owner.clientWidth - insets.trailing) {
+    left = targetLeft + targetRect.width - owner.clientWidth + insets.trailing;
   }
 
   owner.scrollTo({
     left: Math.max(0, Math.min(left, Math.max(0, owner.scrollWidth - owner.clientWidth))),
     behavior: reducedMotion ? "auto" : "smooth",
   });
+}
+
+export function cameraInsets(owner: HTMLElement) {
+  const style = getComputedStyle(owner);
+  return {
+    leading: Number.parseFloat(style.scrollPaddingLeft) || 24,
+    trailing: Number.parseFloat(style.scrollPaddingRight) || 24,
+  };
 }
 
 function stages(owner: HTMLElement) {
@@ -81,10 +97,20 @@ export function useStageCamera(
         if (plan && target) focusStage(owner, target, plan.align, prefersReducedMotion());
       });
     });
+    const focusRequested = (event: Event) => {
+      const { key, align } = (event as CustomEvent<StageFocusDetail>).detail;
+      cancelAnimationFrame(frame);
+      frame = requestAnimationFrame(() => {
+        const target = stages(owner).find((stage) => stage.dataset.stageKey === key);
+        if (target) focusStage(owner, target, align, prefersReducedMotion());
+      });
+    };
     observer.observe(owner, { childList: true, subtree: true });
+    window.addEventListener(STAGE_FOCUS_EVENT, focusRequested);
     return () => {
       cancelAnimationFrame(frame);
       observer.disconnect();
+      window.removeEventListener(STAGE_FOCUS_EVENT, focusRequested);
     };
   }, [mobile, viewportRef, workspaceRef]);
 
@@ -92,7 +118,7 @@ export function useStageCamera(
     const owner = mobile ? viewportRef.current : workspaceRef.current;
     const target = owner && stages(owner)[0];
     if (!owner || !target) return;
-    const frame = requestAnimationFrame(() => focusStage(owner, target, "center", prefersReducedMotion()));
+    const frame = requestAnimationFrame(() => focusStage(owner, target, mobile ? "nearest" : "center", prefersReducedMotion()));
     return () => cancelAnimationFrame(frame);
   }, [mainSelectionKey, mobile, viewportRef, workspaceRef]);
 }

--- a/shared/hooks/useStageCamera.ts
+++ b/shared/hooks/useStageCamera.ts
@@ -6,10 +6,16 @@ type StageFocusPlan = { key: string; align: "center" | "nearest" } | null;
 type StageFocusDetail = NonNullable<StageFocusPlan>;
 
 export const STAGE_FOCUS_EVENT = "lag:stage-focus";
+let pendingFocus: StageFocusDetail | null = null;
 
 export function requestStageFocus(key: string, align: StageFocusDetail["align"] = "nearest") {
   if (typeof window === "undefined") return;
-  window.dispatchEvent(new CustomEvent<StageFocusDetail>(STAGE_FOCUS_EVENT, { detail: { key, align } }));
+  pendingFocus = { key, align };
+  window.dispatchEvent(new CustomEvent<StageFocusDetail>(STAGE_FOCUS_EVENT, { detail: pendingFocus }));
+}
+
+export function pendingStageFocus(): StageFocusDetail | null {
+  return pendingFocus;
 }
 
 export function stageFocusPlan(previous: string[], next: string[]): StageFocusPlan {
@@ -87,10 +93,29 @@ export function useStageCamera(
     if (!owner) return;
     let previous = stages(owner).map((stage) => stage.dataset.stageKey!);
     let frame = 0;
+    const focus = (detail: StageFocusDetail) => {
+      cancelAnimationFrame(frame);
+      frame = requestAnimationFrame(() => {
+        const target = stages(owner).find((stage) => stage.dataset.stageKey === detail.key);
+        if (!target) return;
+        focusStage(owner, target, detail.align, prefersReducedMotion());
+        if (pendingFocus?.key === detail.key) pendingFocus = null;
+      });
+    };
     const observer = new MutationObserver(() => {
       cancelAnimationFrame(frame);
       frame = requestAnimationFrame(() => {
         const nextStages = stages(owner);
+        if (pendingFocus) {
+          const target = nextStages.find((stage) => stage.dataset.stageKey === pendingFocus?.key);
+          if (target) {
+            const detail = pendingFocus;
+            focusStage(owner, target, detail.align, prefersReducedMotion());
+            if (pendingFocus?.key === detail.key) pendingFocus = null;
+          }
+          previous = nextStages.map((stage) => stage.dataset.stageKey!);
+          return;
+        }
         const plan = stageFocusPlan(previous, nextStages.map((stage) => stage.dataset.stageKey!));
         previous = nextStages.map((stage) => stage.dataset.stageKey!);
         const target = plan && nextStages.find((stage) => stage.dataset.stageKey === plan.key);
@@ -98,15 +123,11 @@ export function useStageCamera(
       });
     });
     const focusRequested = (event: Event) => {
-      const { key, align } = (event as CustomEvent<StageFocusDetail>).detail;
-      cancelAnimationFrame(frame);
-      frame = requestAnimationFrame(() => {
-        const target = stages(owner).find((stage) => stage.dataset.stageKey === key);
-        if (target) focusStage(owner, target, align, prefersReducedMotion());
-      });
+      focus((event as CustomEvent<StageFocusDetail>).detail);
     };
     observer.observe(owner, { childList: true, subtree: true });
     window.addEventListener(STAGE_FOCUS_EVENT, focusRequested);
+    if (pendingFocus) focus(pendingFocus);
     return () => {
       cancelAnimationFrame(frame);
       observer.disconnect();
@@ -117,7 +138,7 @@ export function useStageCamera(
   useEffect(() => {
     const owner = mobile ? viewportRef.current : workspaceRef.current;
     const target = owner && stages(owner)[0];
-    if (!owner || !target) return;
+    if (!owner || !target || pendingFocus) return;
     const frame = requestAnimationFrame(() => focusStage(owner, target, mobile ? "nearest" : "center", prefersReducedMotion()));
     return () => cancelAnimationFrame(frame);
   }, [mainSelectionKey, mobile, viewportRef, workspaceRef]);

--- a/shared/hooks/useStageCamera.ts
+++ b/shared/hooks/useStageCamera.ts
@@ -1,9 +1,10 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 type StageFocusPlan = { key: string; align: "center" | "nearest" } | null;
 type StageFocusDetail = NonNullable<StageFocusPlan>;
+export type CameraProfile = "wide" | "compact" | "mobile";
 
 export const STAGE_FOCUS_EVENT = "lag:stage-focus";
 let pendingFocus: StageFocusDetail | null = null;
@@ -35,7 +36,8 @@ export function focusStage(
   target: HTMLElement,
   align: "center" | "nearest",
   reducedMotion: boolean,
-  insets = cameraInsets(owner),
+  insets = cameraInsets(owner, "wide"),
+  profile: CameraProfile = "wide",
 ) {
   const ownerRect = owner.getBoundingClientRect();
   const targetRect = target.getBoundingClientRect();
@@ -44,6 +46,8 @@ export function focusStage(
 
   if (align === "center") {
     left = targetLeft + targetRect.width / 2 - owner.clientWidth / 2;
+  } else if (profile !== "wide") {
+    left = targetLeft - insets.leading;
   } else if (targetLeft < owner.scrollLeft + insets.leading) {
     left = targetLeft - insets.leading;
   } else if (targetLeft + targetRect.width > owner.scrollLeft + owner.clientWidth - insets.trailing) {
@@ -56,11 +60,28 @@ export function focusStage(
   });
 }
 
-export function cameraInsets(owner: HTMLElement) {
+export function cameraProfileForWidth(width: number): CameraProfile {
+  if (width < 768) return "mobile";
+  if (width < 1200) return "compact";
+  return "wide";
+}
+
+export function cameraInsets(owner: HTMLElement, profile: CameraProfile) {
   const style = getComputedStyle(owner);
+  const cssLeading = Number.parseFloat(style.scrollPaddingLeft) || 24;
+  const cssTrailing = Number.parseFloat(style.scrollPaddingRight) || 24;
+  if (profile === "mobile") {
+    return { leading: Math.max(cssLeading, 64), trailing: Math.max(cssTrailing, 24) };
+  }
+  if (profile === "compact") {
+    return {
+      leading: Math.max(cssLeading, Math.min(128, Math.max(72, owner.clientWidth * 0.16))),
+      trailing: Math.max(cssTrailing, 32),
+    };
+  }
   return {
-    leading: Number.parseFloat(style.scrollPaddingLeft) || 24,
-    trailing: Number.parseFloat(style.scrollPaddingRight) || 24,
+    leading: Math.max(cssLeading, 32),
+    trailing: Math.max(cssTrailing, Math.min(160, Math.max(48, owner.clientWidth * 0.12))),
   };
 }
 
@@ -77,19 +98,22 @@ export function useStageCamera(
   workspaceRef: React.RefObject<HTMLDivElement | null>,
   mainSelectionKey: string,
 ) {
-  const [mobile, setMobile] = useState(false);
+  const [profile, setProfile] = useState<CameraProfile>(() =>
+    cameraProfileForWidth(typeof window === "undefined" ? 1200 : window.innerWidth),
+  );
+  const profileRef = useRef(profile);
+  profileRef.current = profile;
+  const lastFocusedStage = useRef<string | null>(null);
 
   useEffect(() => {
-    if (typeof window.matchMedia !== "function") return;
-    const query = window.matchMedia("(max-width: 767px)");
-    const update = () => setMobile(query.matches);
+    const update = () => setProfile(cameraProfileForWidth(window.innerWidth));
     update();
-    query.addEventListener("change", update);
-    return () => query.removeEventListener("change", update);
+    window.addEventListener("resize", update);
+    return () => window.removeEventListener("resize", update);
   }, []);
 
   useEffect(() => {
-    const owner = mobile ? viewportRef.current : workspaceRef.current;
+    const owner = profile === "mobile" ? viewportRef.current : workspaceRef.current;
     if (!owner) return;
     let previous = stages(owner).map((stage) => stage.dataset.stageKey!);
     let frame = 0;
@@ -98,7 +122,8 @@ export function useStageCamera(
       frame = requestAnimationFrame(() => {
         const target = stages(owner).find((stage) => stage.dataset.stageKey === detail.key);
         if (!target) return;
-        focusStage(owner, target, detail.align, prefersReducedMotion());
+        focusStage(owner, target, detail.align, prefersReducedMotion(), cameraInsets(owner, profile), profile);
+        lastFocusedStage.current = detail.key;
         if (pendingFocus?.key === detail.key) pendingFocus = null;
       });
     };
@@ -110,7 +135,8 @@ export function useStageCamera(
           const target = nextStages.find((stage) => stage.dataset.stageKey === pendingFocus?.key);
           if (target) {
             const detail = pendingFocus;
-            focusStage(owner, target, detail.align, prefersReducedMotion());
+            focusStage(owner, target, detail.align, prefersReducedMotion(), cameraInsets(owner, profile), profile);
+            lastFocusedStage.current = detail.key;
             if (pendingFocus?.key === detail.key) pendingFocus = null;
           }
           previous = nextStages.map((stage) => stage.dataset.stageKey!);
@@ -119,7 +145,10 @@ export function useStageCamera(
         const plan = stageFocusPlan(previous, nextStages.map((stage) => stage.dataset.stageKey!));
         previous = nextStages.map((stage) => stage.dataset.stageKey!);
         const target = plan && nextStages.find((stage) => stage.dataset.stageKey === plan.key);
-        if (plan && target) focusStage(owner, target, plan.align, prefersReducedMotion());
+        if (plan && target) {
+          focusStage(owner, target, plan.align, prefersReducedMotion(), cameraInsets(owner, profile), profile);
+          lastFocusedStage.current = plan.key;
+        }
       });
     });
     const focusRequested = (event: Event) => {
@@ -128,18 +157,23 @@ export function useStageCamera(
     observer.observe(owner, { childList: true, subtree: true });
     window.addEventListener(STAGE_FOCUS_EVENT, focusRequested);
     if (pendingFocus) focus(pendingFocus);
+    else if (lastFocusedStage.current) focus({ key: lastFocusedStage.current, align: "nearest" });
     return () => {
       cancelAnimationFrame(frame);
       observer.disconnect();
       window.removeEventListener(STAGE_FOCUS_EVENT, focusRequested);
     };
-  }, [mobile, viewportRef, workspaceRef]);
+  }, [profile, viewportRef, workspaceRef]);
 
   useEffect(() => {
-    const owner = mobile ? viewportRef.current : workspaceRef.current;
+    const currentProfile = profileRef.current;
+    const owner = currentProfile === "mobile" ? viewportRef.current : workspaceRef.current;
     const target = owner && stages(owner)[0];
     if (!owner || !target || pendingFocus) return;
-    const frame = requestAnimationFrame(() => focusStage(owner, target, mobile ? "nearest" : "center", prefersReducedMotion()));
+    const frame = requestAnimationFrame(() => {
+      focusStage(owner, target, currentProfile === "wide" ? "center" : "nearest", prefersReducedMotion(), cameraInsets(owner, currentProfile), currentProfile);
+      lastFocusedStage.current = target.dataset.stageKey ?? null;
+    });
     return () => cancelAnimationFrame(frame);
-  }, [mainSelectionKey, mobile, viewportRef, workspaceRef]);
+  }, [mainSelectionKey, viewportRef, workspaceRef]);
 }

--- a/shared/lib/motion.test.ts
+++ b/shared/lib/motion.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+import { MOTION } from "./motion";
+
+describe("shared staged motion grammar", () => {
+  it("uses a short reveal without cumulative delay and a smaller detail replacement", () => {
+    expect(Math.abs(MOTION.panelSlot.initial.x)).toBeLessThanOrEqual(36);
+    expect(MOTION.panelSlot.transition.duration).toBeGreaterThanOrEqual(0.16);
+    expect(MOTION.panelSlot.transition.duration).toBeLessThanOrEqual(0.24);
+    expect(MOTION.panelSlot.transition).not.toHaveProperty("delay");
+    expect(Math.abs(MOTION.panelContentSwap.initial.x)).toBeLessThanOrEqual(12);
+  });
+
+  it("removes spatial entry and exit when reduced motion is requested", () => {
+    const source = readFileSync("shared/ui/PanelStage.tsx", "utf8");
+    expect(source).toContain('initial={reducedMotion ? false : MOTION.panelSlot.initial}');
+    expect(source).toContain('exit={reducedMotion ? { opacity: 0 } : MOTION.panelSlot.exit}');
+    expect(source).toContain('transition={reducedMotion ? { duration: 0 }');
+  });
+});

--- a/shared/lib/motion.test.ts
+++ b/shared/lib/motion.test.ts
@@ -17,5 +17,6 @@ describe("shared staged motion grammar", () => {
     expect(source).toContain('initial={reducedMotion ? false : MOTION.panelSlot.initial}');
     expect(source).toContain('exit={reducedMotion ? { opacity: 0 } : MOTION.panelSlot.exit}');
     expect(source).toContain('transition={reducedMotion ? { duration: 0 }');
+    expect(source).toContain("useLayoutEffect");
   });
 });

--- a/shared/lib/motion.ts
+++ b/shared/lib/motion.ts
@@ -2,34 +2,35 @@ export const EASE_OUT = [0.22, 1, 0.36, 1] as const;
 
 // Spring configs — 스프링 물리 기반으로 "실재감" 부여
 const SNAP   = { type: "spring", stiffness: 500, damping: 30 } as const;
-const FLOAT  = { type: "spring", stiffness: 360, damping: 28 } as const;
 const GENTLE = { type: "spring", stiffness: 280, damping: 26 } as const;
+const STAGE = { type: "tween", duration: 0.2, ease: EASE_OUT } as const;
+const CONTENT = { type: "tween", duration: 0.16, ease: EASE_OUT } as const;
 
 export const MOTION = {
-  // ── 패널 진입 (우→좌 슬라이드, 스프링으로 리바운드) ──────────────────
+  // ── 패널 진입 — 짧은 SAO-style reveal, 누적 delay 없음 ───────────────
   panelReset: {
-    initial:    { opacity: 0, x: 28, scale: 0.97 },
-    animate:    { opacity: 1, x: 0,  scale: 1    },
-    exit:       { opacity: 0, x: -14, scale: 0.97 },
-    transition: FLOAT,
+    initial:    { opacity: 0, x: 24 },
+    animate:    { opacity: 1, x: 0  },
+    exit:       { opacity: 0, x: -12 },
+    transition: STAGE,
   },
   panelSwap: {
-    initial:    { opacity: 0, x: 32, scale: 0.97 },
-    animate:    { opacity: 1, x: 0,  scale: 1    },
-    exit:       { opacity: 0, x: -14, scale: 0.97 },
-    transition: FLOAT,
+    initial:    { opacity: 0, x: 24 },
+    animate:    { opacity: 1, x: 0  },
+    exit:       { opacity: 0, x: -12 },
+    transition: STAGE,
   },
   panelSlot: {
-    initial:    { opacity: 0, x: 24, scale: 0.97 },
-    animate:    { opacity: 1, x: 0,  scale: 1    },
-    exit:       { opacity: 0, x: -10, scale: 0.97 },
-    transition: FLOAT,
+    initial:    { opacity: 0, x: 24 },
+    animate:    { opacity: 1, x: 0  },
+    exit:       { opacity: 0, x: -12 },
+    transition: STAGE,
   },
   panelContentSwap: {
-    initial:    { opacity: 0, x: 22, scale: 0.98 },
-    animate:    { opacity: 1, x: 0,  scale: 1    },
-    exit:       { opacity: 0, x: -10, scale: 0.97 },
-    transition: FLOAT,
+    initial:    { opacity: 0, x: 8 },
+    animate:    { opacity: 1, x: 0 },
+    exit:       { opacity: 0, x: -6 },
+    transition: CONTENT,
   },
 
   // ── 리스트 아이템 — 스태거와 함께 쓸 때 delay를 index*0.04 로 ────────

--- a/shared/lib/viewport.test.ts
+++ b/shared/lib/viewport.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { clampFloatingPosition, notificationPopupPosition } from "./viewport";
+
+describe("viewport-aware utility geometry", () => {
+  it("clamps a dragged window on every viewport edge and after resize", () => {
+    expect(clampFloatingPosition({ x: -200, y: 900 }, { width: 420, height: 500 }, { width: 1200, height: 800 }))
+      .toEqual({ x: 16, y: 284 });
+    expect(clampFloatingPosition({ x: 760, y: 284 }, { width: 420, height: 500 }, { width: 900, height: 650 }))
+      .toEqual({ x: 464, y: 134 });
+  });
+
+  it("places a notification above when needed and clamps it inside horizontal padding", () => {
+    expect(notificationPopupPosition(
+      { left: 4, right: 36, top: 700, bottom: 732 },
+      { width: 320, height: 360 },
+      { width: 390, height: 844 },
+    )).toEqual({ x: 16, y: 330 });
+  });
+});

--- a/shared/lib/viewport.ts
+++ b/shared/lib/viewport.ts
@@ -1,0 +1,33 @@
+export type ViewportSize = { width: number; height: number };
+export type FloatingSize = { width: number; height: number };
+export type FloatingPosition = { x: number; y: number };
+
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), Math.max(min, max));
+
+export function clampFloatingPosition(
+  position: FloatingPosition,
+  windowSize: FloatingSize,
+  viewport: ViewportSize,
+  padding = 16,
+): FloatingPosition {
+  return {
+    x: clamp(position.x, padding, viewport.width - windowSize.width - padding),
+    y: clamp(position.y, padding, viewport.height - windowSize.height - padding),
+  };
+}
+
+export function notificationPopupPosition(
+  anchor: Pick<DOMRect, "left" | "right" | "top" | "bottom">,
+  popup: FloatingSize,
+  viewport: ViewportSize,
+  padding = 16,
+  gap = 10,
+): FloatingPosition {
+  const below = anchor.bottom + gap;
+  const above = anchor.top - popup.height - gap;
+  const y = below + popup.height <= viewport.height - padding || above < padding ? below : above;
+  return {
+    x: clamp(anchor.right - popup.width, padding, viewport.width - popup.width - padding),
+    y: clamp(y, padding, viewport.height - popup.height - padding),
+  };
+}

--- a/shared/ui/PanelCard.tsx
+++ b/shared/ui/PanelCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { AnimatePresence, motion } from "framer-motion";
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 import { useRef, useState } from "react";
 
 import { useLongPress } from "@/shared/hooks/useLongPress";
@@ -62,10 +62,10 @@ export default function PanelCard({
   onClick,
   onDoubleClick,
   disabled = false,
-  index = 0,
   actions,
   onAction,
 }: PanelCardProps) {
+  const reducedMotion = useReducedMotion();
   const isInteractive = Boolean(onClick) && !disabled;
   const hasActions = Boolean(actions?.length && onAction);
   const hasDelete = actions?.some((a) => a.type === "delete");
@@ -204,14 +204,12 @@ export default function PanelCard({
       data-drag-scroll-allow
       data-scroll-center-target={centerTarget ? "true" : undefined}
       className="relative overflow-hidden"
-      initial={MOTION.listItem.initial}
+      initial={reducedMotion ? false : MOTION.listItem.initial}
       animate={MOTION.listItem.animate}
-      exit={MOTION.listItem.exit}
-      transition={{
-        ...MOTION.listItem.transition,
-        delay: index * 0.045,
-        layout: { type: "tween", duration: 0.34, ease: [0.22, 1, 0.36, 1] },
-      }}
+      exit={reducedMotion ? { opacity: 0 } : MOTION.listItem.exit}
+      transition={reducedMotion
+        ? { duration: 0, layout: { duration: 0 } }
+        : { ...MOTION.listItem.transition, layout: { type: "tween", duration: 0.2, ease: [0.22, 1, 0.36, 1] } }}
     >
       {/* Swipe-left delete hint — revealed behind the card */}
       {hasDelete ? (

--- a/shared/ui/PanelStage.tsx
+++ b/shared/ui/PanelStage.tsx
@@ -1,35 +1,58 @@
 "use client";
 
-import { motion, useReducedMotion } from "framer-motion";
+import { motion, useIsPresent, useReducedMotion } from "framer-motion";
+import { useEffect } from "react";
 
 import { MOTION } from "@/shared/lib/motion";
+import { requestStageFocus } from "@/shared/hooks/useStageCamera";
 
 export default function PanelStage({
   stageKey,
-  index = 0,
+  focusKey,
   children,
   onPointerDownCapture,
   zIndex,
 }: {
   stageKey: string;
+  focusKey?: string | number | null;
   index?: number;
   children: React.ReactNode;
   onPointerDownCapture?: () => void;
   zIndex?: number;
 }) {
   const reducedMotion = useReducedMotion();
+  const isPresent = useIsPresent();
+
+  useEffect(() => {
+    requestStageFocus(stageKey, "nearest");
+  }, [focusKey, stageKey]);
 
   return (
     <motion.div
       layout="position"
       className="lag-panel-stage relative"
       data-stage-key={stageKey}
+      aria-hidden={isPresent ? undefined : true}
       onPointerDownCapture={onPointerDownCapture}
       initial={reducedMotion ? false : MOTION.panelSlot.initial}
       animate={MOTION.panelSlot.animate}
-      exit={MOTION.panelSlot.exit}
-      transition={reducedMotion ? { duration: 0 } : { type: "spring", stiffness: 380, damping: 28, delay: index * 0.055 }}
-      style={{ willChange: "transform, opacity", zIndex }}
+      exit={reducedMotion ? { opacity: 0 } : MOTION.panelSlot.exit}
+      transition={reducedMotion ? { duration: 0 } : MOTION.panelSlot.transition}
+      style={{ willChange: "transform, opacity", pointerEvents: isPresent ? undefined : "none", zIndex }}
+    >
+      {children}
+    </motion.div>
+  );
+}
+
+export function StageContentTransition({ identity, children }: { identity: React.Key; children: React.ReactNode }) {
+  const reducedMotion = useReducedMotion();
+  return (
+    <motion.div
+      key={identity}
+      initial={reducedMotion ? false : MOTION.panelContentSwap.initial}
+      animate={MOTION.panelContentSwap.animate}
+      transition={reducedMotion ? { duration: 0 } : MOTION.panelContentSwap.transition}
     >
       {children}
     </motion.div>

--- a/shared/ui/PanelStage.tsx
+++ b/shared/ui/PanelStage.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { motion, useIsPresent, useReducedMotion } from "framer-motion";
-import { useEffect } from "react";
+import { useLayoutEffect } from "react";
 
 import { MOTION } from "@/shared/lib/motion";
 import { requestStageFocus } from "@/shared/hooks/useStageCamera";
@@ -9,12 +9,14 @@ import { requestStageFocus } from "@/shared/hooks/useStageCamera";
 export default function PanelStage({
   stageKey,
   focusKey,
+  autoFocus = true,
   children,
   onPointerDownCapture,
   zIndex,
 }: {
   stageKey: string;
   focusKey?: string | number | null;
+  autoFocus?: boolean;
   index?: number;
   children: React.ReactNode;
   onPointerDownCapture?: () => void;
@@ -23,9 +25,10 @@ export default function PanelStage({
   const reducedMotion = useReducedMotion();
   const isPresent = useIsPresent();
 
-  useEffect(() => {
+  useLayoutEffect(() => {
+    if (!autoFocus) return;
     requestStageFocus(stageKey, "nearest");
-  }, [focusKey, stageKey]);
+  }, [autoFocus, focusKey, stageKey]);
 
   return (
     <motion.div

--- a/shared/ui/UtilityPortal.tsx
+++ b/shared/ui/UtilityPortal.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+
+export default function UtilityPortal({ children }: { children: React.ReactNode }) {
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+  return mounted ? createPortal(children, document.body) : null;
+}

--- a/widgets/left-context/LeftContext.test.tsx
+++ b/widgets/left-context/LeftContext.test.tsx
@@ -31,4 +31,34 @@ describe("LeftContext에서 Role을 사용할 때", () => {
       expect(selectRole).toHaveBeenCalledWith(3);
     });
   });
+
+  it("Player와 Role이 같은 lane/frame을 유지하고 내부 content만 교체한다", () => {
+    const { container, rerender } = render(
+      <LeftContext mode="player" roles={roles} selectedRoleId={null} socialContext={null} />,
+    );
+    const lane = container.querySelector(".lag-left-anchor");
+    const frame = container.querySelector(".lag-left-context");
+
+    rerender(<LeftContext mode="role" roles={roles} selectedRoleId={null} socialContext={null} />);
+
+    expect(container.querySelector(".lag-left-anchor")).toBe(lane);
+    expect(container.querySelector(".lag-left-context")).toBe(frame);
+    expect(lane).toHaveAttribute("data-context-present", "true");
+  });
+
+  it("keeps a stable collapsible lane and shared bounded content scroll", () => {
+    const css = readFileSync("app/globals.css", "utf8");
+    const { container, rerender } = render(
+      <LeftContext mode="player" roles={roles} selectedRoleId={null} socialContext={null} />,
+    );
+    const lane = container.querySelector(".lag-left-anchor");
+
+    rerender(<LeftContext mode="hidden" socialContext={null} />);
+
+    expect(container.querySelector(".lag-left-anchor")).toBe(lane);
+    expect(lane).toHaveAttribute("data-context-present", "false");
+    expect(css).not.toContain("display: contents");
+    expect(css).toMatch(/\.lag-left-anchor\[data-context-present="false"\]\s*{[^}]*width:\s*0;[^}]*flex-basis:\s*0;/);
+    expect(css).toMatch(/\.lag-left-context-content\s*{[^}]*height:\s*100%;[^}]*overflow-y:\s*auto;/);
+  });
 });

--- a/widgets/left-context/LeftContext.tsx
+++ b/widgets/left-context/LeftContext.tsx
@@ -43,18 +43,19 @@ export default function LeftContext({
   onFocus,
 }: LeftContextProps) {
   const reducedMotion = useReducedMotion();
+  const visible = mode !== "hidden";
   return (
-    <div className={`lag-left-anchor${mode === "hidden" ? " lag-left-anchor-empty" : ""}`}>
+    <div className="lag-left-anchor" data-context-present={visible}>
       <AnimatePresence initial={false}>
-        {mode !== "hidden" ? (
+        {visible ? (
         <motion.div
-          key={`left-context-${mode}`}
+          key="left-context-frame"
           initial={reducedMotion ? false : MOTION.panelReset.initial}
           animate={MOTION.panelReset.animate}
           exit={reducedMotion ? { opacity: 0 } : MOTION.panelReset.exit}
           transition={reducedMotion ? { duration: 0 } : MOTION.panelReset.transition}
           className="lag-left-context lag-panel-stage relative overflow-hidden"
-          data-stage-key={`left-context-${mode}`}
+          data-stage-key="left-context"
           onPointerDownCapture={onFocus}
           style={{
             width: UI_CONSTS.leftContext.width,
@@ -85,19 +86,30 @@ export default function LeftContext({
               pointerEvents: "none",
             }}
           />
-          {mode === "player" ? (
-            <PlayerPanel playerInfo={playerInfo} equipments={equipments} guildName={guildName} roles={roles} selectedRoleId={selectedRoleId} onRoleSelect={onRoleSelect} />
-          ) : mode === "role" ? (
-            <RoleContextPanel
-              roles={roles}
-              selectedRoleId={selectedRoleId ?? null}
-              isLoading={rolesLoading}
-              error={rolesError}
-              onRoleSelect={onRoleSelect}
-            />
-          ) : (
-            <SocialPanel socialContext={socialContext} />
-          )}
+          <AnimatePresence initial={false} mode="wait">
+            <motion.div
+              key={mode}
+              className="lag-left-context-content scrollbar-hide"
+              initial={reducedMotion ? false : MOTION.panelContentSwap.initial}
+              animate={MOTION.panelContentSwap.animate}
+              exit={reducedMotion ? { opacity: 0 } : MOTION.panelContentSwap.exit}
+              transition={reducedMotion ? { duration: 0 } : MOTION.panelContentSwap.transition}
+            >
+              {mode === "player" ? (
+                <PlayerPanel playerInfo={playerInfo} equipments={equipments} guildName={guildName} roles={roles} selectedRoleId={selectedRoleId} onRoleSelect={onRoleSelect} />
+              ) : mode === "role" ? (
+                <RoleContextPanel
+                  roles={roles}
+                  selectedRoleId={selectedRoleId ?? null}
+                  isLoading={rolesLoading}
+                  error={rolesError}
+                  onRoleSelect={onRoleSelect}
+                />
+              ) : (
+                <SocialPanel socialContext={socialContext} />
+              )}
+            </motion.div>
+          </AnimatePresence>
         </motion.div>
         ) : null}
       </AnimatePresence>

--- a/widgets/left-context/LeftContext.tsx
+++ b/widgets/left-context/LeftContext.tsx
@@ -53,12 +53,11 @@ export default function LeftContext({
           animate={MOTION.panelReset.animate}
           exit={reducedMotion ? { opacity: 0 } : MOTION.panelReset.exit}
           transition={reducedMotion ? { duration: 0 } : MOTION.panelReset.transition}
-          className="lag-left-context lag-panel-stage relative h-full min-h-[420px] overflow-hidden"
+          className="lag-left-context lag-panel-stage relative overflow-hidden"
           data-stage-key={`left-context-${mode}`}
           onPointerDownCapture={onFocus}
           style={{
             width: UI_CONSTS.leftContext.width,
-            minHeight: UI_CONSTS.leftContext.minHeight,
             willChange: "transform, opacity",
             zIndex,
           }}

--- a/widgets/left-context/LeftContext.tsx
+++ b/widgets/left-context/LeftContext.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { AnimatePresence, motion } from "framer-motion";
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 
 import type { EquipmentView, PlayerInfo, RoleDetail } from "@/shared/api/types";
 import { MOTION } from "@/shared/lib/motion";
@@ -42,15 +42,17 @@ export default function LeftContext({
   zIndex,
   onFocus,
 }: LeftContextProps) {
+  const reducedMotion = useReducedMotion();
   return (
-    <AnimatePresence initial={false}>
-      {mode !== "hidden" ? (
+    <div className={`lag-left-anchor${mode === "hidden" ? " lag-left-anchor-empty" : ""}`}>
+      <AnimatePresence initial={false}>
+        {mode !== "hidden" ? (
         <motion.div
           key={`left-context-${mode}`}
-          initial={MOTION.panelReset.initial}
+          initial={reducedMotion ? false : MOTION.panelReset.initial}
           animate={MOTION.panelReset.animate}
-          exit={MOTION.panelReset.exit}
-          transition={MOTION.panelReset.transition}
+          exit={reducedMotion ? { opacity: 0 } : MOTION.panelReset.exit}
+          transition={reducedMotion ? { duration: 0 } : MOTION.panelReset.transition}
           className="lag-left-context lag-panel-stage relative h-full min-h-[420px] overflow-hidden"
           data-stage-key={`left-context-${mode}`}
           onPointerDownCapture={onFocus}
@@ -98,7 +100,8 @@ export default function LeftContext({
             <SocialPanel socialContext={socialContext} />
           )}
         </motion.div>
-      ) : null}
-    </AnimatePresence>
+        ) : null}
+      </AnimatePresence>
+    </div>
   );
 }

--- a/widgets/left-context/ui/PlayerPanel.tsx
+++ b/widgets/left-context/ui/PlayerPanel.tsx
@@ -96,7 +96,7 @@ export function PlayerPanel({
   };
 
   return (
-    <div className="relative z-10 overflow-y-auto scrollbar-hide" style={{ maxHeight: "100%" }}>
+    <div className="relative">
       <div className="p-7">
         {/* Identity header */}
         <div className="text-center">

--- a/widgets/left-context/ui/RoleContextPanel.tsx
+++ b/widgets/left-context/ui/RoleContextPanel.tsx
@@ -47,7 +47,7 @@ export function RoleContextPanel({
   onRoleSelect?: (roleId: number) => void;
 }) {
   return (
-    <div className="relative z-10 overflow-y-auto p-7 scrollbar-hide" style={{ maxHeight: "100%" }}>
+    <div className="relative p-7">
       <div className="text-center">
         <p className="uppercase" style={{ fontSize: 11, letterSpacing: "0.24em", color: "var(--lag-text-2)" }}>ROLE CONTEXT</p>
         <h2 className="mt-2 text-2xl font-semibold" style={{ letterSpacing: "0.08em", color: "var(--lag-text)" }}>My Roles</h2>

--- a/widgets/right-panels/RightPanels.test.tsx
+++ b/widgets/right-panels/RightPanels.test.tsx
@@ -1,0 +1,60 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { PanelStackItem } from "@/entities/nav";
+import RightPanels from "./RightPanels";
+
+const root = (selectedId?: string): PanelStackItem => ({
+  id: "main-player",
+  kind: "menu",
+  title: "Player",
+  selectedId,
+  items: [{ id: "title", label: "Title", slotLabel: "TI" }],
+  context: { main: "player", route: "main-submenu" },
+});
+
+const list = (selectedId?: string): PanelStackItem => ({
+  id: "skills-list-passive",
+  kind: "list",
+  title: "Passive List",
+  selectedId,
+  items: [
+    { id: "skill-a", label: "Skill A", slotLabel: "A", detailDescription: "A", detailRows: [] },
+    { id: "skill-b", label: "Skill B", slotLabel: "B", detailDescription: "B", detailRows: [] },
+  ],
+  context: { main: "skills", route: "skills-list" },
+});
+
+const detail = (id: string): PanelStackItem => ({
+  id: `skills-detail-${id}`,
+  kind: "placeholder",
+  title: "Skill Detail",
+  description: id,
+  rows: [],
+});
+
+describe("RightPanels stable stage frames", () => {
+  it("preserves the root and detail DOM frames while child content changes", () => {
+    const props = { selectedMain: "player" as const, onPanelItemSelect: vi.fn() };
+    const view = render(<RightPanels {...props} panelStack={[root()]} />);
+    const rootStage = document.querySelector('[data-stage-key="player-stage-0"]');
+
+    view.rerender(<RightPanels {...props} panelStack={[root("title"), list("skill-a"), detail("skill-a")]} />);
+    const detailStage = document.querySelector('[data-stage-key="player-stage-2"]');
+    expect(document.querySelector('[data-stage-key="player-stage-0"]')).toBe(rootStage);
+
+    view.rerender(<RightPanels {...props} panelStack={[root("title"), list("skill-b"), detail("skill-b")]} />);
+    expect(document.querySelector('[data-stage-key="player-stage-0"]')).toBe(rootStage);
+    expect(document.querySelector('[data-stage-key="player-stage-2"]')).toBe(detailStage);
+    expect(screen.getByText("skill-b")).toBeInTheDocument();
+  });
+
+  it("gives Skills child stages a feature-state Back affordance", () => {
+    const onBack = vi.fn();
+    render(<RightPanels selectedMain="skills" panelStack={[root("title"), list("skill-a"), detail("skill-a")]} onPanelItemSelect={vi.fn()} onPanelBack={onBack} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Back to Passive List" }));
+
+    expect(onBack).toHaveBeenCalledWith(2);
+  });
+});

--- a/widgets/right-panels/RightPanels.tsx
+++ b/widgets/right-panels/RightPanels.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { AnimatePresence, motion } from "framer-motion";
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 import type { MainNavId, PanelStackItem } from "@/entities/nav";
 import { MOTION } from "@/shared/lib/motion";
 import { reorderToCenter } from "@/shared/lib/reorder";
@@ -128,6 +128,7 @@ function PanelContent({
       iconSrc={navIconSrc}
       depth={depth}
       fixedScrollHeight={categoryScrollHeight}
+      contentKey={panel.id}
     >
       {panel.kind === "menu" ? (
         <div style={{ width: "100%", display: "grid", rowGap: 4 }}>
@@ -232,15 +233,16 @@ export default function RightPanels({
   onPanelBack,
   onPanelActionClick,
 }: RightPanelsProps) {
+  const reducedMotion = useReducedMotion();
   return (
     <AnimatePresence mode="wait" initial={false}>
       {panelStack.length > 0 ? (
         <motion.div
           key={panelStackKey}
-          initial={MOTION.hologramIn.initial}
+          initial={reducedMotion ? false : MOTION.hologramIn.initial}
           animate={MOTION.hologramIn.animate}
-          exit={MOTION.hologramIn.exit}
-          transition={MOTION.hologramIn.transition}
+          exit={reducedMotion ? { opacity: 0 } : MOTION.hologramIn.exit}
+          transition={reducedMotion ? { duration: 0 } : MOTION.hologramIn.transition}
           className="lag-panel-rail relative overflow-x-visible"
           data-main={selectedMain}
           style={{
@@ -254,8 +256,9 @@ export default function RightPanels({
               const depth = panelStack.length - 1 - panelIndex;
               return (
                 <PanelStage
-                  key={panel.id}
-                  stageKey={panel.id}
+                  key={`${selectedMain}-stage-${panelIndex}`}
+                  stageKey={`${selectedMain}-stage-${panelIndex}`}
+                  focusKey={panel.id}
                   index={panelIndex}
                   onPointerDownCapture={() => onPanelFocus?.(panelIndex, panel.id)}
                   zIndex={getPanelZIndex?.(panelIndex, panel.id) ?? panelIndex + 1}

--- a/widgets/right-panels/RightPanels.tsx
+++ b/widgets/right-panels/RightPanels.tsx
@@ -1,8 +1,7 @@
 "use client";
 
-import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
+import { AnimatePresence } from "framer-motion";
 import type { MainNavId, PanelStackItem } from "@/entities/nav";
-import { MOTION } from "@/shared/lib/motion";
 import { reorderToCenter } from "@/shared/lib/reorder";
 import { UI_CONSTS } from "@/shared/lib/uiConsts";
 
@@ -12,14 +11,13 @@ import PanelStage from "@/shared/ui/PanelStage";
 
 import { NAV_ICONS, actionBtnStyle } from "./ui/styles";
 import { GoldRow, InfoCard } from "./ui/Rows";
-import { PanelFrame } from "./ui/PanelFrame";
+import { BackButton, PanelFrame } from "./ui/PanelFrame";
 import { FormPanel } from "./ui/FormPanel";
 import { GiftPanel } from "./ui/GiftPanel";
 
 type RightPanelsProps = {
   selectedMain: MainNavId;
   panelStack: PanelStackItem[];
-  panelStackKey: string;
   onPanelFocus?: (panelIndex: number, panelId: string) => void;
   getPanelZIndex?: (panelIndex: number, panelId: string) => number;
   onPanelItemSelect: (panelIndex: number, itemId: string) => void;
@@ -44,6 +42,8 @@ function PanelContent({
   onPanelFormFieldChange,
   onPanelBack,
   onPanelActionClick,
+  showBack,
+  parentTitle,
 }: {
   panel: PanelStackItem;
   panelIndex: number;
@@ -55,6 +55,8 @@ function PanelContent({
   onPanelFormFieldChange?: (formKey: string, fieldKey: string, value: string) => void;
   onPanelBack?: (panelIndex: number) => void;
   onPanelActionClick?: (panelIndex: number) => void;
+  showBack?: boolean;
+  parentTitle?: string;
 }) {
   if (panel.kind === "form") {
     return (
@@ -129,6 +131,7 @@ function PanelContent({
       depth={depth}
       fixedScrollHeight={categoryScrollHeight}
       contentKey={panel.id}
+      backButton={showBack ? <BackButton label={`Back to ${parentTitle ?? "previous panel"}`} onClick={() => onPanelBack?.(panelIndex)} /> : undefined}
     >
       {panel.kind === "menu" ? (
         <div style={{ width: "100%", display: "grid", rowGap: 4 }}>
@@ -222,7 +225,6 @@ function PanelContent({
 export default function RightPanels({
   selectedMain,
   panelStack,
-  panelStackKey,
   onPanelFocus,
   getPanelZIndex,
   onPanelItemSelect,
@@ -233,16 +235,9 @@ export default function RightPanels({
   onPanelBack,
   onPanelActionClick,
 }: RightPanelsProps) {
-  const reducedMotion = useReducedMotion();
   return (
-    <AnimatePresence mode="wait" initial={false}>
-      {panelStack.length > 0 ? (
-        <motion.div
-          key={panelStackKey}
-          initial={reducedMotion ? false : MOTION.hologramIn.initial}
-          animate={MOTION.hologramIn.animate}
-          exit={reducedMotion ? { opacity: 0 } : MOTION.hologramIn.exit}
-          transition={reducedMotion ? { duration: 0 } : MOTION.hologramIn.transition}
+      panelStack.length > 0 ? (
+        <div
           className="lag-panel-rail relative overflow-x-visible"
           data-main={selectedMain}
           style={{
@@ -259,6 +254,7 @@ export default function RightPanels({
                   key={`${selectedMain}-stage-${panelIndex}`}
                   stageKey={`${selectedMain}-stage-${panelIndex}`}
                   focusKey={panel.id}
+                  autoFocus={panelIndex > 0}
                   index={panelIndex}
                   onPointerDownCapture={() => onPanelFocus?.(panelIndex, panel.id)}
                   zIndex={getPanelZIndex?.(panelIndex, panel.id) ?? panelIndex + 1}
@@ -274,13 +270,14 @@ export default function RightPanels({
                     onPanelFormFieldChange={onPanelFormFieldChange}
                     onPanelBack={onPanelBack}
                     onPanelActionClick={onPanelActionClick}
+                    showBack={selectedMain === "skills" && panelIndex > 0}
+                    parentTitle={panelStack[panelIndex - 1]?.title}
                   />
                 </PanelStage>
               );
             })}
           </AnimatePresence>
-        </motion.div>
-      ) : null}
-    </AnimatePresence>
+        </div>
+      ) : null
   );
 }

--- a/widgets/right-panels/ui/PanelFrame.tsx
+++ b/widgets/right-panels/ui/PanelFrame.tsx
@@ -5,13 +5,14 @@ import EdgeFadeScrollArea from "@/shared/ui/EdgeFadeScrollArea";
 import { StageContentTransition } from "@/shared/ui/PanelStage";
 import { getFrameBackground, getFrameStyle, D, cellStyle } from "./styles";
 
-export function BackButton({ onClick }: { onClick: () => void }) {
+export function BackButton({ onClick, label = "Back to previous panel" }: { onClick: () => void; label?: string }) {
   return (
     <button
       type="button"
       className="flex h-7 w-7 flex-shrink-0 items-center justify-center transition-opacity hover:opacity-70"
       style={{ ...cellStyle, borderRadius: "50%", flexShrink: 0 }}
       onClick={onClick}
+      aria-label={label}
     >
       <span style={{ fontSize: "14px", color: D.textSub }}>←</span>
     </button>

--- a/widgets/right-panels/ui/PanelFrame.tsx
+++ b/widgets/right-panels/ui/PanelFrame.tsx
@@ -2,6 +2,7 @@
 
 import { UI_CONSTS } from "@/shared/lib/uiConsts";
 import EdgeFadeScrollArea from "@/shared/ui/EdgeFadeScrollArea";
+import { StageContentTransition } from "@/shared/ui/PanelStage";
 import { getFrameBackground, getFrameStyle, D, cellStyle } from "./styles";
 
 export function BackButton({ onClick }: { onClick: () => void }) {
@@ -27,6 +28,7 @@ export function PanelFrame({
   iconSrc,
   depth = 0,
   fixedScrollHeight,
+  contentKey,
 }: {
   title: string;
   children: React.ReactNode;
@@ -37,6 +39,7 @@ export function PanelFrame({
   iconSrc?: string;
   depth?: number;
   fixedScrollHeight?: number;
+  contentKey?: React.Key;
 }) {
   return (
     <div
@@ -113,7 +116,7 @@ export function PanelFrame({
               }
         }
       >
-        {children}
+        {contentKey === undefined ? children : <StageContentTransition identity={contentKey}>{children}</StageContentTransition>}
       </EdgeFadeScrollArea>
     </div>
   );


### PR DESCRIPTION
## Purpose

Apply the next interaction-polish pass after the v7 shared visual foundation, focusing on staged panel lifecycle, camera follow, utility-window placement, responsive focus, and reactive controls.

Closes #52

## Delivered

- desktop Home/Player visual-center anchoring
- shared bounded draggable window behavior for Connections and Direct Chat
- Notification unread-badge clipping correction
- viewport-aware Notification popup placement
- stable Player staged-panel identity
- downstream disclosure-state reset across navigation branches
- explicit stage-camera focus signaling
- Inventory camera-follow coverage
- unified SAO-inspired panel/detail motion grammar
- improved Credentials and Lifelog interactive-control contrast
- reactive filter/search interaction behavior
- mobile camera leading-space refinement
- preserved System parent stage when opening Options

## Staged Interaction Contract

```text
Stage N
-> explicit selection
-> Stage N+1
```

Child stages are not pre-opened.

Changing a parent selection clears stale descendants.

When a detail stage is already open, selecting another item preserves the panel frame and transitions only its content.

## Camera Contract

The stage camera handles both DOM stage creation/removal and explicit feature focus intent.

New downstream stages are brought into view automatically without requiring manual horizontal scrolling.

Compact/mobile focus keeps additional leading breathing room.

## Desktop Visual Anchor

On tall Home and Player surfaces, navigation/context remains visually anchored around the viewport center while workspace content scrolls.

The anchor remains part of the normal layout rather than becoming a detached fixed overlay.

## Utility Windows

Connections and Direct Chat use shared viewport-bounded dragging on desktop.

Notification badge and popup remain fully visible and are positioned against viewport bounds.

## Motion

Panel motion follows one shared restrained grammar:

- short child-stage reveal
- no long far-right flight
- no cumulative stage delay
- stable detail frame during item replacement
- reduced-motion-safe behavior

## Reactive Controls

Representative existing list filters/search controls update results immediately for local data or with short debounced requests for supported server-backed queries.

No unsupported backend search contract is invented.

## Visual System

Interactive contrast corrections continue to use the approved v7 semantic token system.

No separate theme-specific component tree or new palette authority is introduced.

## Scope Boundaries

This PR does not:

- complete every remaining v7 screen fidelity pass
- redesign backend APIs
- persist floating-window position across sessions
- change Notification read semantics
- change theme runtime/persistence
- introduce a new navigation taxonomy
- introduce a new state-management framework

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added smoother staged transitions across detail panels.
  * Added back navigation for nested inventory, player, skills, and settings views.
  * Added draggable, viewport-aware connections and chat drawers.
  * Improved notification dropdown positioning across screen sizes.
  * Added debounced media title search with immediate category and status filters.
  * Added responsive workspace scrolling and improved mobile layout behavior.
  * Added authenticated theme preference synchronization.

* **Bug Fixes**
  * Prevented stale selections and outdated search results after filtering, paging, or refreshing.
  * Improved reduced-motion behavior and preserved detail views during selection changes.
  * Standardized control styling across settings and certification forms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->