### PR TITLE
[Journal] Apply approved v7 Journal and Quick Record fidelity

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -145,7 +145,14 @@ body {
 .lag-left-context,
 .lag-utility-button,
 .lag-utility-drawer,
-.lag-notification-dropdown {
+.lag-notification-dropdown,
+.lag-journal-entry,
+.lag-journal-control,
+.lag-journal-action,
+.lag-journal-button,
+.lag-journal-chip,
+.lag-journal-toolbar,
+.lag-journal-detail-section {
   transition:
     background-color var(--lag-motion-normal) ease,
     border-color var(--lag-motion-normal) ease,
@@ -552,6 +559,354 @@ body {
   color: var(--lag-text);
 }
 
+/* v7 Journal / Quick Record: shared semantic anatomy, theme tokens supply material. */
+.lag-journal-shell [data-stage-key="lifelog-journal"] .lag-panel-frame {
+  width: min(720px, calc(100vw - 32px)) !important;
+}
+
+.lag-journal-shell [data-stage-key="lifelog-quick-record"] .lag-panel-frame {
+  width: min(620px, calc(100vw - 32px)) !important;
+}
+
+.lag-journal-shell [data-stage-key="lifelog-journal-detail"] .lag-panel-frame {
+  width: min(390px, calc(100vw - 32px)) !important;
+}
+
+.lag-journal-surface,
+.lag-quick-record-surface,
+.lag-quick-record-form,
+.lag-journal-state,
+.lag-journal-detail {
+  display: grid;
+  gap: var(--lag-space-4);
+  padding-inline: var(--lag-space-4);
+}
+
+.lag-journal-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--lag-space-4);
+  padding: var(--lag-space-4);
+  border: 1px solid var(--lag-divider);
+  border-left: 4px solid var(--lag-amber);
+  border-radius: var(--lag-radius-md);
+  background: var(--lag-muted-surface);
+}
+
+.lag-journal-eyebrow,
+.lag-journal-field > span,
+.lag-journal-section-heading span,
+.lag-journal-detail-item dt {
+  color: var(--lag-text-2);
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.lag-journal-intro,
+.lag-quick-record-surface > div:first-child > p:last-child {
+  margin-top: var(--lag-space-1);
+  color: var(--lag-text-2);
+  font-size: 0.82rem;
+}
+
+.lag-quick-record-surface > div:first-child > h4 {
+  margin-top: var(--lag-space-2);
+  color: var(--lag-text);
+  font-size: 1.2rem;
+  font-weight: 700;
+}
+
+.lag-journal-filters,
+.lag-journal-form-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--lag-space-3);
+}
+
+.lag-journal-field {
+  display: grid;
+  min-width: 0;
+  gap: var(--lag-space-2);
+  color: var(--lag-text-2);
+}
+
+.lag-journal-control {
+  width: 100%;
+  min-height: 44px;
+  padding: var(--lag-space-2) var(--lag-space-3);
+  border: 1px solid var(--lag-control-border);
+  border-radius: var(--lag-radius-sm);
+  background: var(--lag-control-bg);
+  color: var(--lag-control-text);
+}
+
+textarea.lag-journal-control {
+  min-height: 92px;
+  resize: vertical;
+}
+
+.lag-journal-control:hover {
+  border-color: var(--lag-focus);
+  background: var(--lag-control-hover-bg);
+}
+
+.lag-journal-action,
+.lag-journal-button,
+.lag-journal-chip {
+  min-height: 44px;
+  border: 1px solid var(--lag-control-border);
+  border-radius: var(--lag-radius-sm);
+  background: var(--lag-control-bg);
+  color: var(--lag-control-text);
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+
+.lag-journal-action {
+  min-width: 148px;
+  padding: var(--lag-space-2) var(--lag-space-4);
+  border-color: var(--lag-violet);
+  background: color-mix(in srgb, var(--lag-violet) 12%, var(--lag-control-bg));
+}
+
+.lag-journal-action[data-variant="retry"] {
+  border-color: var(--lag-warning);
+}
+
+.lag-journal-button {
+  padding: var(--lag-space-2) var(--lag-space-3);
+}
+
+.lag-journal-action:not(:disabled):hover,
+.lag-journal-button:not(:disabled):hover,
+.lag-journal-chip:not(:disabled):hover {
+  border-color: var(--lag-focus);
+  background: var(--lag-control-hover-bg);
+}
+
+.lag-journal-archive {
+  display: grid;
+  gap: var(--lag-space-3);
+  padding: var(--lag-space-4);
+  border: 1px solid var(--lag-border);
+  border-radius: var(--lag-radius-md);
+  background: var(--lag-panel);
+}
+
+.lag-journal-section-heading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--lag-space-3);
+  padding-bottom: var(--lag-space-2);
+  border-bottom: 1px solid var(--lag-divider);
+}
+
+.lag-journal-section-heading h4,
+.lag-journal-detail-section h4 {
+  color: var(--lag-text);
+  font-size: 0.84rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.lag-journal-list {
+  display: grid;
+  gap: var(--lag-space-3);
+}
+
+.lag-journal-entry {
+  display: grid;
+  grid-template-columns: 76px minmax(0, 1fr) auto;
+  min-height: 116px;
+  align-items: center;
+  gap: var(--lag-space-4);
+  padding: var(--lag-space-4);
+  border: 1px solid var(--lag-divider);
+  border-radius: var(--lag-radius-md);
+  background: var(--lag-muted-surface);
+  color: var(--lag-text);
+  text-align: left;
+}
+
+.lag-journal-entry:hover {
+  border-color: var(--lag-focus);
+  background: var(--lag-control-hover-bg);
+}
+
+.lag-journal-entry[data-selected="true"] {
+  border-color: var(--lag-state-selected);
+  box-shadow: inset 4px 0 0 var(--lag-state-selected);
+}
+
+.lag-journal-source {
+  display: grid;
+  width: 76px;
+  height: 76px;
+  place-items: center;
+  border: 1px solid var(--lag-divider);
+  border-radius: var(--lag-radius-sm);
+  background: var(--lag-paper);
+  color: var(--lag-text-2);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+}
+
+.lag-journal-entry-copy {
+  display: grid;
+  min-width: 0;
+  gap: var(--lag-space-2);
+}
+
+.lag-journal-entry-copy strong {
+  overflow-wrap: anywhere;
+  font-size: 0.96rem;
+}
+
+.lag-journal-entry-summary {
+  overflow-wrap: anywhere;
+  color: var(--lag-text-2);
+  font-size: 0.78rem;
+}
+
+.lag-journal-entry-chips,
+.lag-journal-segments {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--lag-space-2);
+}
+
+.lag-journal-entry-chips > span {
+  padding: var(--lag-space-1) var(--lag-space-2);
+  border: 1px solid var(--lag-control-border);
+  border-radius: 999px;
+  background: var(--lag-control-bg);
+  color: var(--lag-text-2);
+  font-size: 0.65rem;
+}
+
+.lag-journal-entry time {
+  align-self: end;
+  color: var(--lag-meta);
+  font-size: 0.66rem;
+  white-space: nowrap;
+}
+
+.lag-journal-pagination {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--lag-space-3);
+  padding-top: var(--lag-space-2);
+  border-top: 1px solid var(--lag-divider);
+  color: var(--lag-text-2);
+  font-size: 0.72rem;
+}
+
+.lag-journal-segments {
+  margin-top: var(--lag-space-2);
+}
+
+.lag-journal-chip {
+  min-width: 112px;
+  padding: var(--lag-space-2) var(--lag-space-3);
+  border-radius: 999px;
+}
+
+.lag-journal-chip[data-selected="true"] {
+  border-color: var(--lag-state-selected);
+  background: var(--lag-selected-surface);
+  box-shadow: inset 0 0 0 1px var(--lag-state-selected);
+}
+
+.lag-quick-record-fields {
+  min-height: 188px;
+  padding: var(--lag-space-4);
+  border: 1px solid var(--lag-divider);
+  border-radius: var(--lag-radius-md);
+  background: var(--lag-muted-surface);
+}
+
+.lag-quick-record-fields fieldset {
+  min-width: 0;
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.lag-journal-feedback {
+  padding: var(--lag-space-3);
+  border: 1px solid currentcolor;
+  border-radius: var(--lag-radius-sm);
+  background: var(--lag-muted-surface);
+  color: var(--lag-text);
+  font-size: 0.76rem;
+}
+
+.lag-journal-feedback[data-state="error"] {
+  border-color: var(--lag-state-error);
+  box-shadow: inset 4px 0 0 var(--lag-state-error);
+}
+
+.lag-journal-feedback[data-state="success"] {
+  border-color: var(--lag-state-success);
+  box-shadow: inset 4px 0 0 var(--lag-state-success);
+}
+
+.lag-journal-detail-hero {
+  display: grid;
+  gap: var(--lag-space-2);
+  padding: var(--lag-space-4);
+  border: 1px solid var(--lag-border);
+  border-left: 4px solid var(--lag-cyan);
+  border-radius: var(--lag-radius-md);
+  background: var(--lag-muted-surface);
+}
+
+.lag-journal-detail-hero > span {
+  color: var(--lag-text-2);
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+}
+
+.lag-journal-detail-section {
+  overflow: hidden;
+  border: 1px solid var(--lag-divider);
+  border-radius: var(--lag-radius-md);
+  background: var(--lag-panel);
+}
+
+.lag-journal-detail-section h4 {
+  padding: var(--lag-space-3) var(--lag-space-4);
+  border-bottom: 1px solid var(--lag-divider);
+  background: var(--lag-panel-2);
+}
+
+.lag-journal-detail-item {
+  display: grid;
+  grid-template-columns: minmax(94px, 0.8fr) minmax(0, 1.2fr);
+  gap: var(--lag-space-3);
+  padding: var(--lag-space-3) var(--lag-space-4);
+  border-bottom: 1px solid var(--lag-divider);
+}
+
+.lag-journal-detail-item:last-child {
+  border-bottom: 0;
+}
+
+.lag-journal-detail-item dd {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  color: var(--lag-text);
+  font-size: 0.78rem;
+}
+
 .lag-state-error {
   padding-left: var(--lag-space-2);
   color: var(--lag-text);
@@ -665,6 +1020,61 @@ body {
     width: auto;
   }
 
+  .lag-journal-shell [data-stage-key="lifelog-journal"] .lag-panel-frame,
+  .lag-journal-shell [data-stage-key="lifelog-quick-record"] .lag-panel-frame,
+  .lag-journal-shell [data-stage-key="lifelog-journal-detail"] .lag-panel-frame {
+    width: clamp(280px, calc(100vw - 32px), 344px) !important;
+  }
+
+  .lag-journal-surface,
+  .lag-quick-record-surface,
+  .lag-quick-record-form,
+  .lag-journal-state,
+  .lag-journal-detail {
+    padding-inline: var(--lag-space-3);
+  }
+
+  .lag-journal-toolbar {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .lag-journal-action {
+    width: 100%;
+  }
+
+  .lag-journal-filters,
+  .lag-journal-form-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .lag-journal-entry {
+    grid-template-columns: 60px minmax(0, 1fr);
+    min-height: 132px;
+    gap: var(--lag-space-3);
+    padding: var(--lag-space-3);
+  }
+
+  .lag-journal-source {
+    width: 60px;
+    height: 72px;
+  }
+
+  .lag-journal-entry time {
+    grid-column: 2;
+    justify-self: end;
+  }
+
+  .lag-journal-chip {
+    min-width: 0;
+    flex: 1 1 92px;
+  }
+
+  .lag-journal-pagination {
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
+  }
+
   .lag-left-anchor {
     --lag-left-lane-width: clamp(280px, calc(100vw - 32px), 344px);
     position: static;
@@ -738,6 +1148,16 @@ body {
   .lag-utility-button,
   .lag-utility-drawer,
   .lag-notification-dropdown {
+    transition-duration: 0s;
+  }
+
+  .lag-journal-entry,
+  .lag-journal-control,
+  .lag-journal-action,
+  .lag-journal-button,
+  .lag-journal-chip,
+  .lag-journal-toolbar,
+  .lag-journal-detail-section {
     transition-duration: 0s;
   }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -792,7 +792,7 @@ textarea.lag-journal-control {
 
 .lag-journal-entry time {
   align-self: end;
-  color: var(--lag-meta);
+  color: var(--lag-text-2);
   font-size: 0.66rem;
   white-space: nowrap;
 }

--- a/features/lifelog/JournalShell.test.tsx
+++ b/features/lifelog/JournalShell.test.tsx
@@ -1,4 +1,5 @@
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { readFileSync } from "node:fs";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { JournalPage, QuickRecordResult, RoleDetail } from "@/shared/api/types";
@@ -12,11 +13,6 @@ const api = vi.hoisted(() => ({
 }));
 
 vi.mock("./api", () => api);
-vi.mock("@/shared/ui/PanelCard", () => ({
-  default: ({ label, slotLabel, subtitle, onClick }: { label: string; slotLabel: string; subtitle?: string; onClick?: () => void }) => (
-    <button type="button" data-testid="journal-entry" onClick={onClick}>{label} · {slotLabel} · {subtitle}</button>
-  ),
-}));
 
 const roles: RoleDetail[] = [
   { id: 1, roleType: "PROFESSIONAL", name: "Backend Engineer", description: "Build systems", status: "ACTIVE", createdAt: "2026-01-01T00:00:00Z", updatedAt: "2026-01-01T00:00:00Z", version: 0 },
@@ -40,7 +36,29 @@ function deferred<T>() {
   return { promise, reject, resolve };
 }
 
-describe("LifeLog Journal surface를 사용할 때", () => {
+async function renderJournal() {
+  const view = render(<JournalShell roles={roles} />);
+  await screen.findAllByTestId("journal-entry");
+  return view;
+}
+
+async function openQuickRecord() {
+  await renderJournal();
+  expect(document.querySelector('[data-stage-key="lifelog-quick-record"]')).not.toBeInTheDocument();
+  fireEvent.click(screen.getByRole("button", { name: "Quick Record" }));
+  return document.querySelector('[data-stage-key="lifelog-quick-record"]')!;
+}
+
+function selectQuickType(type: "COLLECTION" | "EXERCISE" | "MEDIA") {
+  fireEvent.click(screen.getByRole("radio", { name: type }));
+}
+
+function expectDetail(name: string, value: string) {
+  const term = screen.getByText(name);
+  expect(term.nextElementSibling).toHaveTextContent(value);
+}
+
+describe("LifeLog Journal v7 surface", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     api.listJournalApi.mockResolvedValue(mixedPage);
@@ -48,255 +66,254 @@ describe("LifeLog Journal surface를 사용할 때", () => {
     api.quickRecordApi.mockResolvedValue(quickResult);
   });
 
-  describe("Quick Record form을 제출하면", () => {
-    it("Collection payload 하나와 optional top-level metadata만 전송한다", async () => {
-      render(<JournalShell roles={roles} />);
-      fireEvent.click(screen.getByText("Quick Record"));
+  it("uses semantic Journal classes without legacy local styling", () => {
+    const source = readFileSync("features/lifelog/JournalShell.tsx", "utf8");
+    expect(source).toContain("lag-journal-surface");
+    expect(source).not.toMatch(/INPUT_STYLE|\bSAO\b|GoldRow|<details/);
 
-      const type = screen.getByLabelText("Quick Record type") as HTMLSelectElement;
-      expect(Array.from(type.options, ({ value }) => value)).toEqual(["COLLECTION", "EXERCISE", "MEDIA"]);
-      expect(screen.queryByLabelText(/event/i)).not.toBeInTheDocument();
-      fireEvent.change(screen.getByLabelText("Quick Record subtype"), { target: { value: "PROJECT" } });
-      fireEvent.change(screen.getByLabelText("Quick Record role"), { target: { value: "2" } });
-      fireEvent.change(screen.getByLabelText("Collection category"), { target: { value: "BOOK" } });
-      fireEvent.change(screen.getByLabelText("Collection title"), { target: { value: "The Pragmatic Programmer" } });
-      fireEvent.change(screen.getByLabelText("Quantity"), { target: { value: "1" } });
-      fireEvent.click(screen.getByRole("button", { name: "Save Quick Record" }));
+    const css = readFileSync("app/globals.css", "utf8");
+    expect(css).toContain('[data-stage-key="lifelog-journal"]');
+    expect(css).toContain("var(--lag-control-bg)");
+    expect(css).toContain("@media (max-width: 767px)");
+    expect(css).toContain(".lag-orb-column");
+  });
 
-      await waitFor(() => expect(api.quickRecordApi).toHaveBeenCalledOnce());
-      expect(api.quickRecordApi).toHaveBeenCalledWith({
-        type: "COLLECTION",
-        lifeLogSubtype: "PROJECT",
-        primaryRoleId: 2,
-        collection: { category: "BOOK", title: "The Pragmatic Programmer", quantity: 1 },
-      }, expect.stringMatching(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i));
-      expect(screen.queryByLabelText(/rating|player|user/i)).not.toBeInTheDocument();
+  it("renders the real server order as structured record cards", async () => {
+    await renderJournal();
+
+    const entries = screen.getAllByTestId("journal-entry");
+    expect(entries.map((entry) => entry.querySelector("strong")?.textContent)).toEqual([
+      "Architecture Notes",
+      "RUNNING · 2026-08-12",
+      "Designing Data-Intensive Applications",
+      "Legacy Collection",
+    ]);
+    expect(within(entries[0]).getByText("COLLECTION")).toBeInTheDocument();
+    expect(within(entries[0]).getByText("Backend Engineer")).toBeInTheDocument();
+    expect(within(entries[0]).getByText("Event #11")).toBeInTheDocument();
+    expect(within(entries[1]).getByText("Quick")).toBeInTheDocument();
+  });
+
+  it("keeps nullable metrics absent while preserving real zero values", async () => {
+    api.listJournalApi.mockResolvedValue({
+      content: [{
+        ...MOCK_JOURNAL_ENTRIES[1],
+        preview: { ...MOCK_JOURNAL_ENTRIES[1].preview, durationMinutes: 0, distanceKm: null, calories: 240 },
+      }],
+      page: 0,
+      size: 20,
+      totalElements: 1,
+      totalPages: 1,
+    } satisfies JournalPage);
+    await renderJournal();
+
+    const entry = screen.getByTestId("journal-entry");
+    expect(entry).toHaveTextContent("0 min · 240 kcal");
+    expect(entry).not.toHaveTextContent("km");
+  });
+
+  it("changes Role/subtype query immediately and preserves bounded pagination", async () => {
+    api.listJournalApi.mockImplementation(async (params: { primaryRoleId?: number; subtype?: string; page: number; size: number }): Promise<JournalPage> => ({
+      content: MOCK_JOURNAL_ENTRIES.filter((entry) =>
+        (params.primaryRoleId === undefined || entry.primaryRoleId === params.primaryRoleId)
+        && (params.subtype === undefined || entry.subtype === params.subtype)
+      ),
+      page: params.page,
+      size: params.size,
+      totalElements: 40,
+      totalPages: 2,
+    }));
+    await renderJournal();
+
+    expect(screen.getByText("Page 1 / 2")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Previous" })).toBeDisabled();
+    fireEvent.change(screen.getByLabelText("Role filter"), { target: { value: "2" } });
+    await waitFor(() => expect(api.listJournalApi).toHaveBeenLastCalledWith({ primaryRoleId: 2, page: 0, size: 20 }));
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+    await waitFor(() => expect(api.listJournalApi).toHaveBeenLastCalledWith({ primaryRoleId: 2, page: 1, size: 20 }));
+    expect(await screen.findByText("Page 2 / 2")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Next" })).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText("Subtype filter"), { target: { value: "REFLECTION" } });
+    await waitFor(() => expect(api.listJournalApi).toHaveBeenLastCalledWith({ primaryRoleId: 2, subtype: "REFLECTION", page: 0, size: 20 }));
+  });
+
+  it("opens detail only after selection, keeps its stage stable across entries, and Back closes it", async () => {
+    await renderJournal();
+    expect(document.querySelector('[data-stage-key="lifelog-journal-detail"]')).not.toBeInTheDocument();
+    const entries = screen.getAllByTestId("journal-entry");
+
+    fireEvent.click(entries[0]);
+    await screen.findByText("Annotated");
+    const detailStage = document.querySelector('[data-stage-key="lifelog-journal-detail"]');
+    expect(detailStage).toBeInTheDocument();
+    expectDetail("Condition", "Annotated");
+
+    fireEvent.click(entries[1]);
+    await screen.findByText("Morning run");
+    expect(document.querySelector('[data-stage-key="lifelog-journal-detail"]')).toBe(detailStage);
+    expectDetail("Entry mode", "QUICK");
+
+    fireEvent.click(screen.getByRole("button", { name: "Back to Journal" }));
+    await waitFor(() => expect(document.querySelector('[data-stage-key="lifelog-journal-detail"]')).not.toBeInTheDocument());
+  });
+
+  it("renders all current detail fields in semantic common/source sections", async () => {
+    await renderJournal();
+    const entries = screen.getAllByTestId("journal-entry");
+
+    fireEvent.click(entries[3]);
+    await screen.findByText("Collection");
+    expectDetail("Original title", "Not recorded");
+    expectDetail("Quantity", "Not recorded");
+    expectDetail("Condition", "Not recorded");
+    expectDetail("Acquired from", "Not recorded");
+    expectDetail("Tags", "Not recorded");
+
+    fireEvent.click(entries[2]);
+    await screen.findByText("Rewatch count");
+    expectDetail("Rewatch count", "0");
+    expect(screen.queryByRole("button", { name: /edit|delete|complete event/i })).not.toBeInTheDocument();
+  });
+
+  it("keeps detail loading/error retry on the selected lifeLogId", async () => {
+    const first = deferred<ReturnType<typeof journalMock.detail>>();
+    api.getJournalDetailApi.mockReturnValueOnce(first.promise).mockResolvedValueOnce(journalMock.detail(104));
+    await renderJournal();
+    fireEvent.click(screen.getAllByTestId("journal-entry")[0]);
+    expect(screen.getByText("Loading Journal detail...")).toBeInTheDocument();
+
+    await act(async () => {
+      first.reject(new Error("Detail unavailable"));
+      await first.promise.catch(() => undefined);
+    });
+    expect(screen.getByRole("alert")).toHaveTextContent("Detail unavailable");
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    await screen.findByText("Annotated");
+    expect(api.getJournalDetailApi).toHaveBeenNthCalledWith(1, 104);
+    expect(api.getJournalDetailApi).toHaveBeenNthCalledWith(2, 104);
+  });
+
+  it("does not reopen stale detail after leaving and returning", async () => {
+    const view = await renderJournal();
+    fireEvent.click(screen.getAllByTestId("journal-entry")[0]);
+    await screen.findByText("Annotated");
+    view.unmount();
+
+    await renderJournal();
+    expect(document.querySelector('[data-stage-key="lifelog-journal-detail"]')).not.toBeInTheDocument();
+  });
+
+  it("opens Quick Record explicitly, keeps its frame stable across real types, and Back returns", async () => {
+    const stage = await openQuickRecord();
+    const frame = stage.querySelector(".lag-panel-frame");
+    expect(screen.getByRole("radio", { name: "COLLECTION" })).toHaveAttribute("aria-checked", "true");
+    expect(screen.getByLabelText("Collection category")).toBeInTheDocument();
+
+    selectQuickType("EXERCISE");
+    expect(screen.getByLabelText("Duration minutes")).toBeInTheDocument();
+    expect(document.querySelector('[data-stage-key="lifelog-quick-record"] .lag-panel-frame')).toBe(frame);
+    selectQuickType("MEDIA");
+    expect(screen.getByLabelText("Media status")).toBeInTheDocument();
+    expect(document.querySelector('[data-stage-key="lifelog-quick-record"] .lag-panel-frame')).toBe(frame);
+
+    fireEvent.click(screen.getByRole("button", { name: "Back to Journal" }));
+    await waitFor(() => expect(document.querySelector('[data-stage-key="lifelog-quick-record"]')).not.toBeInTheDocument());
+  });
+
+  it("represents every current Quick Record type-specific field", async () => {
+    await openQuickRecord();
+    expect(screen.getByLabelText("Collection category")).toBeInTheDocument();
+    expect(screen.getByLabelText("Collection title")).toBeInTheDocument();
+    expect(screen.getByLabelText("Quantity")).toBeInTheDocument();
+
+    selectQuickType("EXERCISE");
+    for (const name of ["Exercise category", "Duration minutes", "Exercised on", "Distance km", "Calories", "Memo"]) {
+      expect(screen.getByLabelText(name)).toBeInTheDocument();
+    }
+
+    selectQuickType("MEDIA");
+    for (const name of ["Media category", "Media title", "Media status", "Current episode", "Total episodes"]) {
+      expect(screen.getByLabelText(name)).toBeInTheDocument();
+    }
+  });
+
+  it("submits the exact Collection contract and shows success", async () => {
+    await openQuickRecord();
+    fireEvent.change(screen.getByLabelText("Quick Record subtype"), { target: { value: "PROJECT" } });
+    fireEvent.change(screen.getByLabelText("Quick Record role"), { target: { value: "2" } });
+    fireEvent.change(screen.getByLabelText("Collection category"), { target: { value: "BOOK" } });
+    fireEvent.change(screen.getByLabelText("Collection title"), { target: { value: "The Pragmatic Programmer" } });
+    fireEvent.change(screen.getByLabelText("Quantity"), { target: { value: "1" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save Quick Record" }));
+
+    await screen.findByText("✓ Quick Record saved.");
+    expect(api.quickRecordApi).toHaveBeenCalledWith({
+      type: "COLLECTION",
+      lifeLogSubtype: "PROJECT",
+      primaryRoleId: 2,
+      collection: { category: "BOOK", title: "The Pragmatic Programmer", quantity: 1 },
+    }, expect.stringMatching(/^[0-9a-f-]{36}$/i));
+  });
+
+  it("preserves Exercise zero/optional semantics and Media partial progress", async () => {
+    await openQuickRecord();
+    selectQuickType("EXERCISE");
+    fireEvent.change(screen.getByLabelText("Exercise category"), { target: { value: "RUNNING" } });
+    fireEvent.change(screen.getByLabelText("Duration minutes"), { target: { value: "30" } });
+    fireEvent.change(screen.getByLabelText("Exercised on"), { target: { value: "2026-08-14" } });
+    fireEvent.change(screen.getByLabelText("Distance km"), { target: { value: "0" } });
+    fireEvent.change(screen.getByLabelText("Calories"), { target: { value: "0" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save Quick Record" }));
+    await waitFor(() => expect(api.quickRecordApi).toHaveBeenCalledOnce());
+    expect(api.quickRecordApi.mock.calls[0][0]).toEqual({
+      type: "EXERCISE",
+      exercise: { category: "RUNNING", durationMinutes: 30, exercisedOn: "2026-08-14", distanceKm: 0, calories: 0 },
     });
 
-    it("Exercise optional zero를 보존하고 비어 있는 optional field는 생략한다", async () => {
-      render(<JournalShell roles={roles} />);
-      fireEvent.click(screen.getByText("Quick Record"));
-      fireEvent.change(screen.getByLabelText("Quick Record type"), { target: { value: "EXERCISE" } });
-      fireEvent.change(screen.getByLabelText("Exercise category"), { target: { value: "RUNNING" } });
-      fireEvent.change(screen.getByLabelText("Duration minutes"), { target: { value: "30" } });
-      fireEvent.change(screen.getByLabelText("Exercised on"), { target: { value: "2026-08-14" } });
-      fireEvent.change(screen.getByLabelText("Distance km"), { target: { value: "0" } });
-      fireEvent.change(screen.getByLabelText("Calories"), { target: { value: "0" } });
-      fireEvent.click(screen.getByRole("button", { name: "Save Quick Record" }));
-
-      await waitFor(() => expect(api.quickRecordApi).toHaveBeenCalledOnce());
-      expect(api.quickRecordApi.mock.calls[0][0]).toEqual({
-        type: "EXERCISE",
-        exercise: {
-          category: "RUNNING",
-          durationMinutes: 30,
-          exercisedOn: "2026-08-14",
-          distanceKm: 0,
-          calories: 0,
-        },
-      });
-    });
-
-    it("Media currentEpisode zero를 보존하고 partial episode payload를 허용한다", async () => {
-      render(<JournalShell roles={roles} />);
-      fireEvent.click(screen.getByText("Quick Record"));
-      fireEvent.change(screen.getByLabelText("Quick Record type"), { target: { value: "MEDIA" } });
-      fireEvent.change(screen.getByLabelText("Media category"), { target: { value: "ANIME" } });
-      fireEvent.change(screen.getByLabelText("Media title"), { target: { value: "Frieren" } });
-      fireEvent.change(screen.getByLabelText("Media status"), { target: { value: "WATCHING" } });
-      fireEvent.change(screen.getByLabelText("Current episode"), { target: { value: "0" } });
-      fireEvent.click(screen.getByRole("button", { name: "Save Quick Record" }));
-
-      await waitFor(() => expect(api.quickRecordApi).toHaveBeenCalledOnce());
-      expect(api.quickRecordApi.mock.calls[0][0]).toEqual({
-        type: "MEDIA",
-        media: { category: "ANIME", title: "Frieren", status: "WATCHING", currentEpisode: 0 },
-      });
-    });
-
-    it("Media episode input을 비워 두면 request에서도 둘 다 생략한다", async () => {
-      render(<JournalShell roles={roles} />);
-      fireEvent.click(screen.getByText("Quick Record"));
-      fireEvent.change(screen.getByLabelText("Quick Record type"), { target: { value: "MEDIA" } });
-      fireEvent.change(screen.getByLabelText("Media category"), { target: { value: "ANIME" } });
-      fireEvent.change(screen.getByLabelText("Media title"), { target: { value: "Frieren" } });
-      fireEvent.change(screen.getByLabelText("Media status"), { target: { value: "WATCHING" } });
-      fireEvent.click(screen.getByRole("button", { name: "Save Quick Record" }));
-
-      await waitFor(() => expect(api.quickRecordApi).toHaveBeenCalledOnce());
-      expect(api.quickRecordApi.mock.calls[0][0]).toEqual({
-        type: "MEDIA",
-        media: { category: "ANIME", title: "Frieren", status: "WATCHING" },
-      });
-    });
-
-    it("ambiguous failure 뒤 edit 전에는 Retry만 노출하고 edit 후 새 logical Submit을 만든다", async () => {
-      api.quickRecordApi.mockRejectedValueOnce(new Error("Outcome unknown")).mockResolvedValueOnce(quickResult);
-      render(<JournalShell roles={roles} />);
-      fireEvent.click(screen.getByText("Quick Record"));
-      fireEvent.change(screen.getByLabelText("Collection category"), { target: { value: "BOOK" } });
-      fireEvent.change(screen.getByLabelText("Collection title"), { target: { value: "Retry me" } });
-      fireEvent.change(screen.getByLabelText("Quantity"), { target: { value: "1" } });
-      fireEvent.click(screen.getByRole("button", { name: "Save Quick Record" }));
-
-      await screen.findByRole("button", { name: "Retry same record" });
-      expect(screen.queryByRole("button", { name: "Save Quick Record" })).not.toBeInTheDocument();
-      const firstCall = api.quickRecordApi.mock.calls[0];
-      fireEvent.change(screen.getByLabelText("Collection title"), { target: { value: "Edited retry" } });
-
-      expect(screen.queryByRole("button", { name: "Retry same record" })).not.toBeInTheDocument();
-      fireEvent.click(screen.getByRole("button", { name: "Save Quick Record" }));
-      await waitFor(() => expect(api.quickRecordApi).toHaveBeenCalledTimes(2));
-      expect(api.quickRecordApi.mock.calls[1][0]).toEqual({
-        type: "COLLECTION",
-        collection: { category: "BOOK", title: "Edited retry", quantity: 1 },
-      });
-      expect(api.quickRecordApi.mock.calls[1][1]).not.toBe(firstCall[1]);
+    api.quickRecordApi.mockClear();
+    selectQuickType("MEDIA");
+    fireEvent.change(screen.getByLabelText("Media category"), { target: { value: "ANIME" } });
+    fireEvent.change(screen.getByLabelText("Media title"), { target: { value: "Frieren" } });
+    fireEvent.change(screen.getByLabelText("Media status"), { target: { value: "WATCHING" } });
+    fireEvent.change(screen.getByLabelText("Current episode"), { target: { value: "0" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save Quick Record" }));
+    await waitFor(() => expect(api.quickRecordApi).toHaveBeenCalledOnce());
+    expect(api.quickRecordApi.mock.calls[0][0]).toEqual({
+      type: "MEDIA",
+      media: { category: "ANIME", title: "Frieren", status: "WATCHING", currentEpisode: 0 },
     });
   });
 
-  describe("mixed physical source 목록을 읽으면", () => {
-    it("server order와 source/QUICK/Role/Event context를 그대로 표시한다", async () => {
-      render(<JournalShell roles={roles} />);
+  it("keeps failure retry available and edit creates a new logical submission", async () => {
+    api.quickRecordApi.mockRejectedValueOnce(new Error("Outcome unknown")).mockResolvedValueOnce(quickResult);
+    await openQuickRecord();
+    fireEvent.change(screen.getByLabelText("Collection category"), { target: { value: "BOOK" } });
+    fireEvent.change(screen.getByLabelText("Collection title"), { target: { value: "Retry me" } });
+    fireEvent.change(screen.getByLabelText("Quantity"), { target: { value: "1" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save Quick Record" }));
 
-      const entries = await screen.findAllByTestId("journal-entry");
-      expect(entries.map((entry) => entry.textContent?.split(" · ")[0])).toEqual([
-        "Architecture Notes",
-        "RUNNING",
-        "Designing Data-Intensive Applications",
-        "Legacy Collection",
-      ]);
-      expect(entries[0]).toHaveTextContent("COLLECTION");
-      expect(entries[0]).toHaveTextContent("Role context: Backend Engineer");
-      expect(entries[0]).toHaveTextContent("Event context #11");
-      expect(entries[1]).toHaveTextContent("EXERCISE");
-      expect(entries[1]).toHaveTextContent("QUICK");
-      expect(entries[2]).toHaveTextContent("MEDIA");
+    await screen.findByRole("button", { name: "Retry same record" });
+    expect(screen.getByRole("alert")).toHaveTextContent("Outcome unknown");
+    const firstKey = api.quickRecordApi.mock.calls[0][1];
+    fireEvent.change(screen.getByLabelText("Collection title"), { target: { value: "Edited retry" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save Quick Record" }));
+    await waitFor(() => expect(api.quickRecordApi).toHaveBeenCalledTimes(2));
+    expect(api.quickRecordApi.mock.calls[1][0]).toEqual({
+      type: "COLLECTION",
+      collection: { category: "BOOK", title: "Edited retry", quantity: 1 },
     });
-
-    it("nullable Exercise metric은 생략하고 실제 zero/non-null 값은 보존한다", async () => {
-      api.listJournalApi.mockResolvedValue({
-        content: [{
-          ...MOCK_JOURNAL_ENTRIES[1],
-          preview: {
-            ...MOCK_JOURNAL_ENTRIES[1].preview,
-            durationMinutes: 0,
-            distanceKm: null,
-            calories: 240,
-          },
-        }],
-        page: 0,
-        size: 20,
-        totalElements: 1,
-        totalPages: 1,
-      } satisfies JournalPage);
-      render(<JournalShell roles={roles} />);
-
-      const entry = await screen.findByTestId("journal-entry");
-      expect(entry).toHaveTextContent("EXERCISE · RUNNING · 0 min · 240 kcal · ACTIVITY · QUICK");
-      expect(entry).not.toHaveTextContent("— min");
-      expect(entry).not.toHaveTextContent("— km");
-      expect(entry).not.toHaveTextContent("— kcal");
-    });
+    expect(api.quickRecordApi.mock.calls[1][1]).not.toBe(firstKey);
   });
 
-  describe("Role/subtype filter와 server page를 변경하면", () => {
-    it("filter를 보존하고 filter 변경마다 page를 0으로 reset하며 pagination bounds를 적용한다", async () => {
-      api.listJournalApi.mockImplementation(async (params: { primaryRoleId?: number; subtype?: string; page: number; size: number }): Promise<JournalPage> => ({
-        content: MOCK_JOURNAL_ENTRIES.filter((entry) =>
-          (params.primaryRoleId === undefined || entry.primaryRoleId === params.primaryRoleId)
-          && (params.subtype === undefined || entry.subtype === params.subtype)
-        ),
-        page: params.page,
-        size: params.size,
-        totalElements: 40,
-        totalPages: 2,
-      }));
-      render(<JournalShell roles={roles} />);
+  it("does not reopen stale Quick Record after leaving and returning", async () => {
+    const view = await renderJournal();
+    fireEvent.click(screen.getByRole("button", { name: "Quick Record" }));
+    expect(document.querySelector('[data-stage-key="lifelog-quick-record"]')).toBeInTheDocument();
+    view.unmount();
 
-      expect(await screen.findByText("Page 1 / 2")).toBeInTheDocument();
-      expect(screen.getByRole("button", { name: "Previous" })).toBeDisabled();
-      fireEvent.change(screen.getByLabelText("Role filter"), { target: { value: "2" } });
-      await waitFor(() => expect(api.listJournalApi).toHaveBeenLastCalledWith({ primaryRoleId: 2, page: 0, size: 20 }));
-      fireEvent.click(screen.getByRole("button", { name: "Next" }));
-      await waitFor(() => expect(api.listJournalApi).toHaveBeenLastCalledWith({ primaryRoleId: 2, page: 1, size: 20 }));
-      expect(await screen.findByText("Page 2 / 2")).toBeInTheDocument();
-      expect(screen.getByRole("button", { name: "Next" })).toBeDisabled();
-      expect(screen.getByRole("button", { name: "Previous" })).toBeEnabled();
-
-      fireEvent.change(screen.getByLabelText("Subtype filter"), { target: { value: "REFLECTION" } });
-      await waitFor(() => expect(api.listJournalApi).toHaveBeenLastCalledWith({ primaryRoleId: 2, subtype: "REFLECTION", page: 0, size: 20 }));
-    });
-  });
-
-  describe("목록 request가 실패하거나 비어 있으면", () => {
-    it("loading과 error/retry를 거쳐 authoritative empty state를 표시한다", async () => {
-      const first = deferred<JournalPage>();
-      api.listJournalApi.mockReturnValueOnce(first.promise).mockResolvedValueOnce({ ...mixedPage, content: [], totalElements: 0, totalPages: 0 });
-      render(<JournalShell roles={roles} />);
-
-      expect(screen.getByText("Loading Journal...")).toBeInTheDocument();
-      await act(async () => {
-        first.reject(new Error("Journal unavailable"));
-        await first.promise.catch(() => undefined);
-      });
-      expect(screen.getByRole("alert")).toHaveTextContent("Journal unavailable");
-      fireEvent.click(screen.getByRole("button", { name: "Retry" }));
-
-      expect(await screen.findByText("No Journal entries.")).toBeInTheDocument();
-      expect(screen.getByRole("button", { name: "Previous" })).toBeDisabled();
-      expect(screen.getByRole("button", { name: "Next" })).toBeDisabled();
-    });
-  });
-
-  describe("lifeLogId로 Journal detail을 선택하면", () => {
-    it("Collection/Exercise/Media source를 명시적으로 렌더하고 mutation action을 노출하지 않는다", async () => {
-      render(<JournalShell roles={roles} />);
-      const entries = await screen.findAllByTestId("journal-entry");
-
-      fireEvent.click(entries[0]);
-      expect(await screen.findByText("Condition: Annotated")).toBeInTheDocument();
-      expect(api.getJournalDetailApi).toHaveBeenLastCalledWith(104);
-
-      fireEvent.click(entries[1]);
-      expect(await screen.findByText("Memo: Morning run")).toBeInTheDocument();
-      expect(screen.getByText("Entry mode: QUICK")).toBeInTheDocument();
-
-      fireEvent.click(entries[2]);
-      expect(await screen.findByText("Rewatch count: 0")).toBeInTheDocument();
-      expect(screen.queryByRole("button", { name: /edit|delete|complete event/i })).not.toBeInTheDocument();
-      expect(screen.queryByText(/Created by this RoleEvent|Completed event record/)).not.toBeInTheDocument();
-    });
-
-    it("legacy Collection nullable detail을 Not recorded로 표시한다", async () => {
-      render(<JournalShell roles={roles} />);
-      fireEvent.click((await screen.findAllByTestId("journal-entry"))[3]);
-
-      expect(await screen.findByText("Original title: Not recorded")).toBeInTheDocument();
-      expect(screen.getByText("Quantity: Not recorded")).toBeInTheDocument();
-      expect(screen.getByText("Condition: Not recorded")).toBeInTheDocument();
-      expect(screen.getByText("Acquired from: Not recorded")).toBeInTheDocument();
-      expect(screen.getByText("Tags: Not recorded")).toBeInTheDocument();
-      expect(screen.queryByText(/—/)).not.toBeInTheDocument();
-    });
-
-    it("detail loading/error를 표시하고 같은 lifeLogId로 retry한다", async () => {
-      const first = deferred<ReturnType<typeof journalMock.detail>>();
-      api.getJournalDetailApi.mockReturnValueOnce(first.promise).mockResolvedValueOnce(journalMock.detail(104));
-      render(<JournalShell roles={roles} />);
-      fireEvent.click((await screen.findAllByTestId("journal-entry"))[0]);
-      expect(screen.getByText("Loading Journal detail...")).toBeInTheDocument();
-
-      await act(async () => {
-        first.reject(new Error("Detail unavailable"));
-        await first.promise.catch(() => undefined);
-      });
-      expect(screen.getByRole("alert")).toHaveTextContent("Detail unavailable");
-      fireEvent.click(screen.getByRole("button", { name: "Retry" }));
-
-      expect(await screen.findByText("Condition: Annotated")).toBeInTheDocument();
-      expect(api.getJournalDetailApi).toHaveBeenNthCalledWith(1, 104);
-      expect(api.getJournalDetailApi).toHaveBeenNthCalledWith(2, 104);
-    });
+    await renderJournal();
+    expect(document.querySelector('[data-stage-key="lifelog-quick-record"]')).not.toBeInTheDocument();
   });
 });

--- a/features/lifelog/JournalShell.test.tsx
+++ b/features/lifelog/JournalShell.test.tsx
@@ -76,6 +76,9 @@ describe("LifeLog Journal v7 surface", () => {
     expect(css).toContain("var(--lag-control-bg)");
     expect(css).toContain("@media (max-width: 767px)");
     expect(css).toContain(".lag-orb-column");
+    const timestampStyles = css.match(/\.lag-journal-entry time\s*\{([^}]*)\}/)?.[1];
+    expect(timestampStyles).toContain("color: var(--lag-text-2)");
+    expect(timestampStyles).not.toContain("var(--lag-meta)");
   });
 
   it("renders the real server order as structured record cards", async () => {

--- a/features/lifelog/JournalShell.tsx
+++ b/features/lifelog/JournalShell.tsx
@@ -17,11 +17,10 @@ import type {
   QuickRecordType,
   RoleDetail,
 } from "@/shared/api/types";
-import { INPUT_STYLE, SAO } from "@/shared/design/tokens";
-import PanelCard from "@/shared/ui/PanelCard";
-import PanelStage from "@/shared/ui/PanelStage";
-import { PanelFrame } from "@/widgets/right-panels/ui/PanelFrame";
-import { GoldRow, InfoCard } from "@/widgets/right-panels/ui/Rows";
+import { requestStageFocus } from "@/shared/hooks/useStageCamera";
+import PanelStage, { StageContentTransition } from "@/shared/ui/PanelStage";
+import { BackButton, PanelFrame } from "@/widgets/right-panels/ui/PanelFrame";
+import { InfoCard } from "@/widgets/right-panels/ui/Rows";
 import { useJournalQueries } from "./useJournalQueries";
 
 export const JOURNAL_SUBTYPES: JournalSubtype[] = [
@@ -35,16 +34,6 @@ export const JOURNAL_SUBTYPES: JournalSubtype[] = [
   "HEALTH_NOTE",
 ];
 
-const secondaryButton = {
-  border: `1px solid ${SAO.color.border.panel}`,
-  background: SAO.color.bg.inset,
-  color: SAO.color.text.secondary,
-  borderRadius: SAO.radius.panel,
-  padding: "7px 10px",
-  fontSize: "0.68rem",
-  letterSpacing: "0.08em",
-} as const;
-
 const EXERCISE_CATEGORIES = ["RUNNING", "WALKING", "CYCLING", "SWIMMING", "GYM", "YOGA", "OTHER"] as const;
 const MEDIA_CATEGORIES = ["ANIME", "MOVIE", "SERIES", "BOOK", "WEBTOON", "GAME", "MUSIC"] as const;
 const MEDIA_STATUSES = ["PLANNED", "WATCHING", "COMPLETED", "DROPPED", "ON_HOLD"] as const;
@@ -56,6 +45,44 @@ function text(form: FormData, key: string) {
 function optionalNumber(form: FormData, key: string) {
   const raw = text(form, key);
   return raw === "" ? undefined : Number(raw);
+}
+
+function label(value: string) {
+  return value.replaceAll("_", " ");
+}
+
+function displayTimestamp(value: string) {
+  return value.replace("T", " ").replace("Z", " UTC");
+}
+
+function Field({ children, title }: { children: React.ReactNode; title: string }) {
+  return (
+    <label className="lag-journal-field">
+      <span>{title}</span>
+      {children}
+    </label>
+  );
+}
+
+function SelectField({
+  disabled,
+  name,
+  title,
+  values,
+}: {
+  disabled: boolean;
+  name: string;
+  title: string;
+  values: readonly string[];
+}) {
+  return (
+    <Field title={title}>
+      <select className="lag-journal-control" name={name} required defaultValue="" disabled={disabled}>
+        <option value="" disabled>Select...</option>
+        {values.map((value) => <option key={value} value={value}>{label(value)}</option>)}
+      </select>
+    </Field>
+  );
 }
 
 function QuickRecordForm({
@@ -148,94 +175,104 @@ function QuickRecordForm({
     resetAfter(await onSubmit(body));
   };
 
-  const select = (name: string, label: string, values: readonly string[]) => (
-    <label className="block text-xs" style={{ color: SAO.color.text.label }}>
-      {label}
-      <select name={name} required defaultValue="" style={INPUT_STYLE} disabled={pending}>
-        <option value="" disabled>Select...</option>
-        {values.map((value) => <option key={value} value={value}>{value.replaceAll("_", " ")}</option>)}
-      </select>
-    </label>
-  );
+  const chooseType = (next: QuickRecordType) => {
+    onEdit();
+    setType(next);
+  };
 
   return (
-    <form ref={formRef} className="space-y-2" onSubmit={submit} onChangeCapture={onEdit}>
-      <label className="block text-xs" style={{ color: SAO.color.text.label }}>
-        Quick Record type
-        <select
-          name="type"
-          aria-label="Quick Record type"
-          value={type}
-          style={INPUT_STYLE}
-          disabled={pending}
-          onChange={(event) => setType(event.target.value as QuickRecordType)}
-        >
-          <option value="COLLECTION">Collection</option>
-          <option value="EXERCISE">Exercise</option>
-          <option value="MEDIA">Media</option>
-        </select>
-      </label>
-
-      <label className="block text-xs" style={{ color: SAO.color.text.label }}>
-        Quick Record subtype
-        <select name="lifeLogSubtype" aria-label="Quick Record subtype" defaultValue="" style={INPUT_STYLE} disabled={pending}>
-          <option value="">None</option>
-          {JOURNAL_SUBTYPES.map((subtype) => <option key={subtype} value={subtype}>{subtype.replaceAll("_", " ")}</option>)}
-        </select>
-      </label>
-
-      <label className="block text-xs" style={{ color: SAO.color.text.label }}>
-        Quick Record role
-        <select name="primaryRoleId" aria-label="Quick Record role" defaultValue="" style={INPUT_STYLE} disabled={pending || rolesLoading}>
-          <option value="">No Role</option>
-          {roles.map((role) => <option key={role.id} value={role.id}>{role.name}</option>)}
-        </select>
-      </label>
-      {rolesLoading ? <InfoCard>Loading Roles...</InfoCard> : null}
-      {rolesError ? <p role="alert" className="text-xs" style={{ color: SAO.color.action.red }}>Role selection unavailable: {rolesError}</p> : null}
-
-      {type === "COLLECTION" ? (
-        <>
-          {select("collectionCategory", "Collection category", COLLECTION_CATEGORIES)}
-          <label className="block text-xs" style={{ color: SAO.color.text.label }}>Collection title<input name="collectionTitle" required style={INPUT_STYLE} disabled={pending} /></label>
-          <label className="block text-xs" style={{ color: SAO.color.text.label }}>Quantity<input name="quantity" type="number" min={1} required style={INPUT_STYLE} disabled={pending} /></label>
-        </>
-      ) : type === "EXERCISE" ? (
-        <>
-          {select("exerciseCategory", "Exercise category", EXERCISE_CATEGORIES)}
-          <label className="block text-xs" style={{ color: SAO.color.text.label }}>Duration minutes<input name="durationMinutes" type="number" min={1} required style={INPUT_STYLE} disabled={pending} /></label>
-          <label className="block text-xs" style={{ color: SAO.color.text.label }}>Exercised on<input name="exercisedOn" type="date" required style={INPUT_STYLE} disabled={pending} /></label>
-          <label className="block text-xs" style={{ color: SAO.color.text.label }}>Distance km<input name="distanceKm" type="number" min={0} step="any" style={INPUT_STYLE} disabled={pending} /></label>
-          <label className="block text-xs" style={{ color: SAO.color.text.label }}>Calories<input name="calories" type="number" min={0} style={INPUT_STYLE} disabled={pending} /></label>
-          <label className="block text-xs" style={{ color: SAO.color.text.label }}>Memo<textarea name="memo" rows={2} style={{ ...INPUT_STYLE, resize: "vertical" }} disabled={pending} /></label>
-        </>
-      ) : (
-        <>
-          {select("mediaCategory", "Media category", MEDIA_CATEGORIES)}
-          <label className="block text-xs" style={{ color: SAO.color.text.label }}>Media title<input name="mediaTitle" required style={INPUT_STYLE} disabled={pending} /></label>
-          {select("mediaStatus", "Media status", MEDIA_STATUSES)}
-          <label className="block text-xs" style={{ color: SAO.color.text.label }}>Current episode<input name="currentEpisode" type="number" min={0} style={INPUT_STYLE} disabled={pending} /></label>
-          <label className="block text-xs" style={{ color: SAO.color.text.label }}>Total episodes<input name="totalEpisode" type="number" min={1} style={INPUT_STYLE} disabled={pending} /></label>
-        </>
-      )}
-
-      {error ? <p role="alert" className="text-xs" style={{ color: SAO.color.action.red }}>{error}</p> : null}
-      {result ? <p role="status" className="text-xs" style={{ color: SAO.color.text.gold }}>{result.replay ? "Quick Record replay confirmed." : "Quick Record saved."}</p> : null}
-      {refreshError ? <p role="alert" className="text-xs" style={{ color: SAO.color.action.red }}>{refreshError}</p> : null}
-      <div className="flex gap-2">
-        {canRetry
-          ? <button type="button" disabled={pending} style={{ ...secondaryButton, flex: 1 }} onClick={() => void onRetry().then(resetAfter)}>Retry same record</button>
-          : <button type="submit" disabled={pending} style={{ ...secondaryButton, flex: 1 }}>{pending ? "Saving..." : "Save Quick Record"}</button>}
+    <form ref={formRef} className="lag-quick-record-form" onSubmit={submit} onChangeCapture={onEdit}>
+      <div>
+        <p className="lag-journal-eyebrow">Record type</p>
+        <div className="lag-journal-segments" role="radiogroup" aria-label="Quick Record type">
+          {(["COLLECTION", "EXERCISE", "MEDIA"] as const).map((value) => (
+            <button
+              key={value}
+              type="button"
+              role="radio"
+              aria-checked={type === value}
+              className="lag-journal-chip"
+              data-selected={type === value}
+              disabled={pending}
+              onClick={() => chooseType(value)}
+            >
+              {label(value)}
+            </button>
+          ))}
+        </div>
       </div>
+
+      <div className="lag-journal-form-grid">
+        <Field title="Quick Record subtype">
+          <select className="lag-journal-control" name="lifeLogSubtype" aria-label="Quick Record subtype" defaultValue="" disabled={pending}>
+            <option value="">None</option>
+            {JOURNAL_SUBTYPES.map((subtype) => <option key={subtype} value={subtype}>{label(subtype)}</option>)}
+          </select>
+        </Field>
+        <Field title="Quick Record role">
+          <select className="lag-journal-control" name="primaryRoleId" aria-label="Quick Record role" defaultValue="" disabled={pending || rolesLoading}>
+            <option value="">No Role</option>
+            {roles.map((role) => <option key={role.id} value={role.id}>{role.name}</option>)}
+          </select>
+        </Field>
+      </div>
+
+      {rolesLoading ? <InfoCard>Loading Roles...</InfoCard> : null}
+      {rolesError ? <p role="alert" className="lag-journal-feedback" data-state="error">Role selection unavailable: {rolesError}</p> : null}
+
+      <div className="lag-quick-record-fields" data-testid="quick-record-fields">
+        <StageContentTransition identity={type}>
+          <fieldset className="lag-journal-form-grid" disabled={pending}>
+            <legend className="sr-only">{label(type)} fields</legend>
+            {type === "COLLECTION" ? (
+              <>
+                <SelectField name="collectionCategory" title="Collection category" values={COLLECTION_CATEGORIES} disabled={pending} />
+                <Field title="Collection title"><input className="lag-journal-control" name="collectionTitle" required /></Field>
+                <Field title="Quantity"><input className="lag-journal-control" name="quantity" type="number" min={1} required /></Field>
+              </>
+            ) : type === "EXERCISE" ? (
+              <>
+                <SelectField name="exerciseCategory" title="Exercise category" values={EXERCISE_CATEGORIES} disabled={pending} />
+                <Field title="Duration minutes"><input className="lag-journal-control" name="durationMinutes" type="number" min={1} required /></Field>
+                <Field title="Exercised on"><input className="lag-journal-control" name="exercisedOn" type="date" required /></Field>
+                <Field title="Distance km"><input className="lag-journal-control" name="distanceKm" type="number" min={0} step="any" /></Field>
+                <Field title="Calories"><input className="lag-journal-control" name="calories" type="number" min={0} /></Field>
+                <Field title="Memo"><textarea className="lag-journal-control" name="memo" rows={3} /></Field>
+              </>
+            ) : (
+              <>
+                <SelectField name="mediaCategory" title="Media category" values={MEDIA_CATEGORIES} disabled={pending} />
+                <Field title="Media title"><input className="lag-journal-control" name="mediaTitle" required /></Field>
+                <SelectField name="mediaStatus" title="Media status" values={MEDIA_STATUSES} disabled={pending} />
+                <Field title="Current episode"><input className="lag-journal-control" name="currentEpisode" type="number" min={0} /></Field>
+                <Field title="Total episodes"><input className="lag-journal-control" name="totalEpisode" type="number" min={1} /></Field>
+              </>
+            )}
+          </fieldset>
+        </StageContentTransition>
+      </div>
+
+      {error ? <p role="alert" className="lag-journal-feedback" data-state="error">Save failed: {error}</p> : null}
+      {result ? <p role="status" className="lag-journal-feedback" data-state="success">✓ {result.replay ? "Quick Record replay confirmed." : "Quick Record saved."}</p> : null}
+      {refreshError ? <p role="alert" className="lag-journal-feedback" data-state="error">Refresh failed: {refreshError}</p> : null}
+      {canRetry ? (
+        <button type="button" className="lag-journal-action" data-variant="retry" disabled={pending} onClick={() => void onRetry().then(resetAfter)}>
+          {pending ? "Retrying..." : "Retry same record"}
+        </button>
+      ) : (
+        <button type="submit" className="lag-journal-action" disabled={pending}>
+          {pending ? "Saving..." : "Save Quick Record"}
+        </button>
+      )}
     </form>
   );
 }
 
-function ErrorState({ text, retry }: { text: string; retry: () => void }) {
+function ErrorState({ message, retry }: { message: string; retry: () => void }) {
   return (
-    <div className="space-y-2 px-3">
-      <p role="alert" className="text-xs" style={{ color: SAO.color.action.red }}>{text}</p>
-      <button type="button" style={secondaryButton} onClick={retry}>Retry</button>
+    <div className="lag-journal-state">
+      <p role="alert" className="lag-journal-feedback" data-state="error">Load failed: {message}</p>
+      <button type="button" className="lag-journal-button" onClick={retry}>Retry</button>
     </div>
   );
 }
@@ -245,191 +282,265 @@ function entryPresentation(entry: JournalEntry) {
     case "COLLECTION":
       return {
         title: entry.preview.title,
-        summary: [
-          entry.preview.category,
-          entry.preview.quantity !== null ? `Quantity ${entry.preview.quantity}` : null,
-        ].filter((value): value is string => value !== null).join(" · "),
+        summary: [entry.preview.category, entry.preview.quantity !== null ? `Quantity ${entry.preview.quantity}` : null].filter(Boolean).join(" · "),
       };
     case "EXERCISE":
       return {
-        title: `${entry.preview.category} · ${entry.preview.exercisedOn}`,
+        title: `${label(entry.preview.category)} · ${entry.preview.exercisedOn}`,
         summary: [
-          entry.preview.category,
           entry.preview.durationMinutes !== null ? `${entry.preview.durationMinutes} min` : null,
           entry.preview.distanceKm !== null ? `${entry.preview.distanceKm} km` : null,
           entry.preview.calories !== null ? `${entry.preview.calories} kcal` : null,
-        ].filter((value): value is string => value !== null).join(" · "),
+        ].filter(Boolean).join(" · "),
       };
     case "MEDIA":
-      return { title: entry.preview.title, summary: `${entry.preview.category} · ${entry.preview.status} · ${entry.preview.currentEpisode}/${entry.preview.totalEpisode}` };
+      return { title: entry.preview.title, summary: `${label(entry.preview.category)} · ${label(entry.preview.status)} · ${entry.preview.currentEpisode}/${entry.preview.totalEpisode}` };
   }
 }
 
-function roleContext(primaryRoleId: number | null, roles: RoleDetail[]) {
+function roleName(primaryRoleId: number | null, roles: RoleDetail[]) {
   if (primaryRoleId === null) return null;
-  return `Role context: ${roles.find(({ id }) => id === primaryRoleId)?.name ?? `#${primaryRoleId}`}`;
+  return roles.find(({ id }) => id === primaryRoleId)?.name ?? `Role #${primaryRoleId}`;
+}
+
+function DetailItem({ name, value }: { name: string; value: React.ReactNode }) {
+  return (
+    <div className="lag-journal-detail-item">
+      <dt>{name}</dt>
+      <dd>{value}</dd>
+    </div>
+  );
+}
+
+function DetailSection({ children, title }: { children: React.ReactNode; title: string }) {
+  return (
+    <section className="lag-journal-detail-section">
+      <h4>{title}</h4>
+      <dl>{children}</dl>
+    </section>
+  );
 }
 
 function SourceDetail({ detail }: { detail: JournalDetail }) {
   switch (detail.sourceType) {
     case "COLLECTION":
       return (
-        <div className="space-y-1.5">
-          <GoldRow>Category: {detail.source.category}</GoldRow>
-          <GoldRow>Title: {detail.source.title}</GoldRow>
-          <GoldRow>Original title: {detail.source.originalTitle ?? "Not recorded"}</GoldRow>
-          <GoldRow>Quantity: {detail.source.quantity ?? "Not recorded"}</GoldRow>
-          <GoldRow>Condition: {detail.source.conditionNote ?? "Not recorded"}</GoldRow>
-          <GoldRow>Acquired from: {detail.source.acquiredFrom ?? "Not recorded"}</GoldRow>
-          <GoldRow>Tags: {detail.source.tags.length > 0 ? detail.source.tags.join(", ") : "Not recorded"}</GoldRow>
-          <GoldRow>Created: {detail.source.createdAt}</GoldRow>
-          <GoldRow>Updated: {detail.source.updatedAt}</GoldRow>
-        </div>
+        <DetailSection title="Collection">
+          <DetailItem name="Category" value={label(detail.source.category)} />
+          <DetailItem name="Title" value={detail.source.title} />
+          <DetailItem name="Original title" value={detail.source.originalTitle ?? "Not recorded"} />
+          <DetailItem name="Quantity" value={detail.source.quantity ?? "Not recorded"} />
+          <DetailItem name="Condition" value={detail.source.conditionNote ?? "Not recorded"} />
+          <DetailItem name="Acquired from" value={detail.source.acquiredFrom ?? "Not recorded"} />
+          <DetailItem name="Tags" value={detail.source.tags.length > 0 ? detail.source.tags.join(", ") : "Not recorded"} />
+          <DetailItem name="Created" value={displayTimestamp(detail.source.createdAt)} />
+          <DetailItem name="Updated" value={displayTimestamp(detail.source.updatedAt)} />
+        </DetailSection>
       );
     case "EXERCISE":
       return (
-        <div className="space-y-1.5">
-          <GoldRow>Category: {detail.source.category}</GoldRow>
-          <GoldRow>Duration: {detail.source.durationMinutes === null ? "Not recorded" : `${detail.source.durationMinutes} min`}</GoldRow>
-          <GoldRow>Distance: {detail.source.distanceKm === null ? "Not recorded" : `${detail.source.distanceKm} km`}</GoldRow>
-          <GoldRow>Calories: {detail.source.calories === null ? "Not recorded" : `${detail.source.calories} kcal`}</GoldRow>
-          <GoldRow>Exercised on: {detail.source.exercisedOn}</GoldRow>
-          <GoldRow>Memo: {detail.source.memo ?? "Not recorded"}</GoldRow>
-          <GoldRow>Created: {detail.source.createdAt}</GoldRow>
-          <GoldRow>Updated: {detail.source.updatedAt}</GoldRow>
-        </div>
+        <DetailSection title="Exercise">
+          <DetailItem name="Category" value={label(detail.source.category)} />
+          <DetailItem name="Duration" value={detail.source.durationMinutes === null ? "Not recorded" : `${detail.source.durationMinutes} min`} />
+          <DetailItem name="Distance" value={detail.source.distanceKm === null ? "Not recorded" : `${detail.source.distanceKm} km`} />
+          <DetailItem name="Calories" value={detail.source.calories === null ? "Not recorded" : `${detail.source.calories} kcal`} />
+          <DetailItem name="Exercised on" value={detail.source.exercisedOn} />
+          <DetailItem name="Memo" value={detail.source.memo ?? "Not recorded"} />
+          <DetailItem name="Created" value={displayTimestamp(detail.source.createdAt)} />
+          <DetailItem name="Updated" value={displayTimestamp(detail.source.updatedAt)} />
+        </DetailSection>
       );
     case "MEDIA":
       return (
-        <div className="space-y-1.5">
-          <GoldRow>Category: {detail.source.category}</GoldRow>
-          <GoldRow>Title: {detail.source.title}</GoldRow>
-          <GoldRow>Original title: {detail.source.originalTitle ?? "Not recorded"}</GoldRow>
-          <GoldRow>Progress: {detail.source.currentEpisode}/{detail.source.totalEpisode}</GoldRow>
-          <GoldRow>Status: {detail.source.status}</GoldRow>
-          <GoldRow>Rating: {detail.source.rating ?? "Not recorded"}</GoldRow>
-          <GoldRow>Tags: {detail.source.tags.length > 0 ? detail.source.tags.join(", ") : "Not recorded"}</GoldRow>
-          <GoldRow>Rewatch count: {detail.source.rewatchCount}</GoldRow>
-          <GoldRow>Started: {detail.source.startedOn ?? "Not recorded"}</GoldRow>
-          <GoldRow>Finished: {detail.source.finishedOn ?? "Not recorded"}</GoldRow>
-          <GoldRow>Created: {detail.source.createdAt}</GoldRow>
-          <GoldRow>Updated: {detail.source.updatedAt}</GoldRow>
-        </div>
+        <DetailSection title="Media">
+          <DetailItem name="Category" value={label(detail.source.category)} />
+          <DetailItem name="Title" value={detail.source.title} />
+          <DetailItem name="Original title" value={detail.source.originalTitle ?? "Not recorded"} />
+          <DetailItem name="Progress" value={`${detail.source.currentEpisode}/${detail.source.totalEpisode}`} />
+          <DetailItem name="Status" value={label(detail.source.status)} />
+          <DetailItem name="Rating" value={detail.source.rating ?? "Not recorded"} />
+          <DetailItem name="Tags" value={detail.source.tags.length > 0 ? detail.source.tags.join(", ") : "Not recorded"} />
+          <DetailItem name="Rewatch count" value={detail.source.rewatchCount} />
+          <DetailItem name="Started" value={detail.source.startedOn ?? "Not recorded"} />
+          <DetailItem name="Finished" value={detail.source.finishedOn ?? "Not recorded"} />
+          <DetailItem name="Created" value={displayTimestamp(detail.source.createdAt)} />
+          <DetailItem name="Updated" value={displayTimestamp(detail.source.updatedAt)} />
+        </DetailSection>
       );
   }
 }
 
 export default function JournalShell({ roles, rolesLoading = false, rolesError = null }: { roles: RoleDetail[]; rolesLoading?: boolean; rolesError?: string | null }) {
   const journal = useJournalQueries();
+  const [quickRecordOpen, setQuickRecordOpen] = useState(false);
   const { data: page, loading, error } = journal.list;
   const detail = journal.detail.data;
   const previousDisabled = loading || journal.params.page === 0;
   const nextDisabled = loading || page.totalPages === 0 || journal.params.page + 1 >= page.totalPages;
 
-  return (
-    <div className="lag-panel-rail relative" data-testid="journal-shell">
-      <PanelStage stageKey="lifelog-journal-filters">
-        <PanelFrame title="Journal Filters" depth={2}>
-        <div className="space-y-3 px-3">
-          <details>
-            <summary className="cursor-pointer text-xs" style={{ color: SAO.color.text.gold }}>Quick Record</summary>
-            <div className="mt-3">
-              <QuickRecordForm
-                roles={roles}
-                rolesLoading={rolesLoading}
-                rolesError={rolesError}
-                pending={journal.quickRecord.pending}
-                error={journal.quickRecord.error}
-                result={journal.quickRecord.result}
-                refreshError={journal.quickRecord.refreshError}
-                canRetry={journal.quickRecord.canRetry}
-                onSubmit={journal.quickRecord.submit}
-                onRetry={journal.quickRecord.retry}
-                onEdit={journal.quickRecord.invalidateRetry}
-              />
-            </div>
-          </details>
-          <label className="block text-xs" style={{ color: SAO.color.text.label }}>
-            Role
-            <select aria-label="Role filter" value={journal.params.primaryRoleId ?? ""} style={INPUT_STYLE} onChange={(event) => journal.changeRoleFilter(event.target.value ? Number(event.target.value) : undefined)}>
-              <option value="">All Roles</option>
-              {roles.map((role) => <option key={role.id} value={role.id}>{role.name}</option>)}
-            </select>
-          </label>
-          <label className="block text-xs" style={{ color: SAO.color.text.label }}>
-            Subtype
-            <select aria-label="Subtype filter" value={journal.params.subtype ?? ""} style={INPUT_STYLE} onChange={(event) => journal.changeSubtypeFilter(event.target.value ? event.target.value as JournalSubtype : undefined)}>
-              <option value="">All Subtypes</option>
-              {JOURNAL_SUBTYPES.map((subtype) => <option key={subtype} value={subtype}>{subtype.replaceAll("_", " ")}</option>)}
-            </select>
-          </label>
-          {rolesLoading ? <InfoCard>Loading Roles...</InfoCard> : null}
-          {rolesError ? <p role="alert" className="text-xs" style={{ color: SAO.color.action.red }}>Role filter unavailable: {rolesError}</p> : null}
-        </div>
-        </PanelFrame>
-      </PanelStage>
+  const returnToJournal = () => requestStageFocus("lifelog-journal", "nearest");
+  const openQuickRecord = () => {
+    journal.clearSelection();
+    setQuickRecordOpen(true);
+  };
+  const closeQuickRecord = () => {
+    setQuickRecordOpen(false);
+    journal.clearSelection();
+    returnToJournal();
+  };
+  const closeDetail = () => {
+    journal.clearSelection();
+    returnToJournal();
+  };
 
-      <PanelStage stageKey="lifelog-journal-list" index={1}>
-        <PanelFrame title="Journal" depth={1}>
-        <div className="space-y-3">
-          {loading ? <InfoCard>Loading Journal...</InfoCard> : null}
-          {error ? <ErrorState text={error} retry={() => void journal.list.reload()} /> : null}
-          {!loading && !error && page.content.length === 0 ? <InfoCard>No Journal entries.</InfoCard> : null}
-          <div className="space-y-2">
-            {page.content.map((entry, index) => {
-              const presentation = entryPresentation(entry);
-              const context = [
-                entry.sourceType,
-                presentation.summary,
-                entry.subtype,
-                entry.entryMode === "QUICK" ? "QUICK" : null,
-                roleContext(entry.primaryRoleId, roles),
-                entry.roleEventId === null ? null : `Event context #${entry.roleEventId}`,
-                entry.recordedAt,
-              ].filter(Boolean).join(" · ");
-              return (
-                <PanelCard
-                  key={entry.lifeLogId}
-                  label={presentation.title}
-                  slotLabel={entry.sourceType.slice(0, 2)}
-                  subtitle={context}
-                  selected={journal.selectedLifeLogId === entry.lifeLogId}
-                  index={index}
-                  onClick={() => journal.selectEntry(entry.lifeLogId)}
-                />
-              );
-            })}
+  return (
+    <div className="lag-panel-rail lag-journal-shell relative" data-testid="journal-shell">
+      <PanelStage stageKey="lifelog-journal">
+        <PanelFrame title="Journal / LifeLog" depth={1}>
+          <div className="lag-journal-surface">
+            <div className="lag-journal-toolbar">
+              <div>
+                <p className="lag-journal-eyebrow">Archive</p>
+                <p className="lag-journal-intro">Browse your recorded collections, exercise, and media.</p>
+              </div>
+              <button type="button" className="lag-journal-action" onClick={openQuickRecord}>Quick Record</button>
+            </div>
+
+            <div className="lag-journal-filters" aria-label="Journal filters">
+              <Field title="Role">
+                <select
+                  className="lag-journal-control"
+                  aria-label="Role filter"
+                  value={journal.params.primaryRoleId ?? ""}
+                  onChange={(event) => journal.changeRoleFilter(event.target.value ? Number(event.target.value) : undefined)}
+                >
+                  <option value="">All Roles</option>
+                  {roles.map((role) => <option key={role.id} value={role.id}>{role.name}</option>)}
+                </select>
+              </Field>
+              <Field title="Subtype">
+                <select
+                  className="lag-journal-control"
+                  aria-label="Subtype filter"
+                  value={journal.params.subtype ?? ""}
+                  onChange={(event) => journal.changeSubtypeFilter(event.target.value ? event.target.value as JournalSubtype : undefined)}
+                >
+                  <option value="">All Subtypes</option>
+                  {JOURNAL_SUBTYPES.map((subtype) => <option key={subtype} value={subtype}>{label(subtype)}</option>)}
+                </select>
+              </Field>
+            </div>
+            {rolesLoading ? <InfoCard>Loading Roles...</InfoCard> : null}
+            {rolesError ? <p role="alert" className="lag-journal-feedback" data-state="error">Role filter unavailable: {rolesError}</p> : null}
+
+            <section className="lag-journal-archive" aria-label="Journal archive">
+              <div className="lag-journal-section-heading">
+                <h4>Records</h4>
+                <span>{page.totalElements} total</span>
+              </div>
+              {loading ? <InfoCard>Loading Journal...</InfoCard> : null}
+              {error ? <ErrorState message={error} retry={() => void journal.list.reload()} /> : null}
+              {!loading && !error && page.content.length === 0 ? <InfoCard>No Journal entries.</InfoCard> : null}
+              <div className="lag-journal-list">
+                {page.content.map((entry) => {
+                  const presentation = entryPresentation(entry);
+                  const role = roleName(entry.primaryRoleId, roles);
+                  return (
+                    <button
+                      key={entry.lifeLogId}
+                      type="button"
+                      className="lag-journal-entry"
+                      data-testid="journal-entry"
+                      data-selected={journal.selectedLifeLogId === entry.lifeLogId}
+                      aria-pressed={journal.selectedLifeLogId === entry.lifeLogId}
+                      onClick={() => journal.selectEntry(entry.lifeLogId)}
+                    >
+                      <span className="lag-journal-source" aria-hidden>{entry.sourceType.slice(0, 2)}</span>
+                      <span className="lag-journal-entry-copy">
+                        <strong>{presentation.title}</strong>
+                        <span className="lag-journal-entry-summary">{presentation.summary}</span>
+                        <span className="lag-journal-entry-chips">
+                          <span>{label(entry.sourceType)}</span>
+                          {entry.subtype ? <span>{label(entry.subtype)}</span> : null}
+                          {entry.entryMode === "QUICK" ? <span>Quick</span> : null}
+                          {role ? <span>{role}</span> : null}
+                          {entry.roleEventId !== null ? <span>Event #{entry.roleEventId}</span> : null}
+                        </span>
+                      </span>
+                      <time dateTime={entry.recordedAt}>{displayTimestamp(entry.recordedAt)}</time>
+                    </button>
+                  );
+                })}
+              </div>
+              <div className="lag-journal-pagination" aria-label="Journal pages">
+                <button type="button" className="lag-journal-button" disabled={previousDisabled} onClick={() => journal.changePage(journal.params.page - 1)}>Previous</button>
+                <span>Page {page.totalPages === 0 ? 0 : page.page + 1} / {page.totalPages}</span>
+                <button type="button" className="lag-journal-button" disabled={nextDisabled} onClick={() => journal.changePage(journal.params.page + 1)}>Next</button>
+              </div>
+            </section>
           </div>
-          <div className="flex items-center justify-between gap-2 px-3">
-            <button type="button" style={secondaryButton} disabled={previousDisabled} onClick={() => journal.changePage(journal.params.page - 1)}>Previous</button>
-            <span className="text-xs" style={{ color: SAO.color.text.label }}>Page {page.totalPages === 0 ? 0 : page.page + 1} / {page.totalPages}</span>
-            <button type="button" style={secondaryButton} disabled={nextDisabled} onClick={() => journal.changePage(journal.params.page + 1)}>Next</button>
-          </div>
-          <p className="px-3 text-xs" style={{ color: SAO.color.text.label }}>{page.totalElements} total</p>
-        </div>
         </PanelFrame>
       </PanelStage>
 
       <AnimatePresence initial={false}>
-        {journal.selectedLifeLogId ? (
-          <PanelStage stageKey="lifelog-journal-detail" focusKey={journal.selectedLifeLogId} index={2}>
-            <PanelFrame title={detail ? `${detail.sourceType} Journal Detail` : "Journal Detail"} depth={0} contentKey={journal.selectedLifeLogId}>
-              {journal.detail.loading && !detail ? <InfoCard>Loading Journal detail...</InfoCard> : null}
-              {journal.detail.error && !detail ? <ErrorState text={journal.detail.error} retry={journal.detail.retry} /> : null}
-              {detail ? (
-                <div className="space-y-3 px-3">
-                  {journal.detail.error ? <p role="alert" className="text-xs" style={{ color: SAO.color.action.red }}>{journal.detail.error}</p> : null}
-                  <InfoCard>Journal entry #{detail.lifeLogId}</InfoCard>
-                  <GoldRow>Source type: {detail.sourceType}</GoldRow>
-                  <GoldRow>Recorded at: {detail.recordedAt}</GoldRow>
-                  {detail.subtype ? <GoldRow>Subtype: {detail.subtype}</GoldRow> : null}
-                  {detail.entryMode ? <GoldRow>Entry mode: {detail.entryMode}</GoldRow> : null}
-                  {detail.reflectionScope ? <GoldRow>Reflection scope: {detail.reflectionScope}</GoldRow> : null}
-                  {detail.periodKey ? <GoldRow>Period: {detail.periodKey}</GoldRow> : null}
-                  {detail.primaryRoleId !== null ? <GoldRow>{roleContext(detail.primaryRoleId, roles)}</GoldRow> : null}
-                  {detail.roleEventId !== null ? <GoldRow>Event context #{detail.roleEventId}</GoldRow> : null}
-                  <SourceDetail detail={detail} />
+        {quickRecordOpen ? (
+          <PanelStage stageKey="lifelog-quick-record">
+            <PanelFrame title="Quick Record" depth={0} backButton={<BackButton label="Back to Journal" onClick={closeQuickRecord} />}>
+              <div className="lag-quick-record-surface">
+                <div>
+                  <p className="lag-journal-eyebrow">Journal child surface</p>
+                  <h4>Record what matters now.</h4>
+                  <p>Choose a real record type, then add its current supported details.</p>
                 </div>
+                <QuickRecordForm
+                  roles={roles}
+                  rolesLoading={rolesLoading}
+                  rolesError={rolesError}
+                  pending={journal.quickRecord.pending}
+                  error={journal.quickRecord.error}
+                  result={journal.quickRecord.result}
+                  refreshError={journal.quickRecord.refreshError}
+                  canRetry={journal.quickRecord.canRetry}
+                  onSubmit={journal.quickRecord.submit}
+                  onRetry={journal.quickRecord.retry}
+                  onEdit={journal.quickRecord.invalidateRetry}
+                />
+              </div>
+            </PanelFrame>
+          </PanelStage>
+        ) : null}
+      </AnimatePresence>
+
+      <AnimatePresence initial={false}>
+        {!quickRecordOpen && journal.selectedLifeLogId ? (
+          <PanelStage stageKey="lifelog-journal-detail" focusKey={journal.selectedLifeLogId}>
+            <PanelFrame
+              title="Journal Detail"
+              depth={0}
+              contentKey={journal.selectedLifeLogId}
+              backButton={<BackButton label="Back to Journal" onClick={closeDetail} />}
+            >
+              {journal.detail.loading && !detail ? <InfoCard>Loading Journal detail...</InfoCard> : null}
+              {journal.detail.error && !detail ? <ErrorState message={journal.detail.error} retry={journal.detail.retry} /> : null}
+              {detail ? (
+                <article className="lag-journal-detail">
+                  {journal.detail.error ? <p role="alert" className="lag-journal-feedback" data-state="error">Refresh failed: {journal.detail.error}</p> : null}
+                  <div className="lag-journal-detail-hero">
+                    <span>{label(detail.sourceType)}</span>
+                    <strong>Journal entry #{detail.lifeLogId}</strong>
+                  </div>
+                  <DetailSection title="Record context">
+                    <DetailItem name="Source type" value={label(detail.sourceType)} />
+                    <DetailItem name="Recorded at" value={displayTimestamp(detail.recordedAt)} />
+                    {detail.subtype ? <DetailItem name="Subtype" value={label(detail.subtype)} /> : null}
+                    {detail.entryMode ? <DetailItem name="Entry mode" value={label(detail.entryMode)} /> : null}
+                    {detail.reflectionScope ? <DetailItem name="Reflection scope" value={label(detail.reflectionScope)} /> : null}
+                    {detail.periodKey ? <DetailItem name="Period" value={detail.periodKey} /> : null}
+                    {detail.primaryRoleId !== null ? <DetailItem name="Role context" value={roleName(detail.primaryRoleId, roles)} /> : null}
+                    {detail.roleEventId !== null ? <DetailItem name="RoleEvent context" value={`#${detail.roleEventId}`} /> : null}
+                  </DetailSection>
+                  <SourceDetail detail={detail} />
+                </article>
               ) : null}
             </PanelFrame>
           </PanelStage>

--- a/features/lifelog/useJournalQueries.ts
+++ b/features/lifelog/useJournalQueries.ts
@@ -195,6 +195,7 @@ export function useJournalQueries() {
     },
     selectedLifeLogId,
     selectEntry,
+    clearSelection,
     changeRoleFilter,
     changeSubtypeFilter,
     changePage,


### PR DESCRIPTION
## Purpose

Apply the approved Stage 3 Enterprise Dual Theme v7 visual direction to the real Journal / LifeLog and Quick Record surfaces.

Closes #54

## Delivered

- v7 Journal desktop fidelity for Astral and Warm Beige
- v7 Journal mobile fidelity for Astral and Warm Beige
- dedicated staged Quick Record surface
- v7 Quick Record desktop/mobile treatment
- semantic Journal filter and pagination controls
- structured record-card metadata hierarchy
- stable Journal detail panel with inner content replacement
- semantic source/subtype/Role cues
- preserved Quick Record Collection / Exercise / Media contracts
- preserved Quick Record retry/error/success behavior
- shared camera / Back integration
- accessible semantic controls and state treatment

## Source of Truth

Reference-only implementation authority:

```text
LifeAsGame_Stage3_UI_VisualDesigner_Enterprise_Dual_Theme_Result_v7
```

Primary visual references:

- DT7-02 Journal
- DT7-03 Quick Record
- MT7-02 Journal
- MT7-03 Quick Record
- AB7-D02 Journal
- AB7-M02 Journal
- shared v7 token / semantic-state handoff

Reference assets are not committed or shipped in the application.

## Data Authority

The v7 screenshots define visual hierarchy and material direction.

They do not create new product data.

This PR does not fabricate screenshot-only metrics or records.

The existing Journal / LifeLog and Quick Record API/domain contracts remain authoritative.

## Journal

The Journal archive uses the approved v7 material and content hierarchy while preserving real:

- Journal entries
- source type
- subtype
- entry mode
- Role context
- RoleEvent context
- recorded time
- source-specific detail
- Role/Subtype filters
- pagination

Journal Detail remains progressive:

```text
Journal
-> select entry
-> Journal Detail
```

Selecting a different entry preserves the detail frame and replaces only its content.

## Quick Record

Quick Record is now an explicit staged child surface instead of a generic always-available `<details>` disclosure.

```text
Journal
-> Quick Record
-> Back to Journal
```

Real supported mutation types remain:

```text
COLLECTION
EXERCISE
MEDIA
```

All existing type-specific fields, common subtype/Role metadata, retry behavior, and mutation states are preserved.

## Desktop / Mobile

Desktop retains useful parent context and the approved archive hierarchy.

Mobile follows the shared one-screen-one-purpose contract with forward/back spatial navigation and the existing bottom OrbNav.

## Theme Architecture

Both themes share one component tree.

Runtime selectors remain:

```text
astral
warm-beige
```

No Journal-specific theme fork or new palette authority is introduced.

## Accessibility / Motion

- visible focus
- semantic success/error states
- keyboard-operable type/filter controls
- accessible Back controls
- reduced-motion-safe staged transitions
- state meaning is not conveyed by color alone

## Scope Boundaries

This PR does not implement full fidelity for:

- Media
- Collection
- Exercise
- Journey
- Role
- Inventory / Gear
- Growth
- Connections / Direct Chat
- Notification
- Economy

It also does not change backend APIs or the stabilized global panel/camera/theme foundation.