### PR TITLE
[Journey] Apply approved v7 Journey and QuestRoute fidelity

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -152,7 +152,13 @@ body {
 .lag-journal-button,
 .lag-journal-chip,
 .lag-journal-toolbar,
-.lag-journal-detail-section {
+.lag-journal-detail-section,
+.lag-journey-card,
+.lag-journey-action,
+.lag-journey-button,
+.lag-journey-detail-section,
+.lag-route-thread,
+.lag-route-node {
   transition:
     background-color var(--lag-motion-normal) ease,
     border-color var(--lag-motion-normal) ease,
@@ -907,6 +913,437 @@ textarea.lag-journal-control {
   font-size: 0.78rem;
 }
 
+/* v7 Journey: domain-driven Quest and independent Route stages. */
+.lag-journey-shell [data-stage-key="journey-root"] .lag-panel-frame {
+  width: min(440px, calc(100vw - 32px)) !important;
+}
+
+.lag-journey-shell [data-stage-key="journey-list"] .lag-panel-frame {
+  width: min(560px, calc(100vw - 32px)) !important;
+}
+
+.lag-journey-shell [data-stage-key="journey-detail"] .lag-panel-frame {
+  width: min(700px, calc(100vw - 32px)) !important;
+}
+
+.lag-journey-root,
+.lag-journey-list-surface,
+.lag-journey-detail,
+.lag-journey-state {
+  display: grid;
+  gap: var(--lag-space-4);
+  padding-inline: var(--lag-space-4);
+}
+
+.lag-journey-root > header,
+.lag-journey-list-surface > header {
+  padding: var(--lag-space-4);
+  border: 1px solid var(--lag-divider);
+  border-left: 4px solid var(--lag-cyan);
+  border-radius: var(--lag-radius-md);
+  background: var(--lag-muted-surface);
+}
+
+.lag-journey-root > header h4,
+.lag-journey-list-surface > header h4 {
+  margin-top: var(--lag-space-2);
+  color: var(--lag-text);
+  font-size: 1.15rem;
+  font-weight: 700;
+}
+
+.lag-journey-root > header p:last-child,
+.lag-journey-list-surface > header p:last-child {
+  margin-top: var(--lag-space-2);
+  color: var(--lag-text-2);
+  font-size: 0.8rem;
+}
+
+.lag-journey-eyebrow,
+.lag-journey-detail-row dt {
+  color: var(--lag-text-2);
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.lag-journey-root-grid,
+.lag-journey-list {
+  display: grid;
+  gap: var(--lag-space-3);
+}
+
+.lag-journey-card {
+  display: grid;
+  grid-template-columns: 56px minmax(0, 1fr) auto;
+  min-height: 112px;
+  align-items: center;
+  gap: var(--lag-space-3);
+  padding: var(--lag-space-4);
+  border: 1px solid var(--lag-divider);
+  border-radius: var(--lag-radius-md);
+  background: var(--lag-muted-surface);
+  color: var(--lag-text);
+  text-align: left;
+}
+
+.lag-journey-card:hover {
+  border-color: var(--lag-focus);
+  background: var(--lag-control-hover-bg);
+}
+
+.lag-journey-card[data-selected="true"] {
+  border-color: var(--lag-state-selected);
+  box-shadow: inset 4px 0 0 var(--lag-state-selected);
+}
+
+.lag-journey-card-mark {
+  display: grid;
+  width: 52px;
+  height: 52px;
+  place-items: center;
+  border: 1px solid var(--lag-focus);
+  border-radius: 50%;
+  background: var(--lag-paper);
+  color: var(--lag-text-2);
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+}
+
+.lag-journey-card-copy {
+  display: grid;
+  min-width: 0;
+  gap: var(--lag-space-2);
+}
+
+.lag-journey-card-copy > strong {
+  overflow-wrap: anywhere;
+  font-size: 0.94rem;
+}
+
+.lag-journey-card-copy > span:not(.lag-journey-badges) {
+  overflow-wrap: anywhere;
+  color: var(--lag-text-2);
+  font-size: 0.76rem;
+}
+
+.lag-journey-card-arrow {
+  color: var(--lag-text-2);
+  font-size: 1rem;
+}
+
+.lag-journey-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--lag-space-2);
+}
+
+.lag-journey-badges > span,
+.lag-journey-status {
+  width: fit-content;
+  padding: var(--lag-space-1) var(--lag-space-2);
+  border: 1px solid var(--lag-control-border);
+  border-radius: 999px;
+  background: var(--lag-control-bg);
+  color: var(--lag-text-2);
+  font-size: 0.65rem;
+  font-weight: 700;
+}
+
+.lag-journey-progress {
+  display: grid;
+  gap: var(--lag-space-2);
+}
+
+.lag-journey-progress > div:first-child {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--lag-space-3);
+  color: var(--lag-text-2);
+  font-size: 0.68rem;
+}
+
+.lag-journey-progress > div:first-child strong {
+  color: var(--lag-text);
+}
+
+.lag-journey-progress [role="progressbar"] {
+  height: 8px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--lag-shadow) 34%, var(--lag-control-bg));
+}
+
+.lag-journey-progress [role="progressbar"] > span {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--lag-cyan);
+}
+
+.lag-journey-detail-hero {
+  display: grid;
+  gap: var(--lag-space-3);
+  padding: var(--lag-space-4);
+  border: 1px solid var(--lag-border);
+  border-left: 4px solid var(--lag-violet);
+  border-radius: var(--lag-radius-md);
+  background: var(--lag-muted-surface);
+}
+
+.lag-journey-detail-hero > span:first-child {
+  color: var(--lag-text-2);
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.lag-journey-detail-hero h4 {
+  color: var(--lag-text);
+  font-size: 1.16rem;
+  font-weight: 700;
+}
+
+.lag-journey-detail-hero p {
+  color: var(--lag-text-2);
+  font-size: 0.8rem;
+  line-height: 1.55;
+}
+
+.lag-journey-status[data-state="COMPLETED"],
+.lag-journey-status[data-state="READY_TO_ADVANCE"] {
+  border-color: var(--lag-state-success);
+  box-shadow: inset 3px 0 0 var(--lag-state-success);
+}
+
+.lag-journey-status[data-state="GOAL_REACHED"] {
+  border-color: var(--lag-state-warning);
+  box-shadow: inset 3px 0 0 var(--lag-state-warning);
+}
+
+.lag-journey-status[data-state="CURRENT"],
+.lag-journey-status[data-state="IN_PROGRESS"] {
+  border-color: var(--lag-state-info);
+  box-shadow: inset 3px 0 0 var(--lag-state-info);
+}
+
+.lag-journey-status[data-state="CANCELED"],
+.lag-journey-status[data-state="LOCKED"],
+.lag-journey-status[data-state="NOT_SELECTED"] {
+  border-color: var(--lag-state-read-only);
+  box-shadow: inset 3px 0 0 var(--lag-state-read-only);
+}
+
+.lag-journey-detail-section {
+  overflow: hidden;
+  border: 1px solid var(--lag-divider);
+  border-radius: var(--lag-radius-md);
+  background: var(--lag-panel);
+}
+
+.lag-journey-detail-section h4 {
+  padding: var(--lag-space-3) var(--lag-space-4);
+  border-bottom: 1px solid var(--lag-divider);
+  background: var(--lag-panel-2);
+  color: var(--lag-text);
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.lag-journey-detail-row {
+  display: grid;
+  grid-template-columns: minmax(120px, 0.8fr) minmax(0, 1.2fr);
+  gap: var(--lag-space-3);
+  padding: var(--lag-space-3) var(--lag-space-4);
+  border-bottom: 1px solid var(--lag-divider);
+}
+
+.lag-journey-detail-row:last-child {
+  border-bottom: 0;
+}
+
+.lag-journey-detail-row dd {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  color: var(--lag-text);
+  font-size: 0.78rem;
+}
+
+.lag-journey-detail-progress {
+  padding: var(--lag-space-4);
+}
+
+.lag-journey-feedback {
+  padding: var(--lag-space-3);
+  border: 1px solid var(--lag-state-info);
+  border-radius: var(--lag-radius-sm);
+  background: var(--lag-muted-surface);
+  color: var(--lag-text);
+  font-size: 0.76rem;
+}
+
+.lag-journey-feedback[data-state="error"] {
+  border-color: var(--lag-state-error);
+  box-shadow: inset 4px 0 0 var(--lag-state-error);
+}
+
+.lag-journey-feedback[data-state="warning"] {
+  border-color: var(--lag-state-warning);
+  box-shadow: inset 4px 0 0 var(--lag-state-warning);
+}
+
+.lag-journey-feedback[data-state="success"] {
+  border-color: var(--lag-state-success);
+  box-shadow: inset 4px 0 0 var(--lag-state-success);
+}
+
+.lag-journey-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--lag-space-3);
+}
+
+.lag-journey-action,
+.lag-journey-button {
+  min-height: 44px;
+  padding: var(--lag-space-2) var(--lag-space-4);
+  border: 1px solid var(--lag-control-border);
+  border-radius: var(--lag-radius-sm);
+  background: var(--lag-control-bg);
+  color: var(--lag-control-text);
+  font-size: 0.76rem;
+  font-weight: 700;
+}
+
+.lag-journey-action {
+  border-color: var(--lag-violet);
+  background: color-mix(in srgb, var(--lag-violet) 12%, var(--lag-control-bg));
+}
+
+.lag-journey-button[data-variant="destructive"] {
+  border-color: var(--lag-state-error);
+}
+
+.lag-journey-action:not(:disabled):hover,
+.lag-journey-button:not(:disabled):hover {
+  border-color: var(--lag-focus);
+  background: var(--lag-control-hover-bg);
+}
+
+.lag-route-thread {
+  overflow: hidden;
+  padding: var(--lag-space-4);
+  border: 1px solid var(--lag-border);
+  border-radius: var(--lag-radius-md);
+  background: var(--lag-panel);
+}
+
+.lag-route-thread-track {
+  overflow-x: auto;
+  padding-bottom: var(--lag-space-2);
+}
+
+.lag-route-thread ol {
+  display: flex;
+  min-width: max-content;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.lag-route-thread ol > li {
+  position: relative;
+  display: grid;
+  width: 230px;
+  justify-items: center;
+  gap: var(--lag-space-3);
+  padding-inline: var(--lag-space-2);
+}
+
+.lag-route-thread ol > li:not(:last-child)::after {
+  position: absolute;
+  top: 17px;
+  left: calc(50% + 18px);
+  width: calc(100% - 36px);
+  height: 2px;
+  background: var(--lag-divider);
+  content: "";
+}
+
+.lag-route-thread ol > li[data-state="COMPLETED"]:not(:last-child)::after {
+  background: var(--lag-cyan);
+}
+
+.lag-route-node {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  width: 36px;
+  height: 36px;
+  place-items: center;
+  border: 2px solid var(--lag-divider);
+  border-radius: 50%;
+  background: var(--lag-paper);
+  color: var(--lag-text-2);
+  font-size: 0.7rem;
+  font-weight: 700;
+}
+
+.lag-route-thread li[data-state="COMPLETED"] .lag-route-node {
+  border-color: var(--lag-state-success);
+}
+
+.lag-route-thread li[data-current="true"] .lag-route-node {
+  border-color: var(--lag-focus);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--lag-focus) 18%, transparent);
+}
+
+.lag-route-thread article {
+  display: grid;
+  width: 100%;
+  min-height: 190px;
+  align-content: start;
+  gap: var(--lag-space-3);
+  padding: var(--lag-space-3);
+  border: 1px solid var(--lag-divider);
+  border-radius: var(--lag-radius-sm);
+  background: var(--lag-muted-surface);
+}
+
+.lag-route-thread li[data-current="true"] article {
+  border-color: var(--lag-focus);
+  box-shadow: inset 4px 0 0 var(--lag-focus);
+}
+
+.lag-route-thread article > div {
+  display: grid;
+  gap: var(--lag-space-2);
+}
+
+.lag-route-thread article strong {
+  color: var(--lag-text);
+  font-size: 0.78rem;
+}
+
+.lag-route-thread article p,
+.lag-route-thread article li {
+  color: var(--lag-text-2);
+  font-size: 0.7rem;
+  line-height: 1.45;
+}
+
+.lag-route-thread article ul {
+  display: grid;
+  gap: var(--lag-space-1);
+  margin: 0;
+  padding-left: var(--lag-space-4);
+}
+
 .lag-state-error {
   padding-left: var(--lag-space-2);
   color: var(--lag-text);
@@ -1075,6 +1512,44 @@ textarea.lag-journal-control {
     grid-template-columns: 1fr auto 1fr;
   }
 
+  .lag-journey-shell [data-stage-key="journey-root"] .lag-panel-frame,
+  .lag-journey-shell [data-stage-key="journey-list"] .lag-panel-frame,
+  .lag-journey-shell [data-stage-key="journey-detail"] .lag-panel-frame {
+    width: clamp(280px, calc(100vw - 32px), 344px) !important;
+  }
+
+  .lag-journey-root,
+  .lag-journey-list-surface,
+  .lag-journey-detail,
+  .lag-journey-state {
+    padding-inline: var(--lag-space-3);
+  }
+
+  .lag-journey-card {
+    grid-template-columns: 46px minmax(0, 1fr) auto;
+    min-height: 120px;
+    padding: var(--lag-space-3);
+  }
+
+  .lag-journey-card-mark {
+    width: 44px;
+    height: 44px;
+  }
+
+  .lag-journey-detail-row {
+    grid-template-columns: minmax(92px, 0.8fr) minmax(0, 1.2fr);
+  }
+
+  .lag-route-thread ol > li {
+    width: 210px;
+  }
+
+  .lag-journey-actions,
+  .lag-journey-action,
+  .lag-journey-button {
+    width: 100%;
+  }
+
   .lag-left-anchor {
     --lag-left-lane-width: clamp(280px, calc(100vw - 32px), 344px);
     position: static;
@@ -1158,6 +1633,15 @@ textarea.lag-journal-control {
   .lag-journal-chip,
   .lag-journal-toolbar,
   .lag-journal-detail-section {
+    transition-duration: 0s;
+  }
+
+  .lag-journey-card,
+  .lag-journey-action,
+  .lag-journey-button,
+  .lag-journey-detail-section,
+  .lag-route-thread,
+  .lag-route-node {
     transition-duration: 0s;
   }
 

--- a/features/quests/JourneyShell.test.tsx
+++ b/features/quests/JourneyShell.test.tsx
@@ -1,4 +1,5 @@
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { readFileSync } from "node:fs";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { PlayerQuestDetail, QuestAcceptance, QuestRoute, QuestRouteStepDetail } from "@/shared/api/types";
@@ -87,6 +88,10 @@ function deferred<T>() {
   return { promise, reject, resolve };
 }
 
+function renderCurrentJourney() {
+  return render(<JourneyShell initialSurface="current" />);
+}
+
 describe("Journey에서 Quest와 QuestRoute를 볼 때", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -118,7 +123,7 @@ describe("Journey에서 Quest와 QuestRoute를 볼 때", () => {
 
   describe("Journey main navigation으로 직접 진입하면", () => {
     it("root stage만 열고 subsection과 detail은 선택 전까지 만들지 않는다", async () => {
-      render(<JourneyShell initialSurface={null} />);
+      render(<JourneyShell />);
 
       expect(screen.getByRole("button", { name: /Current/ })).toBeInTheDocument();
       expect(document.querySelector('[data-stage-key="journey-root"]')).toBeInTheDocument();
@@ -130,11 +135,58 @@ describe("Journey에서 Quest와 QuestRoute를 볼 때", () => {
       expect(document.querySelector('[data-stage-key="journey-list"]')).toBeInTheDocument();
       expect(document.querySelector('[data-stage-key="journey-detail"]')).not.toBeInTheDocument();
     });
+
+    it("detail/list Back과 surface reset을 staged disclosure로 유지한다", async () => {
+      render(<JourneyShell initialSurface={null} />);
+
+      fireEvent.click(screen.getByRole("button", { name: /Current/ }));
+      fireEvent.click(await screen.findByRole("button", { name: /흔적 세 개 이어보기/ }));
+      await screen.findByText(/Quest progress/);
+      expect(document.querySelector('[data-stage-key="journey-detail"]')).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole("button", { name: "Back to Current" }));
+      await waitFor(() => expect(document.querySelector('[data-stage-key="journey-detail"]')).not.toBeInTheDocument());
+      expect(document.querySelector('[data-stage-key="journey-list"]')).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole("button", { name: /흔적 세 개 이어보기/ }));
+      await screen.findByText(/Quest progress/);
+      fireEvent.click(screen.getByRole("button", { name: /Catalog/ }));
+      await waitFor(() => expect(document.querySelector('[data-stage-key="journey-detail"]')).not.toBeInTheDocument());
+      fireEvent.click(screen.getByRole("button", { name: /Current/ }));
+      expect(document.querySelector('[data-stage-key="journey-detail"]')).not.toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole("button", { name: "Back to Journey" }));
+      await waitFor(() => expect(document.querySelector('[data-stage-key="journey-list"]')).not.toBeInTheDocument());
+      expect(document.querySelector('[data-stage-key="journey-root"]')).toBeInTheDocument();
+    });
+
+    it("같은 list의 selection 변경 시 detail stage DOM을 유지한다", async () => {
+      renderCurrentJourney();
+
+      fireEvent.click(await screen.findByRole("button", { name: /흔적 세 개 이어보기/ }));
+      await screen.findByText(/Quest progress/);
+      const detailStage = document.querySelector('[data-stage-key="journey-detail"]');
+      fireEvent.click(screen.getByRole("button", { name: /한 가지에 25분 집중하기/ }));
+      await screen.findByText("Goal reached. This is not the same as Completed.");
+
+      expect(document.querySelector('[data-stage-key="journey-detail"]')).toBe(detailStage);
+    });
+  });
+
+  it("uses semantic Journey styling without screenshot-only domain data", () => {
+    const source = readFileSync("features/quests/JourneyShell.tsx", "utf8");
+    expect(source).toContain("lag-route-thread");
+    expect(source).not.toMatch(/Backend Developer Route|Spring Core|\bXP\b|fake milestone/i);
+
+    const css = readFileSync("app/globals.css", "utf8");
+    const journeyCss = css.slice(css.indexOf("/* v7 Journey"), css.indexOf(".lag-state-error"));
+    expect(journeyCss).toContain("var(--lag-muted-surface)");
+    expect(journeyCss).not.toMatch(/#[0-9a-f]{3,8}|rgba?\(/i);
   });
 
   describe("Current Quest의 상태와 next action을 확인하면", () => {
     it("IN_PROGRESS/GOAL_REACHED/COMPLETED/CANCELED를 구분하고 Party/Guild surface나 reward claim을 노출하지 않는다", async () => {
-      render(<JourneyShell />);
+      renderCurrentJourney();
 
       expect(await screen.findByText(/In Progress · 1\/3/)).toBeInTheDocument();
       expect(screen.getByText(/Goal Reached · 25\/25/)).toBeInTheDocument();
@@ -151,7 +203,7 @@ describe("Journey에서 Quest와 QuestRoute를 볼 때", () => {
         : quest);
       api.listPlayerQuestsApi.mockResolvedValueOnce(current).mockResolvedValue(completed);
       api.getPlayerQuestApi.mockImplementation(async (code: string) => detail(code, completed.find((item) => item.code === code) ?? null));
-      render(<JourneyShell />);
+      renderCurrentJourney();
 
       fireEvent.click(await screen.findByRole("button", { name: /한 가지에 25분 집중하기/ }));
       expect(await screen.findByText("Goal reached. This is not the same as Completed.")).toBeInTheDocument();
@@ -166,7 +218,7 @@ describe("Journey에서 Quest와 QuestRoute를 볼 때", () => {
     it("valid cancel 후 authoritative list를 reload해 CANCELED history로 표시한다", async () => {
       const canceled = current.map((quest) => quest.code === "Q_RECORD_THREE_TRACES" ? { ...quest, status: "CANCELED" as const } : quest);
       api.listPlayerQuestsApi.mockResolvedValueOnce(current).mockResolvedValue(canceled);
-      render(<JourneyShell />);
+      renderCurrentJourney();
 
       fireEvent.click(await screen.findByRole("button", { name: /흔적 세 개 이어보기/ }));
       fireEvent.click(await screen.findByRole("button", { name: "Cancel Quest" }));
@@ -182,7 +234,7 @@ describe("Journey에서 Quest와 QuestRoute를 볼 때", () => {
       const stale = deferred<PlayerQuestDetail>();
       const latest = deferred<PlayerQuestDetail>();
       api.getPlayerQuestApi.mockImplementation((code: string) => code === "Q_RECORD_THREE_TRACES" ? stale.promise : latest.promise);
-      render(<JourneyShell />);
+      renderCurrentJourney();
 
       fireEvent.click(await screen.findByRole("button", { name: /흔적 세 개 이어보기/ }));
       fireEvent.click(screen.getByRole("button", { name: /한 가지에 25분 집중하기/ }));
@@ -204,7 +256,7 @@ describe("Journey에서 Quest와 QuestRoute를 볼 때", () => {
       const stale = deferred<PlayerQuestDetail>();
       const latest = deferred<PlayerQuestDetail>();
       api.getPlayerQuestApi.mockImplementation((code: string) => code === "Q_RECORD_THREE_TRACES" ? stale.promise : latest.promise);
-      render(<JourneyShell />);
+      renderCurrentJourney();
 
       fireEvent.click(await screen.findByRole("button", { name: /흔적 세 개 이어보기/ }));
       fireEvent.click(screen.getByRole("button", { name: /한 가지에 25분 집중하기/ }));
@@ -242,7 +294,7 @@ describe("Journey에서 Quest와 QuestRoute를 볼 때", () => {
       };
       api.listPlayerQuestsApi.mockResolvedValueOnce(current).mockResolvedValue([...current, acceptedRest]);
       api.acceptQuestApi.mockRejectedValue(new Error("connection lost"));
-      render(<JourneyShell />);
+      renderCurrentJourney();
 
       fireEvent.click(screen.getByRole("button", { name: /Catalog/ }));
       fireEvent.click(await screen.findByRole("button", { name: /흔적 세 개 이어보기/ }));
@@ -279,18 +331,18 @@ describe("Journey에서 Quest와 QuestRoute를 볼 때", () => {
         .mockResolvedValueOnce(detail(completed.code, completed))
         .mockResolvedValue(detail(completed.code, nextAcceptance));
       api.acceptQuestApi.mockResolvedValue(completed);
-      render(<JourneyShell />);
+      renderCurrentJourney();
 
       fireEvent.click(screen.getByRole("button", { name: /Catalog/ }));
       fireEvent.click(await screen.findByRole("button", { name: /한 가지에 25분 집중하기/ }));
-      expect(await screen.findByText("Acceptance: Completed")).toBeInTheDocument();
+      expect((await screen.findAllByText("Acceptance: Completed")).length).toBeGreaterThan(0);
       fireEvent.click(screen.getByRole("button", { name: "Accept Again" }));
 
       await waitFor(() => expect(api.acceptQuestApi).toHaveBeenCalledWith("Q_GROWTH_ONE_FOCUS"));
       expect(api.acceptQuestApi).toHaveBeenCalledTimes(1);
       expect(api.listPlayerQuestsApi).toHaveBeenCalledTimes(2);
       expect(api.listQuestCatalogApi).toHaveBeenCalledTimes(2);
-      expect(await screen.findByText("Acceptance: In Progress")).toBeInTheDocument();
+      expect((await screen.findAllByText("Acceptance: In Progress")).length).toBeGreaterThan(0);
       expect(screen.queryByRole("button", { name: "Accept Again" })).not.toBeInTheDocument();
       expect(api.advanceQuestRouteApi).not.toHaveBeenCalled();
     });
@@ -301,7 +353,7 @@ describe("Journey에서 Quest와 QuestRoute를 볼 때", () => {
       api.listPlayerQuestsApi.mockResolvedValue(before);
       api.getPlayerQuestApi.mockResolvedValue(detail(completed.code, completed));
       api.acceptQuestApi.mockRejectedValue(new Error("Quest acceptance already exists"));
-      render(<JourneyShell />);
+      renderCurrentJourney();
 
       fireEvent.click(screen.getByRole("button", { name: /Catalog/ }));
       fireEvent.click(await screen.findByRole("button", { name: /한 가지에 25분 집중하기/ }));
@@ -311,17 +363,49 @@ describe("Journey에서 Quest와 QuestRoute를 볼 때", () => {
       expect(api.listPlayerQuestsApi).toHaveBeenCalledTimes(2);
       expect(api.listQuestCatalogApi).toHaveBeenCalledTimes(2);
       expect(await screen.findByText(/Request outcome was not confirmed/)).toBeInTheDocument();
-      expect(screen.getByText("Acceptance: Completed")).toBeInTheDocument();
+      expect(screen.getAllByText("Acceptance: Completed").length).toBeGreaterThan(0);
       expect(screen.getByRole("button", { name: "Accept Again" })).toBeInTheDocument();
       expect(api.advanceQuestRouteApi).not.toHaveBeenCalled();
     });
   });
 
   describe("QuestRoute를 명시적으로 선택하고 진행하면", () => {
+    it("multiple progress와 실제 stepOrder/currentStepId/criteria/questLinks를 표시한다", async () => {
+      const first = routeVariant(41, "First Direction", "Current First Step");
+      const second = routeVariant(42, "Second Direction", "Current Second Step");
+      first.steps = first.steps.slice().reverse();
+      first.playerProgress = { ...first.playerProgress!, currentStepId: 12 };
+      first.steps = first.steps.map((step) => ({
+        ...step,
+        criteriaSatisfied: step.id === 11,
+        state: step.id === 11 ? "COMPLETED" : step.id === 12 ? "CURRENT" : "LOCKED",
+      }));
+      api.listQuestRoutesApi.mockResolvedValue([]);
+      api.listMyQuestRoutesApi.mockResolvedValue([first, second]);
+      api.getMyQuestRouteApi.mockResolvedValue(first);
+      api.getMyQuestRouteStepApi.mockResolvedValue(routeStep(first));
+      render(<JourneyShell initialSurface="routes" />);
+
+      expect(await screen.findByRole("button", { name: /First Direction/ })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /Second Direction/ })).toBeInTheDocument();
+      fireEvent.click(screen.getByRole("button", { name: /First Direction/ }));
+
+      const thread = await screen.findByRole("region", { name: "Ordered Route Steps" });
+      const steps = Array.from(thread.querySelectorAll(":scope > .lag-route-thread-track > ol > li"));
+      expect(steps.map((step) => step.querySelector("strong")?.textContent)).toEqual([
+        "1. Current First Step",
+        "2. 흔적 연결하기",
+        "3. 돌아보기",
+      ]);
+      expect(steps[1]).toHaveAttribute("data-current", "true");
+      expect(within(thread).getByText("Criteria: Satisfied")).toBeInTheDocument();
+      expect(within(thread).getByText(/Requirement: 첫 흔적 남기기/)).toBeInTheDocument();
+    });
+
     it("catalog에 없는 My Route도 보존하고 My Route detail과 step을 표시한다", async () => {
       api.listQuestRoutesApi.mockResolvedValue([]);
       api.listMyQuestRoutesApi.mockResolvedValue([selectedRoute]);
-      render(<JourneyShell />);
+      renderCurrentJourney();
 
       fireEvent.click(screen.getByRole("button", { name: /Routes/ }));
       fireEvent.click(await screen.findByRole("button", { name: /기록으로 시작하기/ }));
@@ -343,12 +427,14 @@ describe("Journey에서 Quest와 QuestRoute를 볼 때", () => {
         .mockResolvedValueOnce([advancedRoute]);
       api.getMyQuestRouteApi.mockResolvedValueOnce(selectedRoute).mockResolvedValueOnce(advancedRoute);
       api.getMyQuestRouteStepApi.mockResolvedValueOnce(readyStepDetail).mockResolvedValueOnce(advancedStepDetail);
-      render(<JourneyShell />);
+      renderCurrentJourney();
 
       fireEvent.click(screen.getByRole("button", { name: /Routes/ }));
       fireEvent.click(await screen.findByRole("button", { name: /기록으로 시작하기/ }));
       expect(await screen.findByText("Status: NOT_SELECTED")).toBeInTheDocument();
-      expect(screen.getAllByText(/LOCKED · criteria/)).toHaveLength(3);
+      expect(screen.getAllByText("LOCKED")).toHaveLength(3);
+      expect(screen.getAllByText("Criteria: Not satisfied")).toHaveLength(2);
+      expect(screen.getByText("Criteria: Satisfied")).toBeInTheDocument();
       fireEvent.click(screen.getByRole("button", { name: "Select Route" }));
 
       expect(window.confirm).toHaveBeenCalledWith("Select Route 기록으로 시작하기?");
@@ -357,7 +443,7 @@ describe("Journey에서 Quest와 QuestRoute를 볼 때", () => {
 
       await waitFor(() => expect(api.advanceQuestRouteApi).toHaveBeenCalledWith(1, 11));
       expect(api.advanceQuestRouteApi).toHaveBeenCalledTimes(1);
-      expect(await screen.findByText("Current Step ID: 12")).toBeInTheDocument();
+      expect(await screen.findByText(/ID 12/)).toBeInTheDocument();
       expect(screen.getByText("Current Step Detail: 흔적 연결하기 · CURRENT")).toBeInTheDocument();
       expect(screen.queryByRole("button", { name: "Advance Current Step" })).not.toBeInTheDocument();
     });
@@ -371,7 +457,7 @@ describe("Journey에서 Quest와 QuestRoute를 볼 때", () => {
       api.listMyQuestRoutesApi.mockResolvedValue([staleRoute, latestRoute]);
       api.getMyQuestRouteApi.mockImplementation((routeId: number) => routeId === staleRoute.id ? stale.promise : latest.promise);
       api.getMyQuestRouteStepApi.mockImplementation(async (routeId: number) => routeStep(routeId === staleRoute.id ? staleRoute : latestRoute));
-      render(<JourneyShell />);
+      renderCurrentJourney();
 
       fireEvent.click(screen.getByRole("button", { name: /Routes/ }));
       fireEvent.click(await screen.findByRole("button", { name: /Stale Route/ }));
@@ -401,7 +487,7 @@ describe("Journey에서 Quest와 QuestRoute를 볼 때", () => {
       api.listMyQuestRoutesApi.mockResolvedValue([staleRoute, latestRoute]);
       api.getMyQuestRouteApi.mockImplementation((routeId: number) => routeId === staleRoute.id ? Promise.resolve(staleRoute) : latest.promise);
       api.getMyQuestRouteStepApi.mockImplementation((routeId: number) => routeId === staleRoute.id ? staleStep.promise : Promise.resolve(routeStep(latestRoute)));
-      render(<JourneyShell />);
+      renderCurrentJourney();
 
       fireEvent.click(screen.getByRole("button", { name: /Routes/ }));
       fireEvent.click(await screen.findByRole("button", { name: /Route With Stale Step/ }));
@@ -427,7 +513,7 @@ describe("Journey에서 Quest와 QuestRoute를 볼 때", () => {
       api.getMyQuestRouteApi.mockResolvedValue(selectedRoute);
       api.getMyQuestRouteStepApi.mockResolvedValue(readyStepDetail);
       api.advanceQuestRouteApi.mockRejectedValue(new Error("stale step"));
-      render(<JourneyShell />);
+      renderCurrentJourney();
 
       fireEvent.click(screen.getByRole("button", { name: /Routes/ }));
       fireEvent.click(await screen.findByRole("button", { name: /기록으로 시작하기/ }));
@@ -436,7 +522,7 @@ describe("Journey에서 Quest와 QuestRoute를 볼 때", () => {
       await waitFor(() => expect(api.advanceQuestRouteApi).toHaveBeenCalledTimes(1));
       await waitFor(() => expect(api.getMyQuestRouteApi).toHaveBeenCalledTimes(2));
       expect(await screen.findByText(/Request outcome was not confirmed/)).toBeInTheDocument();
-      expect(screen.getByText("Current Step ID: 11")).toBeInTheDocument();
+      expect(screen.getByText(/ID 11/)).toBeInTheDocument();
     });
 
     it("completed Route에는 select/advance를 다시 노출하지 않는다", async () => {
@@ -444,12 +530,12 @@ describe("Journey에서 Quest와 QuestRoute를 볼 때", () => {
       api.listMyQuestRoutesApi.mockResolvedValue([completedRoute]);
       api.getMyQuestRouteApi.mockResolvedValue(completedRoute);
       api.getMyQuestRouteStepApi.mockResolvedValue(routeStep(completedRoute));
-      render(<JourneyShell />);
+      renderCurrentJourney();
 
       fireEvent.click(screen.getByRole("button", { name: /Routes/ }));
       fireEvent.click(await screen.findByRole("button", { name: /기록으로 시작하기/ }));
 
-      expect(await screen.findByText("Route completed by an explicit final Step advance.")).toBeInTheDocument();
+      expect(await screen.findByText(/Route completed by an explicit final Step advance/)).toBeInTheDocument();
       expect(screen.queryByRole("button", { name: "Select Route" })).not.toBeInTheDocument();
       expect(screen.queryByRole("button", { name: "Advance Current Step" })).not.toBeInTheDocument();
     });
@@ -460,7 +546,7 @@ describe("Journey에서 Quest와 QuestRoute를 볼 때", () => {
       api.listPlayerQuestsApi.mockResolvedValue([]);
       api.listQuestCatalogApi.mockResolvedValue([]);
       api.listQuestRoutesApi.mockResolvedValue([]);
-      render(<JourneyShell />);
+      renderCurrentJourney();
 
       expect(await screen.findByText("No Quest acceptances yet.")).toBeInTheDocument();
       fireEvent.click(screen.getByRole("button", { name: /Catalog/ }));
@@ -471,20 +557,20 @@ describe("Journey에서 Quest와 QuestRoute를 볼 때", () => {
 
     it("Quest failure와 무관하게 Route를 사용할 수 있다", async () => {
       api.listPlayerQuestsApi.mockRejectedValue(new Error("Quest unavailable"));
-      render(<JourneyShell />);
+      renderCurrentJourney();
 
-      expect(await screen.findByText("Quest unavailable")).toBeInTheDocument();
+      expect(await screen.findByText(/Quest unavailable/)).toBeInTheDocument();
       fireEvent.click(screen.getByRole("button", { name: /Routes/ }));
       expect(await screen.findByRole("button", { name: /기록으로 시작하기/ })).toBeInTheDocument();
     });
 
     it("Route failure는 Current를 막지 않고 자체 Retry로 복구한다", async () => {
       api.listQuestRoutesApi.mockRejectedValueOnce(new Error("Route unavailable")).mockResolvedValue([unselectedRoute]);
-      render(<JourneyShell />);
+      renderCurrentJourney();
 
       expect(await screen.findByText(/In Progress · 1\/3/)).toBeInTheDocument();
       fireEvent.click(screen.getByRole("button", { name: /Routes/ }));
-      expect(await screen.findByText("Route unavailable")).toBeInTheDocument();
+      expect(await screen.findByText(/Route unavailable/)).toBeInTheDocument();
       fireEvent.click(screen.getByRole("button", { name: "Retry" }));
       expect(await screen.findByRole("button", { name: /기록으로 시작하기/ })).toBeInTheDocument();
     });

--- a/features/quests/JourneyShell.tsx
+++ b/features/quests/JourneyShell.tsx
@@ -5,12 +5,16 @@ import { AnimatePresence } from "framer-motion";
 
 import { SUBMENUS_BY_MAIN } from "@/entities/nav";
 import type { QuestsSubId } from "@/entities/nav";
-import type { PlayerQuestDetail, QuestRoute, QuestRouteStepDetail } from "@/shared/api/types";
-import PanelCard from "@/shared/ui/PanelCard";
+import type {
+  PlayerQuestDetail,
+  QuestAcceptance,
+  QuestRoute,
+  QuestRouteStepDetail,
+} from "@/shared/api/types";
+import { requestStageFocus } from "@/shared/hooks/useStageCamera";
 import PanelStage from "@/shared/ui/PanelStage";
-import { PanelFrame } from "@/widgets/right-panels/ui/PanelFrame";
-import { GoldRow, InfoCard } from "@/widgets/right-panels/ui/Rows";
-import { actionBtnStyle } from "@/widgets/right-panels/ui/styles";
+import { BackButton, PanelFrame } from "@/widgets/right-panels/ui/PanelFrame";
+import { InfoCard } from "@/widgets/right-panels/ui/Rows";
 import {
   acceptQuestApi,
   advanceQuestRouteApi,
@@ -32,26 +36,128 @@ import {
 } from "./model";
 import { useJourneyQueries } from "./useJourneyQueries";
 
-const secondaryButton = {
-  border: "1px solid var(--lag-control-border)",
-  background: "var(--lag-control-bg)",
-  color: "var(--lag-control-text)",
-  borderRadius: "var(--lag-radius-sm)",
-  padding: "7px 10px",
-  fontSize: "0.68rem",
-  letterSpacing: "0.08em",
-} as const;
+const SURFACE_COPY: Record<QuestsSubId, string> = {
+  current: "Review accepted Quests and their canonical progress.",
+  catalog: "Explore available Quest blueprints and acceptance rules.",
+  routes: "Choose and advance independent long-term directions.",
+};
 
 function message(caught: unknown, fallback: string): string {
   return caught instanceof Error ? caught.message : fallback;
 }
 
+function humanize(value: string) {
+  return value.replaceAll("_", " ");
+}
+
 function ErrorState({ text, retry }: { text: string; retry: () => void }) {
   return (
-    <div className="space-y-2 px-3">
-      <p role="alert" className="text-xs" style={{ color: "var(--lag-state-error)" }}>{text}</p>
-      <button type="button" style={secondaryButton} onClick={retry}>Retry</button>
+    <div className="lag-journey-state">
+      <p role="alert" className="lag-journey-feedback" data-state="error">Load failed: {text}</p>
+      <button type="button" className="lag-journey-button" onClick={retry}>Retry</button>
     </div>
+  );
+}
+
+function ProgressBar({ label, percent, valueText }: { label: string; percent: number; valueText: string }) {
+  return (
+    <div className="lag-journey-progress">
+      <div><span>{label}</span><strong>{valueText}</strong></div>
+      <div role="progressbar" aria-label={label} aria-valuemin={0} aria-valuemax={100} aria-valuenow={percent} aria-valuetext={valueText}>
+        <span style={{ width: `${percent}%` }} />
+      </div>
+    </div>
+  );
+}
+
+function JourneyCard({
+  badge,
+  badges = [],
+  progress,
+  selected,
+  supporting,
+  title,
+  onClick,
+}: {
+  badge: string;
+  badges?: string[];
+  progress?: { percent: number; valueText: string };
+  selected: boolean;
+  supporting: string;
+  title: string;
+  onClick: () => void;
+}) {
+  return (
+    <button type="button" className="lag-journey-card" data-selected={selected} aria-pressed={selected} onClick={onClick}>
+      <span className="lag-journey-card-mark" aria-hidden>{badge}</span>
+      <span className="lag-journey-card-copy">
+        <strong>{title}</strong>
+        <span>{supporting}</span>
+        {badges.length > 0 ? <span className="lag-journey-badges">{badges.map((item) => <span key={item}>{item}</span>)}</span> : null}
+        {progress ? <ProgressBar label={`${title} progress`} percent={progress.percent} valueText={progress.valueText} /> : null}
+      </span>
+      <span className="lag-journey-card-arrow" aria-hidden>→</span>
+    </button>
+  );
+}
+
+function DetailRow({ name, value }: { name: string; value: React.ReactNode }) {
+  return <div className="lag-journey-detail-row"><dt>{name}</dt><dd>{value}</dd></div>;
+}
+
+function DetailSection({ children, title }: { children: React.ReactNode; title: string }) {
+  return <section className="lag-journey-detail-section"><h4>{title}</h4><dl>{children}</dl></section>;
+}
+
+function StatusBadge({ children, state }: { children: React.ReactNode; state: string }) {
+  return <span className="lag-journey-status" data-state={state}>{children}</span>;
+}
+
+function orderedSteps(route: QuestRoute) {
+  return route.steps.slice().sort((left, right) => left.stepOrder - right.stepOrder);
+}
+
+function currentStepPosition(route: QuestRoute) {
+  const currentStepId = route.playerProgress?.currentStepId;
+  if (!currentStepId) return null;
+  const steps = orderedSteps(route);
+  const index = steps.findIndex(({ id }) => id === currentStepId);
+  return index < 0 ? null : `Step ${index + 1} of ${steps.length}`;
+}
+
+function RouteThread({ route, quests }: { route: QuestRoute; quests: QuestAcceptance[] }) {
+  const steps = orderedSteps(route);
+  return (
+    <section className="lag-route-thread" aria-label="Ordered Route Steps">
+      <div className="lag-route-thread-track">
+        <ol>
+          {steps.map((step) => {
+            const current = step.id === route.playerProgress?.currentStepId;
+            return (
+              <li key={step.id} data-state={step.state} data-current={current}>
+                <span className="lag-route-node" aria-hidden>{step.stepOrder}</span>
+                <article>
+                  <div>
+                    <strong>{step.stepOrder}. {step.title}</strong>
+                    <StatusBadge state={step.state}>{humanize(step.state)}{current ? " · Current step" : ""}</StatusBadge>
+                  </div>
+                  <p>{step.description ?? "No Step description."}</p>
+                  <p>Criteria: {step.criteriaSatisfied ? "Satisfied" : "Not satisfied"}</p>
+                  {step.questLinks.length > 0 ? (
+                    <ul aria-label={`Quest requirements for ${step.title}`}>
+                      {step.questLinks.map((link) => {
+                        const quest = quests.find((item) => item.questId === link.questId);
+                        return <li key={link.questId}>Requirement: {quest?.title ?? `Quest #${link.questId}`} · {humanize(link.requirementType)}</li>;
+                      })}
+                    </ul>
+                  ) : <p>No linked Quest requirements.</p>}
+                </article>
+              </li>
+            );
+          })}
+        </ol>
+      </div>
+    </section>
   );
 }
 
@@ -70,7 +176,7 @@ type RouteDetailState = {
   error: string | null;
 };
 
-export default function JourneyShell({ initialSurface = "current" }: { initialSurface?: QuestsSubId | null }) {
+export default function JourneyShell({ initialSurface = null }: { initialSurface?: QuestsSubId | null }) {
   const queries = useJourneyQueries(true);
   const [surface, setSurface] = useState<QuestsSubId | null>(initialSurface);
   const [selectedAcceptanceId, setSelectedAcceptanceId] = useState<number | null>(null);
@@ -84,8 +190,7 @@ export default function JourneyShell({ initialSurface = "current" }: { initialSu
   const questDetailRequestId = useRef(0);
   const routeDetailRequestId = useRef(0);
 
-  const selectSurface = (next: QuestsSubId) => {
-    setSurface(next);
+  const clearDetail = () => {
     setSelectedAcceptanceId(null);
     setSelectedCatalogCode(null);
     setSelectedRouteId(null);
@@ -94,6 +199,22 @@ export default function JourneyShell({ initialSurface = "current" }: { initialSu
     setMutationError(null);
     questDetailRequestId.current += 1;
     routeDetailRequestId.current += 1;
+  };
+
+  const selectSurface = (next: QuestsSubId) => {
+    clearDetail();
+    setSurface(next);
+  };
+
+  const closeDetail = () => {
+    clearDetail();
+    requestStageFocus("journey-list", "nearest");
+  };
+
+  const closeList = () => {
+    clearDetail();
+    setSurface(null);
+    requestStageFocus("journey-root", "nearest");
   };
 
   const mineById = new Map(queries.routes.data.mine.map((route) => [route.id, route]));
@@ -190,42 +311,47 @@ export default function JourneyShell({ initialSurface = "current" }: { initialSu
   };
 
   const renderCurrentList = () => (
-    <div className="space-y-3">
+    <div className="lag-journey-list">
       {queries.current.loading && queries.current.data.length === 0 ? <InfoCard>Loading current Quests...</InfoCard> : null}
       {queries.current.error ? <ErrorState text={queries.current.error} retry={() => void queries.current.reload()} /> : null}
       {!queries.current.loading && !queries.current.error && queries.current.data.length === 0 ? <InfoCard>No Quest acceptances yet.</InfoCard> : null}
-      {queries.current.data.map((quest, index) => (
-        <PanelCard
-          key={quest.id}
-          label={quest.title}
-          slotLabel={quest.status === "GOAL_REACHED" ? "GR" : quest.status.slice(0, 2)}
-          subtitle={`${QUEST_STATUS_LABEL[quest.status]} · ${quest.progressValue}/${quest.targetValue}`}
-          selected={selectedAcceptanceId === quest.id}
-          index={index}
-          onClick={() => {
-            setSelectedAcceptanceId(quest.id);
-            void loadQuestDetail(quest.code);
-          }}
-        />
-      ))}
+      {queries.current.data.map((quest) => {
+        const percent = questProgressPercent(quest);
+        return (
+          <JourneyCard
+            key={quest.id}
+            badge={quest.status === "GOAL_REACHED" ? "GR" : quest.status.slice(0, 2)}
+            title={quest.title}
+            supporting={`${QUEST_STATUS_LABEL[quest.status]} · ${quest.progressValue}/${quest.targetValue}`}
+            badges={[QUEST_STATUS_LABEL[quest.status], humanize(quest.completionPolicy)]}
+            progress={{ percent, valueText: `${quest.progressValue} / ${quest.targetValue} (${percent}%)` }}
+            selected={selectedAcceptanceId === quest.id}
+            onClick={() => {
+              setSelectedAcceptanceId(quest.id);
+              void loadQuestDetail(quest.code);
+            }}
+          />
+        );
+      })}
     </div>
   );
 
   const renderCatalogList = () => (
-    <div className="space-y-3">
+    <div className="lag-journey-list">
       {queries.catalog.loading && queries.catalog.data.length === 0 ? <InfoCard>Loading Quest catalog...</InfoCard> : null}
       {queries.catalog.error ? <ErrorState text={queries.catalog.error} retry={() => void queries.catalog.reload()} /> : null}
       {!queries.catalog.loading && !queries.catalog.error && queries.catalog.data.length === 0 ? <InfoCard>No active Quest blueprints.</InfoCard> : null}
-      {queries.catalog.data.map((quest, index) => {
+      {queries.catalog.data.map((quest) => {
         const acceptance = latestAcceptance(queries.current.data, quest.code);
+        const category = quest.semanticCategory ?? quest.category;
         return (
-          <PanelCard
+          <JourneyCard
             key={quest.code}
-            label={quest.title}
-            slotLabel={(quest.semanticCategory ?? quest.category ?? "QU").slice(0, 2)}
-            subtitle={acceptance ? QUEST_STATUS_LABEL[acceptance.status] : `${quest.targetType} × ${quest.targetValue}`}
+            badge={(category ?? "QU").slice(0, 2)}
+            title={quest.title}
+            supporting={acceptance ? `Acceptance: ${QUEST_STATUS_LABEL[acceptance.status]}` : `${humanize(quest.targetType)} × ${quest.targetValue}`}
+            badges={[...(category ? [humanize(category)] : []), humanize(quest.completionPolicy), humanize(quest.repeatPolicy ?? quest.repeatRule)]}
             selected={selectedCatalogCode === quest.code}
-            index={index}
             onClick={() => {
               setSelectedCatalogCode(quest.code);
               void loadQuestDetail(quest.code);
@@ -237,59 +363,76 @@ export default function JourneyShell({ initialSurface = "current" }: { initialSu
   );
 
   const renderRouteList = () => (
-    <div className="space-y-3">
+    <div className="lag-journey-list">
       {queries.routes.loading && routes.length === 0 ? <InfoCard>Loading Quest Routes...</InfoCard> : null}
       {queries.routes.error ? <ErrorState text={queries.routes.error} retry={() => void queries.routes.reload()} /> : null}
       {!queries.routes.loading && !queries.routes.error && routes.length === 0 ? <InfoCard>No active Quest Routes.</InfoCard> : null}
-      {routes.map((route, index) => (
-        <PanelCard
-          key={route.id}
-          label={route.title}
-          slotLabel={route.playerProgress?.status === "COMPLETED" ? "CP" : route.playerProgress ? "IP" : "NS"}
-          subtitle={route.playerProgress ? route.playerProgress.status : "Not selected"}
-          selected={selectedRouteId === route.id}
-          index={index}
-          onClick={() => {
-            setSelectedRouteId(route.id);
-            void loadRouteDetail(route.id, Boolean(route.playerProgress));
-          }}
-        />
-      ))}
+      {routes.map((route) => {
+        const position = currentStepPosition(route);
+        const status = route.playerProgress?.status ?? "NOT_SELECTED";
+        return (
+          <JourneyCard
+            key={route.id}
+            badge={status === "COMPLETED" ? "CP" : route.playerProgress ? "IP" : "NS"}
+            title={route.title}
+            supporting={[humanize(status), position].filter(Boolean).join(" · ")}
+            badges={[route.playerProgress ? "Selected" : "Not selected", `${route.steps.length} steps`]}
+            selected={selectedRouteId === route.id}
+            onClick={() => {
+              setSelectedRouteId(route.id);
+              void loadRouteDetail(route.id, Boolean(route.playerProgress));
+            }}
+          />
+        );
+      })}
     </div>
   );
 
   const questDetailFor = (code: string) => questDetail.code === code ? questDetail : null;
 
   const renderCurrentDetail = () => {
-    if (!selectedAcceptance) return <InfoCard>Select a Quest acceptance.</InfoCard>;
+    if (!selectedAcceptance) return null;
     const detail = questDetailFor(selectedAcceptance.code);
     if (detail?.loading && !detail.data) return <InfoCard>Loading Quest detail...</InfoCard>;
     if (detail?.error && !detail.data) return <ErrorState text={detail.error} retry={() => void loadQuestDetail(selectedAcceptance.code)} />;
+    const percent = questProgressPercent(selectedAcceptance);
     return (
-      <div className="space-y-3 px-3">
-        {detail?.error ? <p role="alert" className="text-xs" style={{ color: "var(--lag-state-error)" }}>{detail.error}</p> : null}
-        {mutationError ? <p role="alert" className="text-xs" style={{ color: "var(--lag-state-error)" }}>{mutationError}</p> : null}
-        <InfoCard>{detail?.data?.descriptionMd ?? selectedAcceptance.descriptionMd}</InfoCard>
-        <GoldRow>Status: {QUEST_STATUS_LABEL[selectedAcceptance.status]}</GoldRow>
-        <GoldRow>Progress: {selectedAcceptance.progressValue} / {selectedAcceptance.targetValue} ({questProgressPercent(selectedAcceptance)}%)</GoldRow>
-        <GoldRow>Completion policy: {selectedAcceptance.completionPolicy}</GoldRow>
-        {selectedAcceptance.status === "GOAL_REACHED" ? <InfoCard>Goal reached. This is not the same as Completed.</InfoCard> : null}
-        <div className="flex flex-wrap gap-2">
-          {canManualCheckQuest(selectedAcceptance) ? (
-            <button type="button" disabled={Boolean(pending)} style={secondaryButton} onClick={() => void runMutation(`manual-${selectedAcceptance.code}`, () => manualCheckQuestApi(selectedAcceptance.code), () => recoverQuest(selectedAcceptance.code))}>Manual Check</button>
-          ) : null}
-          {canCancelQuest(selectedAcceptance) ? (
-            <button type="button" disabled={Boolean(pending)} style={secondaryButton} onClick={() => {
-              if (window.confirm(`Cancel Quest ${selectedAcceptance.title}?`)) void runMutation(`cancel-${selectedAcceptance.code}`, () => cancelQuestApi(selectedAcceptance.code), () => recoverQuest(selectedAcceptance.code));
-            }}>Cancel Quest</button>
-          ) : null}
-        </div>
-      </div>
+      <article className="lag-journey-detail">
+        {detail?.error ? <p role="alert" className="lag-journey-feedback" data-state="error">{detail.error}</p> : null}
+        {mutationError ? <p role="alert" className="lag-journey-feedback" data-state="error">{mutationError}</p> : null}
+        <header className="lag-journey-detail-hero">
+          <span>Current Quest</span>
+          <h4>{selectedAcceptance.title}</h4>
+          <StatusBadge state={selectedAcceptance.status}>Status: {QUEST_STATUS_LABEL[selectedAcceptance.status]}</StatusBadge>
+          <p>{detail?.data?.descriptionMd ?? selectedAcceptance.descriptionMd}</p>
+        </header>
+        <DetailSection title="Progress">
+          <div className="lag-journey-detail-progress"><ProgressBar label="Quest progress" percent={percent} valueText={`${selectedAcceptance.progressValue} / ${selectedAcceptance.targetValue} (${percent}%)`} /></div>
+        </DetailSection>
+        <DetailSection title="Completion rule">
+          <DetailRow name="Completion policy" value={humanize(selectedAcceptance.completionPolicy)} />
+          <DetailRow name="Progress source" value={selectedAcceptance.progressSource ? humanize(selectedAcceptance.progressSource) : "Not recorded"} />
+          <DetailRow name="Repeat" value={humanize(selectedAcceptance.repeatPolicy ?? selectedAcceptance.repeatRule)} />
+        </DetailSection>
+        {selectedAcceptance.status === "GOAL_REACHED" ? <p className="lag-journey-feedback" data-state="warning">Goal reached. This is not the same as Completed.</p> : null}
+        {(canManualCheckQuest(selectedAcceptance) || canCancelQuest(selectedAcceptance)) ? (
+          <section className="lag-journey-actions" aria-label="Available Quest actions">
+            {canManualCheckQuest(selectedAcceptance) ? (
+              <button type="button" className="lag-journey-action" disabled={Boolean(pending)} onClick={() => void runMutation(`manual-${selectedAcceptance.code}`, () => manualCheckQuestApi(selectedAcceptance.code), () => recoverQuest(selectedAcceptance.code))}>Manual Check</button>
+            ) : null}
+            {canCancelQuest(selectedAcceptance) ? (
+              <button type="button" className="lag-journey-button" data-variant="destructive" disabled={Boolean(pending)} onClick={() => {
+                if (window.confirm(`Cancel Quest ${selectedAcceptance.title}?`)) void runMutation(`cancel-${selectedAcceptance.code}`, () => cancelQuestApi(selectedAcceptance.code), () => recoverQuest(selectedAcceptance.code));
+              }}>Cancel Quest</button>
+            ) : null}
+          </section>
+        ) : null}
+      </article>
     );
   };
 
   const renderCatalogDetail = () => {
-    if (!selectedBlueprint) return <InfoCard>Select a Quest blueprint.</InfoCard>;
+    if (!selectedBlueprint) return null;
     const detail = questDetailFor(selectedBlueprint.code);
     const acceptance = latestAcceptance(queries.current.data, selectedBlueprint.code);
     const acceptanceKnown = !queries.current.loading && !queries.current.error;
@@ -298,58 +441,66 @@ export default function JourneyShell({ initialSurface = "current" }: { initialSu
     if (detail?.loading && !detail.data) return <InfoCard>Loading Quest detail...</InfoCard>;
     if (detail?.error && !detail.data) return <ErrorState text={detail.error} retry={() => void loadQuestDetail(selectedBlueprint.code)} />;
     return (
-      <div className="space-y-3 px-3">
-        {mutationError ? <p role="alert" className="text-xs" style={{ color: "var(--lag-state-error)" }}>{mutationError}</p> : null}
-        <InfoCard>{detail?.data?.descriptionMd ?? selectedBlueprint.descriptionMd}</InfoCard>
-        <GoldRow>Target: {selectedBlueprint.targetType} × {selectedBlueprint.targetValue}</GoldRow>
-        <GoldRow>Completion policy: {selectedBlueprint.completionPolicy}</GoldRow>
-        <GoldRow>Repeat: {selectedBlueprint.repeatPolicy ?? selectedBlueprint.repeatRule}</GoldRow>
-        <GoldRow>Reward profile: {selectedBlueprint.rewardProfileCode ?? "None"}</GoldRow>
-        {acceptance ? <GoldRow>Acceptance: {QUEST_STATUS_LABEL[acceptance.status]}</GoldRow> : null}
-        {!acceptanceKnown ? <InfoCard>Acceptance state unavailable. Accept is disabled until Current reloads.</InfoCard> : null}
+      <article className="lag-journey-detail">
+        {mutationError ? <p role="alert" className="lag-journey-feedback" data-state="error">{mutationError}</p> : null}
+        <header className="lag-journey-detail-hero">
+          <span>Quest Blueprint</span>
+          <h4>{selectedBlueprint.title}</h4>
+          {acceptance ? <StatusBadge state={acceptance.status}>Acceptance: {QUEST_STATUS_LABEL[acceptance.status]}</StatusBadge> : null}
+          <p>{detail?.data?.descriptionMd ?? selectedBlueprint.descriptionMd}</p>
+        </header>
+        <DetailSection title="Target and completion">
+          <DetailRow name="Target" value={`${humanize(selectedBlueprint.targetType)} × ${selectedBlueprint.targetValue}`} />
+          <DetailRow name="Completion policy" value={humanize(selectedBlueprint.completionPolicy)} />
+          <DetailRow name="Repeat" value={humanize(selectedBlueprint.repeatPolicy ?? selectedBlueprint.repeatRule)} />
+          <DetailRow name="Reward profile" value={selectedBlueprint.rewardProfileCode ?? "None"} />
+        </DetailSection>
+        {!acceptanceKnown ? <p className="lag-journey-feedback" data-state="warning">Acceptance state unavailable. Accept is disabled until Current reloads.</p> : null}
         {acceptAction ? (
-          <button type="button" disabled={Boolean(pending)} style={actionBtnStyle} onClick={() => {
+          <button type="button" className="lag-journey-action" disabled={Boolean(pending)} onClick={() => {
             if (window.confirm(`${acceptLabel} ${selectedBlueprint.title}?`)) void runMutation(`accept-${selectedBlueprint.code}`, () => acceptQuestApi(selectedBlueprint.code), () => recoverQuest(selectedBlueprint.code));
           }}>{acceptLabel}</button>
         ) : null}
-      </div>
+      </article>
     );
   };
 
   const renderRouteDetail = () => {
-    if (!selectedRoute) return <InfoCard>Select a Quest Route.</InfoCard>;
+    if (!selectedRoute) return null;
     const detailState = routeDetail.routeId === selectedRoute.id ? routeDetail : null;
     const route = detailState?.data ?? selectedRoute;
     if (detailState?.loading && !detailState.data) return <InfoCard>Loading Route detail...</InfoCard>;
     if (detailState?.error && !detailState.data) return <ErrorState text={detailState.error} retry={() => void loadRouteDetail(selectedRoute.id, Boolean(selectedRoute.playerProgress))} />;
     const progress = route.playerProgress;
-    const currentStep = progress ? route.steps.find((step) => step.id === progress.currentStepId) ?? null : null;
+    const steps = orderedSteps(route);
+    const currentStep = progress ? steps.find((step) => step.id === progress.currentStepId) ?? null : null;
     const canAdvance = progress?.status === "IN_PROGRESS" && currentStep?.state === "READY_TO_ADVANCE";
+    const completedSteps = steps.filter((step) => step.state === "COMPLETED").length;
+    const percent = steps.length > 0 ? Math.round((completedSteps / steps.length) * 100) : null;
     return (
-      <div className="space-y-3 px-3">
-        {detailState?.error ? <p role="alert" className="text-xs" style={{ color: "var(--lag-state-error)" }}>{detailState.error}</p> : null}
-        {mutationError ? <p role="alert" className="text-xs" style={{ color: "var(--lag-state-error)" }}>{mutationError}</p> : null}
-        <InfoCard>{route.description ?? "No Route description."}</InfoCard>
-        <GoldRow>Status: {progress?.status ?? "NOT_SELECTED"}</GoldRow>
-        {progress ? <GoldRow>Current Step ID: {progress.currentStepId}</GoldRow> : null}
-        <section className="space-y-2" aria-label="Ordered Route Steps">
-          {route.steps.slice().sort((left, right) => left.stepOrder - right.stepOrder).map((step) => (
-            <div key={step.id} className="rounded-sm px-3 py-2" style={{ background: "var(--lag-muted-surface)", border: `1px solid ${step.id === progress?.currentStepId ? "var(--lag-focus)" : "var(--lag-divider)"}` }}>
-              <p className="text-sm font-semibold" style={{ color: "var(--lag-text)" }}>{step.stepOrder}. {step.title}</p>
-              <p className="text-xs" style={{ color: "var(--lag-text-2)" }}>{step.state} · criteria {step.criteriaSatisfied ? "satisfied" : "not satisfied"}</p>
-              <p className="text-xs" style={{ color: "var(--lag-text-2)" }}>{step.description ?? "No Step description."}</p>
-              {step.questLinks.map((link) => {
-                const acceptedQuest = queries.current.data.find((quest) => quest.questId === link.questId);
-                return <p key={link.questId} className="text-xs" style={{ color: "var(--lag-text-2)" }}>Requirement: {acceptedQuest?.title ?? `Quest #${link.questId}`} · {link.requirementType}</p>;
-              })}
-            </div>
-          ))}
-        </section>
+      <article className="lag-journey-detail lag-route-detail">
+        {detailState?.error ? <p role="alert" className="lag-journey-feedback" data-state="error">{detailState.error}</p> : null}
+        {mutationError ? <p role="alert" className="lag-journey-feedback" data-state="error">{mutationError}</p> : null}
+        <header className="lag-journey-detail-hero">
+          <span>Quest Route · Long-term direction</span>
+          <h4>{route.title}</h4>
+          <StatusBadge state={progress?.status ?? "NOT_SELECTED"}>Status: {progress?.status ?? "NOT_SELECTED"}</StatusBadge>
+          <p>{route.description ?? "No Route description."}</p>
+        </header>
+        {progress ? (
+          <DetailSection title="Route progress">
+            <DetailRow name="Current step" value={`${currentStepPosition(route) ?? `Step #${progress.currentStepId}`} · ID ${progress.currentStepId}`} />
+            {percent !== null ? <div className="lag-journey-detail-progress"><ProgressBar label="Completed Route steps" percent={percent} valueText={`${completedSteps} / ${steps.length} completed (${percent}%)`} /></div> : null}
+          </DetailSection>
+        ) : null}
+        <RouteThread route={route} quests={queries.current.data} />
         {detailState?.step ? <InfoCard>Current Step Detail: {detailState.step.step.title} · {detailState.step.step.state}</InfoCard> : null}
-        {!progress ? <button type="button" disabled={Boolean(pending)} style={actionBtnStyle} onClick={() => void selectRoute(route)}>Select Route</button> : null}
-        {canAdvance ? <button type="button" disabled={Boolean(pending)} style={actionBtnStyle} onClick={() => void advanceRoute(route)}>Advance Current Step</button> : null}
-        {progress?.status === "COMPLETED" ? <InfoCard>Route completed by an explicit final Step advance.</InfoCard> : null}
-      </div>
+        <section className="lag-journey-actions" aria-label="Available Route actions">
+          {!progress ? <button type="button" className="lag-journey-action" disabled={Boolean(pending)} onClick={() => void selectRoute(route)}>Select Route</button> : null}
+          {canAdvance ? <button type="button" className="lag-journey-action" disabled={Boolean(pending)} onClick={() => void advanceRoute(route)}>Advance Current Step</button> : null}
+        </section>
+        {progress?.status === "COMPLETED" ? <p className="lag-journey-feedback" data-state="success">✓ Route completed by an explicit final Step advance.</p> : null}
+      </article>
     );
   };
 
@@ -361,23 +512,43 @@ export default function JourneyShell({ initialSurface = "current" }: { initialSu
         ? `journey-route-detail-${selectedRoute.id}`
         : null;
 
+  const listTitle = SUBMENUS_BY_MAIN.quests.find((item) => item.id === surface)?.label ?? "Journey";
+  const detailTitle = surface === "current" ? "Quest Detail" : surface === "catalog" ? "Blueprint Detail" : "Route Detail";
+
   return (
-    <div className="lag-panel-rail relative" data-testid="journey-shell">
+    <div className="lag-panel-rail lag-journey-shell relative" data-testid="journey-shell">
       <PanelStage stageKey="journey-root">
-        <PanelFrame title="Journey" depth={2}>
-          <div className="grid gap-1">
-            {SUBMENUS_BY_MAIN.quests.map((item, index) => (
-              <PanelCard key={item.id} label={item.label} slotLabel={item.slotLabel} selected={surface === item.id} index={index} onClick={() => selectSurface(item.id as QuestsSubId)} />
-            ))}
+        <PanelFrame title="Journey / Quest Route" depth={2}>
+          <div className="lag-journey-root">
+            <header>
+              <p className="lag-journey-eyebrow">Journey</p>
+              <h4>Choose your next depth.</h4>
+              <p>Quests are actionable units. Routes remain independent long-term directions.</p>
+            </header>
+            <div className="lag-journey-root-grid">
+              {SUBMENUS_BY_MAIN.quests.map((item) => (
+                <JourneyCard
+                  key={item.id}
+                  badge={item.slotLabel}
+                  title={item.label}
+                  supporting={SURFACE_COPY[item.id as QuestsSubId]}
+                  selected={surface === item.id}
+                  onClick={() => selectSurface(item.id as QuestsSubId)}
+                />
+              ))}
+            </div>
           </div>
         </PanelFrame>
       </PanelStage>
 
       <AnimatePresence initial={false}>
         {surface ? (
-          <PanelStage key="journey-list" stageKey="journey-list" focusKey={surface} index={1}>
-            <PanelFrame title={SUBMENUS_BY_MAIN.quests.find((item) => item.id === surface)?.label ?? "Journey"} depth={1} contentKey={surface}>
-              {surface === "current" ? renderCurrentList() : surface === "catalog" ? renderCatalogList() : renderRouteList()}
+          <PanelStage stageKey="journey-list" focusKey={surface}>
+            <PanelFrame title={listTitle} depth={1} contentKey={surface} backButton={<BackButton label="Back to Journey" onClick={closeList} />}>
+              <section className="lag-journey-list-surface" aria-label={`${listTitle} list`}>
+                <header><p className="lag-journey-eyebrow">Journey child surface</p><h4>{listTitle}</h4><p>{SURFACE_COPY[surface]}</p></header>
+                {surface === "current" ? renderCurrentList() : surface === "catalog" ? renderCatalogList() : renderRouteList()}
+              </section>
             </PanelFrame>
           </PanelStage>
         ) : null}
@@ -385,8 +556,8 @@ export default function JourneyShell({ initialSurface = "current" }: { initialSu
 
       <AnimatePresence initial={false} mode="popLayout">
         {detailContentKey ? (
-          <PanelStage key="journey-detail" stageKey="journey-detail" focusKey={detailContentKey} index={2}>
-            <PanelFrame title={surface === "current" ? selectedAcceptance?.title ?? "Quest Detail" : surface === "catalog" ? selectedBlueprint?.title ?? "Catalog Detail" : selectedRoute?.title ?? "Route Detail"} depth={0} contentKey={detailContentKey}>
+          <PanelStage stageKey="journey-detail" focusKey={detailContentKey}>
+            <PanelFrame title={detailTitle} depth={0} contentKey={detailContentKey} backButton={<BackButton label={`Back to ${listTitle}`} onClick={closeDetail} />}>
               {surface === "current" ? renderCurrentDetail() : surface === "catalog" ? renderCatalogDetail() : renderRouteDetail()}
             </PanelFrame>
           </PanelStage>


### PR DESCRIPTION
## Purpose

Apply the approved Stage 3 Enterprise Dual Theme v7 visual direction to the real Journey, Quest, Quest Catalog, and QuestRoute surfaces.

Closes #56

## Delivered

- v7 Journey root treatment
- Current Quest list/detail fidelity
- Quest Catalog list/detail fidelity
- QuestRoute list/detail fidelity
- real RouteStep-driven route thread/timeline
- explicit Journey staged Back/navigation
- stable detail frame replacement
- semantic Quest/Route state presentation
- desktop Astral Journey fidelity
- desktop Warm Beige Journey fidelity
- mobile Astral Journey fidelity
- mobile Warm Beige Journey fidelity
- accessible route-state and mutation presentation

## Source of Truth

Reference-only visual authority:

```text
LifeAsGame_Stage3_UI_VisualDesigner_Enterprise_Dual_Theme_Result_v7
```

Primary references:

- DT7-04 Journey Astral
- DT7-04 Journey Warm Beige
- MT7-04 Journey Astral
- MT7-04 Journey Warm Beige
- AB7-D03 Journey
- AB7-M03 Journey
- shared v7 semantic/token handoff

Reference artifacts are not committed or shipped.

## Domain Authority

The screenshots define visual hierarchy, not domain data.

This implementation preserves:

```text
Quest = actionable unit
QuestRoute = long-term direction
RouteStep = explicit ordered route structure
```

No screenshot-only Quest names, route names, XP values, milestone entities, or fake progress percentages are introduced.

## Journey Stages

```text
Journey
-> Current / Catalog / Routes
-> selected Quest / Blueprint / Route Detail
```

Later stages are absent until explicitly opened.

Changing the Journey surface clears stale downstream detail state.

Selecting another item in the same list preserves the detail panel frame and replaces only its content.

Back returns from detail to list and from list to Journey.

## Current Quests

Current Quest presentation retains real:

- status
- progress
- target
- completion policy
- GOAL_REACHED distinction
- Manual Check eligibility
- Cancel eligibility

Existing mutation/recovery behavior is unchanged.

## Quest Catalog

Catalog presentation retains real:

- semantic/category data
- target type/value
- completion policy
- repeat policy
- reward profile reference
- known current acceptance state
- Accept / Accept Again policy

No acceptance eligibility is guessed when authoritative current state is unavailable.

## QuestRoute

QuestRoute remains an explicit long-term direction.

The route thread is driven by real ordered RouteStep data including:

- step order
- current step
- step state
- criteria state
- linked Quest requirements

Route selection remains explicit.

Route advancement remains explicit and preserves the `expectedStepId` contract.

Quest completion does not automatically advance a Route.

No global single-active Route assumption is introduced.

## Desktop / Mobile

Desktop follows the approved v7 route-thread/material hierarchy while retaining the real Current/Catalog/Routes IA.

Mobile follows one-screen-one-purpose staged navigation with the existing bottom OrbNav.

## Theme Architecture

Astral and Warm Beige use the same components and state.

No Journey-specific theme branch or new palette authority is introduced.

## Camera Scope

This PR intentionally does not retune the global stage camera.

Journey uses the existing camera/stage-focus contract.

Final global camera composition tuning remains deferred until additional v7 screen groups are implemented.

## Scope Boundaries

This PR does not implement full fidelity for:

- Role
- Growth
- Inventory / Gear
- Collection / Exercise / Media
- Connections / Direct Chat
- Notification
- Economy

It does not change backend contracts, theme runtime behavior, or global camera mathematics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a redesigned Journey interface with clearer panels, cards, progress indicators, status badges, and action controls.
  * Added richer quest, blueprint, and route details, including requirements, rewards, completion status, repeat options, and route progress.
  * Improved route navigation with ordered steps and explicit back and close controls.
  * Added responsive layouts and reduced-motion support for Journey and Route views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->