### PR TITLE
[Role] Apply approved v7 Role fidelity with real domain data

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -158,7 +158,14 @@ body {
 .lag-journey-button,
 .lag-journey-detail-section,
 .lag-route-thread,
-.lag-route-node {
+.lag-route-node,
+.lag-role-node,
+.lag-role-create,
+.lag-role-action,
+.lag-role-button,
+.lag-role-surface-card,
+.lag-role-section,
+.lag-role-event {
   transition:
     background-color var(--lag-motion-normal) ease,
     border-color var(--lag-motion-normal) ease,
@@ -436,6 +443,392 @@ body {
 }
 
 .lag-role-control:hover {
+  background: var(--lag-control-hover-bg);
+}
+
+/* v7 Role: one canonical node selector and explicit workspace depth. */
+.lag-role-selector {
+  display: grid;
+  gap: var(--lag-space-4);
+  padding: var(--lag-space-6);
+}
+
+.lag-role-selector > header {
+  padding-bottom: var(--lag-space-3);
+  border-bottom: 1px solid var(--lag-divider);
+}
+
+.lag-role-selector > header p,
+.lag-role-hero > span:first-child,
+.lag-role-form label,
+.lag-role-data-row dt,
+.lag-role-subheading {
+  color: var(--lag-text-2);
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.lag-role-selector > header h2 {
+  margin-top: var(--lag-space-2);
+  color: var(--lag-text);
+  font-size: 1.35rem;
+  font-weight: 700;
+}
+
+.lag-role-selector > header span,
+.lag-role-selector-state,
+.lag-role-node small {
+  color: var(--lag-text-2);
+  font-size: 0.72rem;
+}
+
+.lag-role-selector-state:empty {
+  display: none;
+}
+
+.lag-role-selector-state > div {
+  display: grid;
+  gap: var(--lag-space-2);
+}
+
+.lag-role-selector-state [role="alert"] {
+  padding-left: var(--lag-space-2);
+  border-left: 3px solid var(--lag-state-error);
+}
+
+.lag-role-node-list {
+  display: grid;
+  gap: var(--lag-space-3);
+}
+
+.lag-role-node {
+  display: grid;
+  min-height: 68px;
+  grid-template-columns: 40px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: var(--lag-space-3);
+  padding: var(--lag-space-3);
+  border: 1px solid var(--lag-control-border);
+  border-radius: var(--lag-radius-md);
+  background: var(--lag-muted-surface);
+  color: var(--lag-text);
+  text-align: left;
+}
+
+.lag-role-node:hover,
+.lag-role-node[data-selected="true"] {
+  border-color: var(--lag-focus);
+  background: var(--lag-control-hover-bg);
+}
+
+.lag-role-node[data-selected="true"] {
+  box-shadow: inset 4px 0 0 var(--lag-state-selected);
+}
+
+.lag-role-node-mark {
+  display: grid;
+  width: 36px;
+  height: 36px;
+  place-items: center;
+  border: 1px solid var(--lag-violet);
+  border-radius: 50%;
+  background: var(--lag-paper);
+  color: var(--lag-text);
+  font-size: 0.72rem;
+  font-weight: 700;
+}
+
+.lag-role-node > span:nth-child(2) {
+  display: grid;
+  min-width: 0;
+  gap: var(--lag-space-1);
+}
+
+.lag-role-node strong {
+  overflow-wrap: anywhere;
+  font-size: 0.86rem;
+}
+
+.lag-role-create,
+.lag-role-action,
+.lag-role-button {
+  display: inline-flex;
+  min-height: 44px;
+  align-items: center;
+  justify-content: center;
+  padding: var(--lag-space-2) var(--lag-space-4);
+  border: 1px solid var(--lag-control-border);
+  border-radius: var(--lag-radius-sm);
+  background: var(--lag-control-bg);
+  color: var(--lag-control-text);
+  font-size: 0.76rem;
+  font-weight: 700;
+}
+
+.lag-role-action,
+.lag-role-create {
+  border-color: var(--lag-violet);
+  background: color-mix(in srgb, var(--lag-violet) 12%, var(--lag-control-bg));
+}
+
+.lag-role-button[data-variant="destructive"] {
+  border-color: var(--lag-state-error);
+}
+
+.lag-role-shell [data-stage-key="role-summary"] .lag-panel-frame {
+  width: min(520px, calc(100vw - 32px)) !important;
+}
+
+.lag-role-shell [data-stage-key="role-detail"] .lag-panel-frame {
+  width: min(660px, calc(100vw - 32px)) !important;
+}
+
+.lag-role-summary,
+.lag-role-detail,
+.lag-role-state,
+.lag-role-form {
+  display: grid;
+  gap: var(--lag-space-4);
+  padding-inline: var(--lag-space-4);
+}
+
+.lag-role-hero {
+  display: grid;
+  gap: var(--lag-space-3);
+  padding: var(--lag-space-4);
+  border: 1px solid var(--lag-border);
+  border-left: 4px solid var(--lag-violet);
+  border-radius: var(--lag-radius-md);
+  background: var(--lag-muted-surface);
+}
+
+.lag-role-hero h4 {
+  color: var(--lag-text);
+  font-size: 1.18rem;
+  font-weight: 700;
+}
+
+.lag-role-hero p,
+.lag-role-description,
+.lag-role-record p {
+  color: var(--lag-text-2);
+  font-size: 0.78rem;
+  line-height: 1.55;
+}
+
+.lag-role-badges,
+.lag-role-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--lag-space-3);
+}
+
+.lag-role-badges span,
+.lag-role-status {
+  width: fit-content;
+  padding: var(--lag-space-1) var(--lag-space-2);
+  border: 1px solid var(--lag-control-border);
+  border-radius: 999px;
+  background: var(--lag-control-bg);
+  color: var(--lag-text-2);
+  font-size: 0.68rem;
+  font-weight: 700;
+}
+
+.lag-role-surface-grid,
+.lag-role-event-list {
+  display: grid;
+  gap: var(--lag-space-3);
+}
+
+.lag-role-surface-card {
+  display: grid;
+  min-height: 76px;
+  grid-template-columns: 42px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: var(--lag-space-3);
+  padding: var(--lag-space-3);
+  border: 1px solid var(--lag-divider);
+  border-radius: var(--lag-radius-md);
+  background: var(--lag-muted-surface);
+  color: var(--lag-text);
+  text-align: left;
+}
+
+.lag-role-surface-card > span:first-child {
+  display: grid;
+  width: 38px;
+  height: 38px;
+  place-items: center;
+  border: 1px solid var(--lag-violet);
+  border-radius: 50%;
+  color: var(--lag-text-2);
+  font-size: 0.68rem;
+}
+
+.lag-role-surface-card strong,
+.lag-role-surface-card small {
+  grid-column: 2;
+}
+
+.lag-role-surface-card small {
+  color: var(--lag-text-2);
+  font-size: 0.7rem;
+}
+
+.lag-role-surface-card > span:last-child {
+  grid-row: 1 / span 2;
+  grid-column: 3;
+}
+
+.lag-role-surface-card:hover,
+.lag-role-surface-card[data-selected="true"] {
+  border-color: var(--lag-focus);
+  background: var(--lag-control-hover-bg);
+}
+
+.lag-role-surface-card[data-selected="true"] {
+  box-shadow: inset 4px 0 0 var(--lag-state-selected);
+}
+
+.lag-role-section {
+  overflow: hidden;
+  border: 1px solid var(--lag-divider);
+  border-radius: var(--lag-radius-md);
+  background: var(--lag-panel);
+}
+
+.lag-role-section > h4 {
+  padding: var(--lag-space-3) var(--lag-space-4);
+  border-bottom: 1px solid var(--lag-divider);
+  background: var(--lag-panel-2);
+  color: var(--lag-text);
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.lag-role-section > div,
+.lag-role-section-body {
+  display: grid;
+  gap: var(--lag-space-3);
+  padding: var(--lag-space-4);
+}
+
+.lag-role-data-row {
+  display: grid;
+  grid-template-columns: minmax(110px, 0.7fr) minmax(0, 1.3fr);
+  gap: var(--lag-space-3);
+  padding-block: var(--lag-space-2);
+  border-bottom: 1px solid var(--lag-divider);
+}
+
+.lag-role-data-row:last-child {
+  border-bottom: 0;
+}
+
+.lag-role-data-row dd {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  color: var(--lag-text);
+  font-size: 0.78rem;
+}
+
+.lag-role-form {
+  padding: var(--lag-space-4);
+  border: 1px solid var(--lag-divider);
+  border-radius: var(--lag-radius-md);
+  background: var(--lag-muted-surface);
+}
+
+.lag-role-form label {
+  display: grid;
+  gap: var(--lag-space-2);
+}
+
+.lag-role-form textarea {
+  resize: vertical;
+}
+
+.lag-role-form-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--lag-space-3);
+}
+
+.lag-role-record {
+  display: grid;
+  gap: var(--lag-space-2);
+  padding: var(--lag-space-3);
+  border: 1px solid var(--lag-divider);
+  border-radius: var(--lag-radius-sm);
+  background: var(--lag-muted-surface);
+  color: var(--lag-text);
+}
+
+.lag-role-record[data-kind="person"] {
+  border-left: 4px solid var(--lag-cyan);
+}
+
+.lag-role-record[data-kind="relation"] {
+  border-left: 4px solid var(--lag-violet);
+}
+
+.lag-role-event {
+  display: grid;
+  min-height: 64px;
+  grid-template-columns: 34px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: var(--lag-space-3);
+  padding: var(--lag-space-3);
+  border: 1px solid var(--lag-divider);
+  border-radius: var(--lag-radius-sm);
+  background: var(--lag-muted-surface);
+  color: var(--lag-text);
+  text-align: left;
+}
+
+.lag-role-event > span:nth-child(2) {
+  display: grid;
+  gap: var(--lag-space-1);
+}
+
+.lag-role-event small {
+  color: var(--lag-text-2);
+  font-size: 0.7rem;
+}
+
+.lag-role-event:hover,
+.lag-role-event[data-selected="true"] {
+  border-color: var(--lag-focus);
+  background: var(--lag-control-hover-bg);
+}
+
+.lag-role-event[data-selected="true"] {
+  box-shadow: inset 4px 0 0 var(--lag-state-selected);
+}
+
+.lag-role-feedback {
+  padding: var(--lag-space-3);
+  border: 1px solid var(--lag-state-info);
+  border-radius: var(--lag-radius-sm);
+  background: var(--lag-muted-surface);
+  color: var(--lag-text);
+  font-size: 0.76rem;
+}
+
+.lag-role-feedback[data-state="error"] {
+  border-color: var(--lag-state-error);
+  box-shadow: inset 4px 0 0 var(--lag-state-error);
+}
+
+.lag-role-create:hover,
+.lag-role-action:not(:disabled):hover,
+.lag-role-button:not(:disabled):hover {
+  border-color: var(--lag-focus);
   background: var(--lag-control-hover-bg);
 }
 
@@ -1550,6 +1943,34 @@ textarea.lag-journal-control {
     width: 100%;
   }
 
+  .lag-role-selector {
+    padding: var(--lag-space-4);
+  }
+
+  .lag-role-shell [data-stage-key="role-summary"] .lag-panel-frame,
+  .lag-role-shell [data-stage-key="role-detail"] .lag-panel-frame {
+    width: clamp(280px, calc(100vw - 32px), 344px) !important;
+  }
+
+  .lag-role-summary,
+  .lag-role-detail,
+  .lag-role-state,
+  .lag-role-form {
+    padding-inline: var(--lag-space-3);
+  }
+
+  .lag-role-form-grid,
+  .lag-role-data-row {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .lag-role-actions,
+  .lag-role-action,
+  .lag-role-button,
+  .lag-role-create {
+    width: 100%;
+  }
+
   .lag-left-anchor {
     --lag-left-lane-width: clamp(280px, calc(100vw - 32px), 344px);
     position: static;
@@ -1642,6 +2063,16 @@ textarea.lag-journal-control {
   .lag-journey-detail-section,
   .lag-route-thread,
   .lag-route-node {
+    transition-duration: 0s;
+  }
+
+  .lag-role-node,
+  .lag-role-create,
+  .lag-role-action,
+  .lag-role-button,
+  .lag-role-surface-card,
+  .lag-role-section,
+  .lag-role-event {
     transition-duration: 0s;
   }
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -804,6 +804,7 @@ export default function Home() {
           selectedRoleId={selectedRoleId}
           socialContext={socialContext}
           onRoleSelect={handleRoleSelect}
+          onRoleRetry={() => void roleState.refresh()}
           onFocus={() => bringSurfaceToFront("left-context")}
           zIndex={getSurfaceZIndex("left-context", SURFACE_GROUP_BASE_Z.left)}
         />
@@ -857,8 +858,6 @@ export default function Home() {
               <RoleShell
                 roles={roleState.roles}
                 selectedRoleId={selectedRoleId}
-                isLoading={roleState.isLoading}
-                error={roleState.error}
                 onSelectRole={setSelectedRoleId}
                 onRefresh={roleState.refresh}
               />

--- a/features/role/RoleShell.test.tsx
+++ b/features/role/RoleShell.test.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { PersonDetail, RoleDetail, RoleEventDetail, RoleRelationDetail } from "@/shared/api/types";
+import { RoleContextPanel } from "@/widgets/left-context/ui/RoleContextPanel";
 import RoleShell from "./RoleShell";
 
 const api = vi.hoisted(() => ({
@@ -22,23 +23,7 @@ const api = vi.hoisted(() => ({
   updateRoleEventApi: vi.fn(),
   updateRoleRelationApi: vi.fn(),
 }));
-const router = vi.hoisted(() => ({ push: vi.fn() }));
-
 vi.mock("./api", () => api);
-vi.mock("next/navigation", () => ({ useRouter: () => router }));
-vi.mock("@/shared/ui/PanelCard", () => ({
-  default: ({ label, onClick, actions, onAction }: {
-    label: string;
-    onClick?: () => void;
-    actions?: Array<{ type: string; label: string }>;
-    onAction?: (type: string) => void;
-  }) => (
-    <div>
-      <button type="button" onClick={onClick}>{label}</button>
-      {actions?.map((action) => <button key={action.type} type="button" onClick={() => onAction?.(action.type)}>{action.label} {label}</button>)}
-    </div>
-  ),
-}));
 
 const roles: RoleDetail[] = [
   { id: 1, roleType: "PROFESSIONAL", name: "Backend Engineer", description: "Build systems", status: "ACTIVE", createdAt: "2026-01-01T00:00:00Z", updatedAt: "2026-01-01T00:00:00Z", version: 0 },
@@ -48,9 +33,24 @@ const person: PersonDetail = { id: 7, linkedUserId: 44, displayName: "Alex", not
 const relation: RoleRelationDetail = { id: 9, personId: 7, personDisplayName: "Alex", linkedUserId: 44, relationType: "FRIEND", roleNotes: "Call monthly", status: "ACTIVE", createdAt: "2026-01-01T00:00:00Z", updatedAt: "2026-01-01T00:00:00Z", version: 0 };
 const roleEvent: RoleEventDetail = { id: 11, roleId: 1, title: "Architecture review", description: "Review boundaries", startsAt: null, endsAt: null, status: "PLANNED", completedAt: null, participants: [{ participantLinkId: 1, participantType: "SERVICE_USER", participantId: 99 }], createdAt: "2026-01-01T00:00:00Z", updatedAt: "2026-01-01T00:00:00Z", version: 0 };
 
+function deferred<T>() {
+  let reject!: (reason?: unknown) => void;
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+}
+
 function Harness({ initialRoleId = 1, availableRoles = roles, loading = false, error = null, refresh = vi.fn().mockResolvedValue(undefined) }: { initialRoleId?: number | null; availableRoles?: RoleDetail[]; loading?: boolean; error?: string | null; refresh?: () => Promise<void> }) {
   const [selectedRoleId, setSelectedRoleId] = useState<number | null>(initialRoleId);
-  return <RoleShell roles={availableRoles} selectedRoleId={selectedRoleId} isLoading={loading} error={error} onSelectRole={setSelectedRoleId} onRefresh={refresh} />;
+  return (
+    <>
+      <RoleContextPanel roles={availableRoles} selectedRoleId={selectedRoleId} isLoading={loading} error={error} onRoleSelect={setSelectedRoleId} onRetry={() => void refresh()} />
+      <RoleShell roles={availableRoles} selectedRoleId={selectedRoleId} onSelectRole={setSelectedRoleId} onRefresh={refresh} />
+    </>
+  );
 }
 
 describe("실제 Role shell을 사용할 때", () => {
@@ -72,50 +72,82 @@ describe("실제 Role shell을 사용할 때", () => {
 
   it("Role list/surface/detail/form이 shared semantic material만 사용한다", () => {
     const source = readFileSync("features/role/RoleShell.tsx", "utf8");
+    const selector = readFileSync("widgets/left-context/ui/RoleContextPanel.tsx", "utf8");
 
-    expect(source).toContain("var(--lag-control-bg)");
-    expect(source).toContain("var(--lag-state-error)");
-    expect(source).not.toMatch(/SAO\.color|INPUT_STYLE|rgba\(/);
+    expect(source).toContain("lag-role-summary");
+    expect(selector).toContain("data-role-selector");
+    expect(source).not.toMatch(/role-list|PanelCard|GoldRow|outline:\s*["']?none|Knowledge|Consistency|Connection|Confidence|Role (?:score|rank|level)/i);
+    expect(`${source}\n${selector}`).not.toContain("data-theme");
+
+    const css = readFileSync("app/globals.css", "utf8");
+    const roleCss = css.slice(css.indexOf("/* v7 Role"), css.indexOf(".lag-semantic-controls"));
+    expect(roleCss).toContain("var(--lag-muted-surface)");
+    expect(roleCss).not.toMatch(/#[0-9a-f]{3,8}|rgba?\(/i);
+    expect(css).toContain('.lag-role-shell [data-stage-key="role-summary"]');
+    expect(css).toContain("@media (max-width: 767px)");
   });
 
   describe("Role 목록을 탐색하고 관리하면", () => {
-    it("loading/empty/error 상태를 표시하고 선택·create·edit·archive 흐름을 제공한다", async () => {
+    it("canonical selector가 loading/empty/error/retry와 선택·create·edit·archive 흐름을 제공한다", async () => {
       const refresh = vi.fn().mockResolvedValue(undefined);
-      const { rerender } = render(<Harness loading availableRoles={[]} initialRoleId={null} refresh={refresh} />);
+      const loading = render(<Harness loading availableRoles={[]} initialRoleId={null} refresh={refresh} />);
       expect(screen.getByText("Loading Roles...")).toBeInTheDocument();
+      loading.unmount();
 
-      rerender(<Harness availableRoles={[]} initialRoleId={null} error="Role load failed" refresh={refresh} />);
+      const failed = render(<Harness availableRoles={[]} initialRoleId={null} error="Role load failed" refresh={refresh} />);
       expect(screen.getByRole("alert")).toHaveTextContent("Role load failed");
+      fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+      expect(refresh).toHaveBeenCalled();
+      failed.unmount();
 
-      rerender(<Harness availableRoles={[]} initialRoleId={null} refresh={refresh} />);
+      const empty = render(<Harness availableRoles={[]} initialRoleId={null} refresh={refresh} />);
       expect(screen.getByText(/No Roles yet/)).toBeInTheDocument();
+      empty.unmount();
 
-      rerender(<Harness refresh={refresh} />);
-      fireEvent.click(screen.getByRole("button", { name: "Family Member" }));
-      fireEvent.click(screen.getByRole("button", { name: "Overview" }));
+      render(<Harness initialRoleId={null} refresh={refresh} />);
+      fireEvent.click(screen.getByRole("button", { name: /Family Member/ }));
       expect(screen.getByText("Be present")).toBeInTheDocument();
+      expect(screen.queryByText("Knowledge")).not.toBeInTheDocument();
 
-      fireEvent.click(screen.getByRole("button", { name: "Create Role" }));
-      expect(router.push).toHaveBeenCalledWith("/roles/create");
+      expect(screen.getByRole("link", { name: "Create Role" })).toHaveAttribute("href", "/roles/create");
 
-      fireEvent.click(screen.getByRole("button", { name: "Edit Family Member" }));
+      fireEvent.click(screen.getByRole("button", { name: "Edit Role" }));
       fireEvent.change(screen.getByLabelText("Name"), { target: { value: "Family Anchor" } });
       fireEvent.click(screen.getByRole("button", { name: "Save Role" }));
       await waitFor(() => expect(api.updateRoleApi).toHaveBeenCalledWith(2, { roleType: "FAMILY", name: "Family Anchor", description: "Be present" }));
 
-      fireEvent.click(screen.getByRole("button", { name: "Archive Family Member" }));
+      fireEvent.click(screen.getByRole("button", { name: "Archive Role" }));
       await waitFor(() => expect(api.archiveRoleApi).toHaveBeenCalledWith(2));
       expect(refresh).toHaveBeenCalled();
+    });
+
+    it("Role edit 실패 중 pending과 draft를 보존하고 Cancel로 summary에 돌아간다", async () => {
+      const saving = deferred<RoleDetail>();
+      api.updateRoleApi.mockReturnValue(saving.promise);
+      render(<Harness />);
+
+      fireEvent.click(screen.getByRole("button", { name: "Edit Role" }));
+      fireEvent.change(screen.getByLabelText("Name"), { target: { value: "Draft Role" } });
+      fireEvent.click(screen.getByRole("button", { name: "Save Role" }));
+      expect(screen.getByRole("button", { name: "Saving..." })).toBeDisabled();
+
+      saving.reject(new Error("Role save failed"));
+      expect(await screen.findByRole("alert")).toHaveTextContent("Role save failed");
+      expect(screen.getByLabelText("Name")).toHaveValue("Draft Role");
+      fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+      await waitFor(() => expect(document.querySelector('[data-stage-key="role-detail"]')).not.toBeInTheDocument());
+      expect(document.querySelector('[data-stage-key="role-summary"]')).toBeInTheDocument();
     });
   });
 
   describe("Role을 선택하지 않은 상태이면", () => {
     it("첫 Role을 자동 선택하지 않고 downstream stage/API를 열지 않는다", () => {
       const onSelectRole = vi.fn();
-      render(<RoleShell roles={roles} selectedRoleId={null} isLoading={false} error={null} onSelectRole={onSelectRole} onRefresh={vi.fn()} />);
+      render(<RoleShell roles={roles} selectedRoleId={null} onSelectRole={onSelectRole} onRefresh={vi.fn()} />);
 
       expect(onSelectRole).not.toHaveBeenCalled();
-      expect(screen.queryByRole("button", { name: "Overview" })).not.toBeInTheDocument();
+      expect(document.querySelector('[data-stage-key="role-list"]')).not.toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: /Overview/ })).not.toBeInTheDocument();
       expect(screen.queryByText("Build systems")).not.toBeInTheDocument();
       expect(api.listPersonsApi).not.toHaveBeenCalled();
       expect(api.listRoleRelationsApi).not.toHaveBeenCalled();
@@ -124,17 +156,38 @@ describe("실제 Role shell을 사용할 때", () => {
 
     it("Role 선택은 surfaces만 열고 surface 선택 후 detail을 열며 Role 교체 시 detail을 닫는다", async () => {
       render(<Harness initialRoleId={null} />);
+      const selector = document.querySelector("[data-role-selector]");
 
-      fireEvent.click(screen.getByRole("button", { name: "Backend Engineer" }));
-      expect(screen.getByRole("button", { name: "Overview" })).toBeInTheDocument();
-      expect(screen.queryByText("Build systems")).not.toBeInTheDocument();
-
-      fireEvent.click(screen.getByRole("button", { name: "Overview" }));
+      fireEvent.click(screen.getByRole("button", { name: /Backend Engineer/ }));
+      expect(screen.getByRole("button", { name: /Overview/ })).toBeInTheDocument();
       expect(screen.getByText("Build systems")).toBeInTheDocument();
+      expect(api.listRoleEventsApi).not.toHaveBeenCalled();
 
-      fireEvent.click(screen.getByRole("button", { name: "Family Member" }));
-      await waitFor(() => expect(screen.queryByText("Build systems")).not.toBeInTheDocument());
-      expect(screen.queryByText("Be present")).not.toBeInTheDocument();
+      fireEvent.click(screen.getByRole("button", { name: /Overview/ }));
+      expect(document.querySelector('[data-stage-key="role-detail"]')).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole("button", { name: /Family Member/ }));
+      await waitFor(() => expect(document.querySelector('[data-stage-key="role-detail"]')).not.toBeInTheDocument());
+      expect(screen.getByText("Be present")).toBeInTheDocument();
+      expect(document.querySelector("[data-role-selector]")).toBe(selector);
+
+      fireEvent.click(screen.getByRole("button", { name: /Backend Engineer/ }));
+      expect(document.querySelector('[data-stage-key="role-detail"]')).not.toBeInTheDocument();
+      expect(screen.queryByText("Role Overview")).not.toBeInTheDocument();
+    });
+
+    it("surface Back은 selected Role summary를 유지하고 summary Back은 selector로 돌아간다", async () => {
+      render(<Harness />);
+      fireEvent.click(screen.getByRole("button", { name: /Overview/ }));
+      expect(await screen.findByText("Role Overview")).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole("button", { name: "Back to Backend Engineer" }));
+      await waitFor(() => expect(document.querySelector('[data-stage-key="role-detail"]')).not.toBeInTheDocument());
+      expect(document.querySelector('[data-stage-key="role-summary"]')).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole("button", { name: "Back to Role selector" }));
+      await waitFor(() => expect(document.querySelector('[data-stage-key="role-summary"]')).not.toBeInTheDocument());
+      expect(document.querySelector("[data-role-selector]")).toBeInTheDocument();
     });
 
     it("Role이 비어 있으면 downstream API를 호출하지 않는다", () => {
@@ -150,7 +203,7 @@ describe("실제 Role shell을 사용할 때", () => {
     it("Role 목록이 loading되는 동안 선택 ID를 지우지 않는다", () => {
       const onSelectRole = vi.fn();
 
-      render(<RoleShell roles={[]} selectedRoleId={2} isLoading error={null} onSelectRole={onSelectRole} onRefresh={vi.fn()} />);
+      render(<RoleShell roles={[]} selectedRoleId={2} onSelectRole={onSelectRole} onRefresh={vi.fn()} />);
 
       expect(onSelectRole).not.toHaveBeenCalledWith(null);
     });
@@ -159,7 +212,7 @@ describe("실제 Role shell을 사용할 때", () => {
   describe("Relations surface에서 Person과 관계를 관리하면", () => {
     it("Person을 별도 identity로 생성·선택하고 Relation을 create/update/archive한다", async () => {
       render(<Harness />);
-      fireEvent.click(screen.getByRole("button", { name: "Relations" }));
+      fireEvent.click(screen.getByRole("button", { name: /Relations/ }));
 
       expect(await screen.findByText("Linked account available · identity remains Person")).toBeInTheDocument();
 
@@ -187,7 +240,7 @@ describe("실제 Role shell을 사용할 때", () => {
   describe("Events surface에서 일정 lifecycle을 수행하면", () => {
     it("list/detail/participant 표시 후 create/update/complete를 수행하되 participant 입력은 노출하지 않는다", async () => {
       render(<Harness />);
-      fireEvent.click(screen.getByRole("button", { name: "Events" }));
+      fireEvent.click(screen.getByRole("button", { name: /Events/ }));
       fireEvent.click(await screen.findByRole("button", { name: /Architecture review/ }));
 
       expect(await screen.findByText("SERVICE_USER #99")).toBeInTheDocument();
@@ -209,7 +262,7 @@ describe("실제 Role shell을 사용할 때", () => {
 
     it("cancel은 독립 endpoint만 호출하고 LifeLog 또는 participant mutation을 만들지 않는다", async () => {
       render(<Harness />);
-      fireEvent.click(screen.getByRole("button", { name: "Events" }));
+      fireEvent.click(screen.getByRole("button", { name: /Events/ }));
       fireEvent.click(await screen.findByRole("button", { name: /Architecture review/ }));
       fireEvent.click(await screen.findByRole("button", { name: "Cancel Event" }));
 

--- a/features/role/RoleShell.tsx
+++ b/features/role/RoleShell.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import { useRouter } from "next/navigation";
 import { AnimatePresence } from "framer-motion";
 
 import type {
@@ -11,11 +10,10 @@ import type {
   RoleEventInput,
   RoleRelationDetail,
 } from "@/shared/api/types";
-import PanelCard from "@/shared/ui/PanelCard";
+import { requestStageFocus } from "@/shared/hooks/useStageCamera";
 import PanelStage from "@/shared/ui/PanelStage";
-import { PanelFrame } from "@/widgets/right-panels/ui/PanelFrame";
-import { GoldRow, InfoCard } from "@/widgets/right-panels/ui/Rows";
-import { actionBtnStyle } from "@/widgets/right-panels/ui/styles";
+import { BackButton, PanelFrame } from "@/widgets/right-panels/ui/PanelFrame";
+import { InfoCard } from "@/widgets/right-panels/ui/Rows";
 import {
   archiveRoleApi,
   archiveRoleRelationApi,
@@ -41,37 +39,6 @@ const ROLE_SURFACES: Array<{ id: RoleSurface; label: string; slotLabel: string }
   { id: "events", label: "Events", slotLabel: "EV" },
 ];
 
-const secondaryButton = {
-  border: "1px solid var(--lag-control-border)",
-  background: "var(--lag-control-bg)",
-  color: "var(--lag-control-text)",
-  borderRadius: "var(--lag-radius-sm)",
-  padding: "7px 10px",
-  fontSize: "0.68rem",
-  letterSpacing: "0.08em",
-} as const;
-
-const fieldLabel = {
-  display: "block",
-  fontSize: "0.62rem",
-  letterSpacing: "0.14em",
-  color: "var(--lag-text-2)",
-  textTransform: "uppercase",
-} as const;
-
-const inputStyle = {
-  width: "100%",
-  boxSizing: "border-box",
-  padding: "8px 12px",
-  background: "var(--lag-control-bg)",
-  border: "1px solid var(--lag-control-border)",
-  borderRadius: "var(--lag-radius-sm)",
-  color: "var(--lag-control-text)",
-  fontSize: "0.875rem",
-  letterSpacing: "0.04em",
-  outline: "none",
-} as const;
-
 function value(form: FormData, key: string) {
   return String(form.get(key) ?? "").trim();
 }
@@ -93,11 +60,19 @@ function toInstant(local: string) {
 
 function ErrorState({ message, onRetry }: { message: string; onRetry: () => void }) {
   return (
-    <div className="space-y-3 px-3">
-      <p role="alert" className="text-sm" style={{ color: "var(--lag-state-error)" }}>{message}</p>
-      <button type="button" style={secondaryButton} onClick={onRetry}>Retry</button>
+    <div className="lag-role-state">
+      <p role="alert" className="lag-role-feedback" data-state="error">{message}</p>
+      <button type="button" className="lag-role-button" onClick={onRetry}>Retry</button>
     </div>
   );
+}
+
+function RoleDataRow({ label, children }: { label: string; children: React.ReactNode }) {
+  return <div className="lag-role-data-row"><dt>{label}</dt><dd>{children}</dd></div>;
+}
+
+function RoleSection({ title, children }: { title: string; children: React.ReactNode }) {
+  return <section className="lag-role-section"><h4>{title}</h4><div>{children}</div></section>;
 }
 
 function RoleEditForm({ role, onSaved, onCancel }: { role: RoleDetail; onSaved: () => Promise<void>; onCancel: () => void }) {
@@ -124,14 +99,14 @@ function RoleEditForm({ role, onSaved, onCancel }: { role: RoleDetail; onSaved: 
   };
 
   return (
-    <form className="space-y-3 px-3" onSubmit={submit}>
-      <label style={fieldLabel}>Role Type<input className="lag-role-control" name="roleType" required defaultValue={role.roleType} style={inputStyle} /></label>
-      <label style={fieldLabel}>Name<input className="lag-role-control" name="name" required defaultValue={role.name} style={inputStyle} /></label>
-      <label style={fieldLabel}>Description<textarea className="lag-role-control" name="description" required defaultValue={role.description} rows={4} style={{ ...inputStyle, resize: "vertical" }} /></label>
-      {error ? <p role="alert" className="text-xs" style={{ color: "var(--lag-state-error)" }}>{error}</p> : null}
-      <div className="flex gap-2">
-        <button type="submit" disabled={pending} style={{ ...actionBtnStyle, flex: 1 }}>{pending ? "Saving..." : "Save Role"}</button>
-        <button type="button" style={secondaryButton} onClick={onCancel}>Cancel</button>
+    <form className="lag-role-form" onSubmit={submit}>
+      <label>Role Type<input className="lag-role-control" name="roleType" required defaultValue={role.roleType} /></label>
+      <label>Name<input className="lag-role-control" name="name" required defaultValue={role.name} /></label>
+      <label>Description<textarea className="lag-role-control" name="description" required defaultValue={role.description} rows={4} /></label>
+      {error ? <p role="alert" className="lag-role-feedback" data-state="error">{error}</p> : null}
+      <div className="lag-role-actions">
+        <button type="submit" disabled={pending} className="lag-role-action">{pending ? "Saving..." : "Save Role"}</button>
+        <button type="button" className="lag-role-button" onClick={onCancel}>Cancel</button>
       </div>
     </form>
   );
@@ -139,12 +114,21 @@ function RoleEditForm({ role, onSaved, onCancel }: { role: RoleDetail; onSaved: 
 
 function Overview({ role }: { role: RoleDetail }) {
   return (
-    <div className="space-y-3 px-3">
-      <InfoCard>{role.description}</InfoCard>
-      <GoldRow>Name: {role.name}</GoldRow>
-      <GoldRow>Role Type: {role.roleType}</GoldRow>
-      <GoldRow>Status: {role.status}</GoldRow>
-    </div>
+    <article className="lag-role-detail">
+      <header className="lag-role-hero">
+        <span>Role Overview</span>
+        <h4>{role.name}</h4>
+        <span className="lag-role-status">{role.status}</span>
+        <p>{role.description}</p>
+      </header>
+      <RoleSection title="Role identity">
+        <dl>
+          <RoleDataRow label="Name">{role.name}</RoleDataRow>
+          <RoleDataRow label="Role type">{role.roleType}</RoleDataRow>
+          <RoleDataRow label="Status">{role.status}</RoleDataRow>
+        </dl>
+      </RoleSection>
+    </article>
   );
 }
 
@@ -235,60 +219,64 @@ function RelationsSurface({ roleId }: { roleId: number }) {
   if (error && persons.length === 0 && relations.length === 0) return <ErrorState message={error} onRetry={() => void load()} />;
 
   return (
-    <div className="space-y-5 px-3">
-      {error ? <p role="alert" className="text-xs" style={{ color: "var(--lag-state-error)" }}>{error}</p> : null}
-      <section className="space-y-2" aria-labelledby="persons-heading">
-        <h3 id="persons-heading" style={fieldLabel}>Persons</h3>
+    <div className="lag-role-detail lag-role-relations">
+      {error ? <p role="alert" className="lag-role-feedback" data-state="error">{error}</p> : null}
+      <section className="lag-role-section" aria-labelledby="persons-heading">
+        <h4 id="persons-heading">Persons</h4>
+        <div className="lag-role-section-body">
         {persons.length ? persons.map((person) => (
-          <div key={person.id} className="lag-utility-row rounded-sm border px-3 py-2">
-            <p className="text-sm font-semibold" style={{ color: "var(--lag-text)" }}>{person.displayName}</p>
-            <p className="text-xs" style={{ color: "var(--lag-text-2)" }}>
+          <article key={person.id} className="lag-role-record" data-kind="person">
+            <strong>{person.displayName}</strong>
+            <p>
               {person.linkedUserId ? "Linked account available · identity remains Person" : "Person"}
             </p>
-          </div>
+          </article>
         )) : <InfoCard>No Persons yet.</InfoCard>}
-        <form className="space-y-2" onSubmit={createPerson}>
-          <label style={fieldLabel}>Display Name<input className="lag-role-control" name="displayName" required style={inputStyle} /></label>
-          <label style={fieldLabel}>Notes<input className="lag-role-control" name="notes" style={inputStyle} /></label>
-          <div className="grid grid-cols-2 gap-2">
-            <label style={fieldLabel}>Birthday<input className="lag-role-control" name="birthday" type="date" style={inputStyle} /></label>
-            <label style={fieldLabel}>Contact<input className="lag-role-control" name="contact" style={inputStyle} /></label>
+        <form className="lag-role-form" onSubmit={createPerson}>
+          <label>Display Name<input className="lag-role-control" name="displayName" required /></label>
+          <label>Notes<input className="lag-role-control" name="notes" /></label>
+          <div className="lag-role-form-grid">
+            <label>Birthday<input className="lag-role-control" name="birthday" type="date" /></label>
+            <label>Contact<input className="lag-role-control" name="contact" /></label>
           </div>
-          <button type="submit" disabled={pending} style={secondaryButton}>Create Person</button>
+          <button type="submit" disabled={pending} className="lag-role-button">Create Person</button>
         </form>
+        </div>
       </section>
 
-      <section className="space-y-2" aria-labelledby="relations-heading">
-        <h3 id="relations-heading" style={fieldLabel}>Role Relations</h3>
+      <section className="lag-role-section" aria-labelledby="relations-heading">
+        <h4 id="relations-heading">Role Relations</h4>
+        <div className="lag-role-section-body">
         {relations.length ? relations.map((relation) => (
-          <div key={relation.id} className="lag-utility-row rounded-sm border px-3 py-2">
-            <p className="text-sm font-semibold" style={{ color: "var(--lag-text)" }}>{relation.personDisplayName} · {relation.relationType}</p>
-            <p className="text-xs" style={{ color: "var(--lag-text-2)" }}>{relation.roleNotes || "No role notes"}</p>
-            <div className="mt-2 flex gap-2">
-              <button type="button" style={secondaryButton} onClick={() => setEditing(relation)}>Edit</button>
-              <button type="button" disabled={pending} style={secondaryButton} onClick={() => void archiveRelation(relation)}>Archive</button>
+          <article key={relation.id} className="lag-role-record" data-kind="relation">
+            <strong>{relation.personDisplayName} · {relation.relationType}</strong>
+            <p>{relation.roleNotes || "No role notes"}</p>
+            <div className="lag-role-actions">
+              <button type="button" className="lag-role-button" onClick={() => setEditing(relation)}>Edit</button>
+              <button type="button" disabled={pending} className="lag-role-button" data-variant="destructive" onClick={() => void archiveRelation(relation)}>Archive</button>
             </div>
-          </div>
+          </article>
         )) : <InfoCard>No Relations for this Role.</InfoCard>}
 
-        <form key={editing?.id ?? "new-relation"} className="space-y-2" onSubmit={saveRelation}>
+        <form key={editing?.id ?? "new-relation"} className="lag-role-form" onSubmit={saveRelation}>
           {editing ? (
             <InfoCard>Editing {editing.personDisplayName}. Person identity cannot be changed here.</InfoCard>
           ) : (
-            <label style={fieldLabel}>Person
-              <select className="lag-role-control" name="personId" required defaultValue="" style={inputStyle}>
+            <label>Person
+              <select className="lag-role-control" name="personId" required defaultValue="">
                 <option value="" disabled>Select a Person</option>
                 {persons.map((person) => <option key={person.id} value={person.id}>{person.displayName}</option>)}
               </select>
             </label>
           )}
-          <label style={fieldLabel}>Relation Type<input className="lag-role-control" name="relationType" required defaultValue={editing?.relationType ?? ""} placeholder="e.g. FAMILY" style={inputStyle} /></label>
-          <label style={fieldLabel}>Role Notes<textarea className="lag-role-control" name="roleNotes" defaultValue={editing?.roleNotes ?? ""} rows={3} style={{ ...inputStyle, resize: "vertical" }} /></label>
-          <div className="flex gap-2">
-            <button type="submit" disabled={pending || (!editing && persons.length === 0)} style={secondaryButton}>{editing ? "Update Relation" : "Create Relation"}</button>
-            {editing ? <button type="button" style={secondaryButton} onClick={() => setEditing(null)}>Cancel Edit</button> : null}
+          <label>Relation Type<input className="lag-role-control" name="relationType" required defaultValue={editing?.relationType ?? ""} placeholder="e.g. FAMILY" /></label>
+          <label>Role Notes<textarea className="lag-role-control" name="roleNotes" defaultValue={editing?.roleNotes ?? ""} rows={3} /></label>
+          <div className="lag-role-actions">
+            <button type="submit" disabled={pending || (!editing && persons.length === 0)} className="lag-role-action">{editing ? "Update Relation" : "Create Relation"}</button>
+            {editing ? <button type="button" className="lag-role-button" onClick={() => setEditing(null)}>Cancel Edit</button> : null}
           </div>
         </form>
+        </div>
       </section>
     </div>
   );
@@ -322,15 +310,15 @@ function EventForm({ roleId, event, onSaved, onCancel }: { roleId: number; event
   };
 
   return (
-    <form className="space-y-3" onSubmit={submit}>
-      <label style={fieldLabel}>Title<input className="lag-role-control" name="title" required maxLength={120} defaultValue={event?.title ?? ""} style={inputStyle} /></label>
-      <label style={fieldLabel}>Description<textarea className="lag-role-control" name="description" maxLength={1000} defaultValue={event?.description ?? ""} rows={3} style={{ ...inputStyle, resize: "vertical" }} /></label>
-      <label style={fieldLabel}>Starts At<input className="lag-role-control" name="startsAt" type="datetime-local" defaultValue={toLocalDateTime(event?.startsAt ?? null)} style={inputStyle} /></label>
-      <label style={fieldLabel}>Ends At<input className="lag-role-control" name="endsAt" type="datetime-local" defaultValue={toLocalDateTime(event?.endsAt ?? null)} style={inputStyle} /></label>
-      {error ? <p role="alert" className="text-xs" style={{ color: "var(--lag-state-error)" }}>{error}</p> : null}
-      <div className="flex gap-2">
-        <button type="submit" disabled={pending} style={secondaryButton}>{event ? "Update Event" : "Save New Event"}</button>
-        <button type="button" style={secondaryButton} onClick={onCancel}>Cancel</button>
+    <form className="lag-role-form" onSubmit={submit}>
+      <label>Title<input className="lag-role-control" name="title" required maxLength={120} defaultValue={event?.title ?? ""} /></label>
+      <label>Description<textarea className="lag-role-control" name="description" maxLength={1000} defaultValue={event?.description ?? ""} rows={3} /></label>
+      <label>Starts At<input className="lag-role-control" name="startsAt" type="datetime-local" defaultValue={toLocalDateTime(event?.startsAt ?? null)} /></label>
+      <label>Ends At<input className="lag-role-control" name="endsAt" type="datetime-local" defaultValue={toLocalDateTime(event?.endsAt ?? null)} /></label>
+      {error ? <p role="alert" className="lag-role-feedback" data-state="error">{error}</p> : null}
+      <div className="lag-role-actions">
+        <button type="submit" disabled={pending} className="lag-role-action">{event ? "Update Event" : "Save New Event"}</button>
+        <button type="button" className="lag-role-button" onClick={onCancel}>Cancel</button>
       </div>
     </form>
   );
@@ -394,14 +382,15 @@ function EventsSurface({ roleId }: { roleId: number }) {
   if (error && events.length === 0) return <ErrorState message={error} onRetry={() => void load()} />;
 
   return (
-    <div className="space-y-4 px-3">
-      {error ? <p role="alert" className="text-xs" style={{ color: "var(--lag-state-error)" }}>{error}</p> : null}
-      <button type="button" style={actionBtnStyle} onClick={() => setFormEvent("create")}>Create Event</button>
-      <div className="space-y-2">
+    <div className="lag-role-detail lag-role-events">
+      {error ? <p role="alert" className="lag-role-feedback" data-state="error">{error}</p> : null}
+      <button type="button" className="lag-role-action" onClick={() => setFormEvent("create")}>Create Event</button>
+      <div className="lag-role-event-list" aria-label="Role Events">
         {events.length ? events.map((roleEvent) => (
-          <button key={roleEvent.id} type="button" className="w-full rounded-sm px-3 py-2 text-left" style={{ background: selectedEvent?.id === roleEvent.id ? "var(--lag-selected-surface)" : "var(--lag-control-bg)", border: `1px solid ${selectedEvent?.id === roleEvent.id ? "var(--lag-focus)" : "var(--lag-control-border)"}` }} onClick={() => void selectEvent(roleEvent.id)}>
-            <span className="block text-sm font-semibold" style={{ color: "var(--lag-text)" }}>{roleEvent.title}</span>
-            <span className="block text-xs" style={{ color: "var(--lag-text-2)" }}>{roleEvent.status}</span>
+          <button key={roleEvent.id} type="button" className="lag-role-event" data-selected={selectedEvent?.id === roleEvent.id} aria-pressed={selectedEvent?.id === roleEvent.id} onClick={() => void selectEvent(roleEvent.id)}>
+            <span aria-hidden>{roleEvent.status === "PLANNED" ? "○" : roleEvent.status === "COMPLETED" ? "✓" : "×"}</span>
+            <span><strong>{roleEvent.title}</strong><small>{roleEvent.status}</small></span>
+            <span aria-hidden>→</span>
           </button>
         )) : <InfoCard>No Events for this Role.</InfoCard>}
       </div>
@@ -409,25 +398,28 @@ function EventsSurface({ roleId }: { roleId: number }) {
       {formEvent ? (
         <EventForm key={formEvent === "create" ? "create" : `${formEvent.id}-${formEvent.version}`} roleId={roleId} event={formEvent === "create" ? null : formEvent} onSaved={saved} onCancel={() => setFormEvent(null)} />
       ) : selectedEvent ? (
-        <section className="space-y-2" aria-label="Event detail">
-          <InfoCard>{selectedEvent.description || "No description"}</InfoCard>
-          <GoldRow>Status: {selectedEvent.status}</GoldRow>
-          <GoldRow>Starts: {selectedEvent.startsAt || "Not set"}</GoldRow>
-          <GoldRow>Ends: {selectedEvent.endsAt || "Not set"}</GoldRow>
-          <div className="space-y-1">
-            <p style={fieldLabel}>Participants</p>
+        <section className="lag-role-section" aria-label="Event detail">
+          <h4>{selectedEvent.title}</h4>
+          <div className="lag-role-section-body">
+            <p className="lag-role-description">{selectedEvent.description || "No description"}</p>
+            <dl>
+              <RoleDataRow label="Status">{selectedEvent.status}</RoleDataRow>
+              <RoleDataRow label="Starts">{selectedEvent.startsAt || "Not set"}</RoleDataRow>
+              <RoleDataRow label="Ends">{selectedEvent.endsAt || "Not set"}</RoleDataRow>
+            </dl>
+            <h5 className="lag-role-subheading">Participants</h5>
             {selectedEvent.participants.length ? selectedEvent.participants.map((participant) => (
-              <GoldRow key={participant.participantLinkId}>{participant.participantType} #{participant.participantId}</GoldRow>
+              <div className="lag-role-record" key={participant.participantLinkId} data-kind="participant"><strong>{participant.participantType} #{participant.participantId}</strong></div>
             )) : <InfoCard>No participants.</InfoCard>}
-          </div>
-          <div className="flex flex-wrap gap-2">
-            <button type="button" style={secondaryButton} onClick={() => setFormEvent(selectedEvent)}>Edit Event</button>
+          <div className="lag-role-actions">
+            <button type="button" className="lag-role-button" onClick={() => setFormEvent(selectedEvent)}>Edit Event</button>
             {selectedEvent.status === "PLANNED" ? (
               <>
-                <button type="button" disabled={pending} style={secondaryButton} onClick={() => void transition("complete")}>Complete Event</button>
-                <button type="button" disabled={pending} style={secondaryButton} onClick={() => void transition("cancel")}>Cancel Event</button>
+                <button type="button" disabled={pending} className="lag-role-action" onClick={() => void transition("complete")}>Complete Event</button>
+                <button type="button" disabled={pending} className="lag-role-button" data-variant="destructive" onClick={() => void transition("cancel")}>Cancel Event</button>
               </>
             ) : null}
+          </div>
           </div>
         </section>
       ) : <InfoCard>Select an Event to load its detail.</InfoCard>}
@@ -438,19 +430,14 @@ function EventsSurface({ roleId }: { roleId: number }) {
 export default function RoleShell({
   roles,
   selectedRoleId,
-  isLoading,
-  error,
   onSelectRole,
   onRefresh,
 }: {
   roles: RoleDetail[];
   selectedRoleId: number | null;
-  isLoading: boolean;
-  error: string | null;
   onSelectRole: (roleId: number | null) => void;
   onRefresh: () => Promise<void>;
 }) {
-  const router = useRouter();
   const [surface, setSurface] = useState<RoleSurface | null>(null);
   const [surfaceRoleId, setSurfaceRoleId] = useState<number | null>(null);
   const [editingRoleId, setEditingRoleId] = useState<number | null>(null);
@@ -463,7 +450,23 @@ export default function RoleShell({
     setSurface(null);
     setSurfaceRoleId(null);
     setEditingRoleId((current) => current === selectedRoleId ? current : null);
+    setActionError(null);
   }, [selectedRoleId]);
+
+  const closeDetail = () => {
+    setSurface(null);
+    setSurfaceRoleId(null);
+    setEditingRoleId(null);
+    requestStageFocus("role-summary", "nearest");
+  };
+
+  const closeSummary = () => {
+    setSurface(null);
+    setSurfaceRoleId(null);
+    setEditingRoleId(null);
+    onSelectRole(null);
+    requestStageFocus("left-context", "nearest");
+  };
 
   const archiveRole = async (role: RoleDetail) => {
     if (!window.confirm(`Archive Role ${role.name}?`)) return;
@@ -478,48 +481,34 @@ export default function RoleShell({
   };
 
   return (
-    <div className="lag-panel-rail relative" data-testid="role-shell">
-      <PanelStage stageKey="role-list">
-        <PanelFrame title="Roles" depth={2}>
-        <div className="space-y-3">
-          <div className="px-3"><button type="button" style={actionBtnStyle} onClick={() => router.push("/roles/create")}>Create Role</button></div>
-          {isLoading ? <InfoCard>Loading Roles...</InfoCard> : null}
-          {error ? <ErrorState message={error} onRetry={() => void onRefresh()} /> : null}
-          {actionError ? <p role="alert" className="px-3 text-xs" style={{ color: "var(--lag-state-error)" }}>{actionError}</p> : null}
-          {!isLoading && !error && roles.length === 0 ? <InfoCard>No Roles yet. Create your first Role.</InfoCard> : null}
-          {roles.map((role, index) => (
-            <PanelCard
-              key={role.id}
-              label={role.name}
-              slotLabel={role.roleType.slice(0, 2).toUpperCase()}
-              subtitle={`${role.roleType} · ${role.status}`}
-              selected={selectedRoleId === role.id}
-              index={index}
-              actions={[{ type: "edit", label: "Edit" }, { type: "delete", label: "Archive" }]}
-              onClick={() => onSelectRole(role.id)}
-              onAction={(action) => {
-                if (action === "edit") {
-                  onSelectRole(role.id);
-                  setEditingRoleId(role.id);
-                } else {
-                  void archiveRole(role);
-                }
-              }}
-            />
-          ))}
-        </div>
-        </PanelFrame>
-      </PanelStage>
-
+    <div className="lag-panel-rail lag-role-shell relative" data-testid="role-shell">
       <AnimatePresence initial={false}>
         {selectedRole ? (
-          <PanelStage key="role-surfaces" stageKey="role-surfaces" focusKey={selectedRole.id} index={1}>
-            <PanelFrame title={selectedRole.name} depth={1} contentKey={selectedRole.id}>
-              <div className="grid gap-1">
-                {ROLE_SURFACES.map((item, index) => (
-                  <PanelCard key={item.id} label={item.label} slotLabel={item.slotLabel} selected={activeSurface === item.id} index={index} onClick={() => { setSurface(item.id); setSurfaceRoleId(selectedRole.id); setEditingRoleId(null); }} />
-                ))}
-              </div>
+          <PanelStage stageKey="role-summary" focusKey={selectedRole.id} index={1}>
+            <PanelFrame title={selectedRole.name} depth={1} contentKey={selectedRole.id} backButton={<BackButton label="Back to Role selector" onClick={closeSummary} />}>
+              <article className="lag-role-summary">
+                {actionError ? <p role="alert" className="lag-role-feedback" data-state="error">{actionError}</p> : null}
+                <header className="lag-role-hero">
+                  <span>Selected Role</span>
+                  <h4>{selectedRole.name}</h4>
+                  <div className="lag-role-badges"><span>{selectedRole.roleType}</span><span>{selectedRole.status}</span></div>
+                  <p>{selectedRole.description}</p>
+                </header>
+                <section className="lag-role-surface-grid" aria-label="Role surfaces">
+                  {ROLE_SURFACES.map((item) => (
+                    <button key={item.id} type="button" className="lag-role-surface-card" aria-pressed={activeSurface === item.id} data-selected={activeSurface === item.id} onClick={() => { setSurface(item.id); setSurfaceRoleId(selectedRole.id); setEditingRoleId(null); }}>
+                      <span aria-hidden>{item.slotLabel}</span>
+                      <strong>{item.label}</strong>
+                      <small>{item.id === "overview" ? "Real Role identity" : item.id === "relations" ? "Persons and Role Relations" : "RoleEvent lifecycle"}</small>
+                      <span aria-hidden>→</span>
+                    </button>
+                  ))}
+                </section>
+                <div className="lag-role-actions">
+                  <button type="button" className="lag-role-button" onClick={() => { setEditingRoleId(selectedRole.id); setSurface(null); setSurfaceRoleId(null); }}>Edit Role</button>
+                  <button type="button" className="lag-role-button" data-variant="destructive" onClick={() => void archiveRole(selectedRole)}>Archive Role</button>
+                </div>
+              </article>
             </PanelFrame>
           </PanelStage>
         ) : null}
@@ -527,10 +516,10 @@ export default function RoleShell({
 
       <AnimatePresence initial={false} mode="popLayout">
         {selectedRole && (editingRole || activeSurface) ? (
-          <PanelStage key="role-detail" stageKey="role-detail" focusKey={`${selectedRole.id}-${editingRole ? "edit" : activeSurface}`} index={2}>
-            <PanelFrame title={editingRole ? "Edit Role" : ROLE_SURFACES.find(({ id }) => id === activeSurface)?.label ?? "Role"} depth={0} contentKey={`${selectedRole.id}-${editingRole ? "edit" : activeSurface}`}>
+          <PanelStage stageKey="role-detail" focusKey={`${selectedRole.id}-${editingRole ? "edit" : activeSurface}`} index={2}>
+            <PanelFrame title={editingRole ? "Edit Role" : ROLE_SURFACES.find(({ id }) => id === activeSurface)?.label ?? "Role"} depth={0} contentKey={`${selectedRole.id}-${editingRole ? "edit" : activeSurface}`} backButton={<BackButton label={`Back to ${selectedRole.name}`} onClick={closeDetail} />}>
               {editingRole ? (
-                <RoleEditForm role={selectedRole} onSaved={async () => { await onRefresh(); setEditingRoleId(null); }} onCancel={() => setEditingRoleId(null)} />
+                <RoleEditForm role={selectedRole} onSaved={async () => { await onRefresh(); closeDetail(); }} onCancel={closeDetail} />
               ) : activeSurface === "overview" ? <Overview role={selectedRole} />
                 : activeSurface === "relations" ? <RelationsSurface roleId={selectedRole.id} />
                   : <EventsSurface roleId={selectedRole.id} />}

--- a/widgets/left-context/LeftContext.test.tsx
+++ b/widgets/left-context/LeftContext.test.tsx
@@ -46,6 +46,22 @@ describe("LeftContext에서 Role을 사용할 때", () => {
     expect(lane).toHaveAttribute("data-context-present", "true");
   });
 
+  it("Role mode에서 canonical Role Nodes selector를 유지하며 selection을 전달한다", () => {
+    const selectRole = vi.fn();
+    const { container, rerender } = render(
+      <LeftContext mode="role" roles={roles} selectedRoleId={null} socialContext={null} onRoleSelect={selectRole} />,
+    );
+    const selector = container.querySelector("[data-role-selector]");
+
+    fireEvent.click(screen.getByRole("button", { name: /Backend Engineer/ }));
+    expect(selectRole).toHaveBeenCalledWith(3);
+
+    rerender(<LeftContext mode="role" roles={roles} selectedRoleId={3} socialContext={null} onRoleSelect={selectRole} />);
+    expect(container.querySelector("[data-role-selector]")).toBe(selector);
+    expect(screen.getByRole("button", { name: /Backend Engineer/ })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("link", { name: "Create Role" })).toHaveAttribute("href", "/roles/create");
+  });
+
   it("keeps a stable collapsible lane and shared bounded content scroll", () => {
     const css = readFileSync("app/globals.css", "utf8");
     const { container, rerender } = render(

--- a/widgets/left-context/LeftContext.tsx
+++ b/widgets/left-context/LeftContext.tsx
@@ -24,6 +24,7 @@ type LeftContextProps = {
   selectedRoleId?: number | null;
   socialContext: SocialContextData | null;
   onRoleSelect?: (roleId: number) => void;
+  onRoleRetry?: () => void;
   zIndex?: number;
   onFocus?: () => void;
 };
@@ -39,6 +40,7 @@ export default function LeftContext({
   selectedRoleId,
   socialContext,
   onRoleSelect,
+  onRoleRetry,
   zIndex,
   onFocus,
 }: LeftContextProps) {
@@ -104,6 +106,7 @@ export default function LeftContext({
                   isLoading={rolesLoading}
                   error={rolesError}
                   onRoleSelect={onRoleSelect}
+                  onRetry={onRoleRetry}
                 />
               ) : (
                 <SocialPanel socialContext={socialContext} />

--- a/widgets/left-context/ui/RoleContextPanel.tsx
+++ b/widgets/left-context/ui/RoleContextPanel.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import Link from "next/link";
+
 import type { RoleDetail } from "@/shared/api/types";
 
 const cellStyle = {
@@ -39,26 +41,48 @@ export function RoleContextPanel({
   isLoading,
   error,
   onRoleSelect,
+  onRetry,
 }: {
   roles: RoleDetail[];
   selectedRoleId: number | null;
   isLoading?: boolean;
   error?: string | null;
   onRoleSelect?: (roleId: number) => void;
+  onRetry?: () => void;
 }) {
   return (
-    <div className="relative p-7">
-      <div className="text-center">
-        <p className="uppercase" style={{ fontSize: 11, letterSpacing: "0.24em", color: "var(--lag-text-2)" }}>ROLE CONTEXT</p>
-        <h2 className="mt-2 text-2xl font-semibold" style={{ letterSpacing: "0.08em", color: "var(--lag-text)" }}>My Roles</h2>
+    <section className="lag-role-selector" data-role-selector aria-labelledby="role-selector-title">
+      <header>
+        <p>Role context</p>
+        <h2 id="role-selector-title">Role Nodes</h2>
+        <span>Select one Role before choosing a deeper surface.</span>
+      </header>
+
+      <div className="lag-role-selector-state">
+        {isLoading ? <p role="status">Loading Roles...</p> : null}
+        {error ? (
+          <div>
+            <p role="alert">{error}</p>
+            {onRetry ? <button type="button" className="lag-role-button" onClick={onRetry}>Retry</button> : null}
+          </div>
+        ) : null}
+        {!isLoading && !error && roles.length === 0 ? <p>No Roles yet.</p> : null}
       </div>
 
-      <div className="mt-5">
-        {isLoading ? <p className="text-center text-sm" style={{ color: "var(--lag-text-2)" }}>Loading Roles...</p> : null}
-        {error ? <p role="alert" className="text-center text-xs" style={{ color: "var(--lag-state-error)" }}>{error}</p> : null}
-        {!isLoading && !error && roles.length === 0 ? <p className="text-center text-sm" style={{ color: "var(--lag-text-2)" }}>No Roles yet.</p> : null}
-        <RoleBadges roles={roles} selectedRoleId={selectedRoleId} onSelect={onRoleSelect} />
+      <div className="lag-role-node-list" aria-label="Role Nodes">
+        {roles.map((role) => {
+          const selected = selectedRoleId === role.id;
+          return (
+            <button key={role.id} type="button" className="lag-role-node" aria-pressed={selected} data-selected={selected} onClick={() => onRoleSelect?.(role.id)}>
+              <span className="lag-role-node-mark" aria-hidden>{role.name.trim().charAt(0).toUpperCase() || role.roleType.charAt(0).toUpperCase()}</span>
+              <span><strong>{role.name}</strong><small>{role.roleType} · {role.status}</small></span>
+              <span aria-hidden>→</span>
+            </button>
+          );
+        })}
       </div>
-    </div>
+
+      <Link href="/roles/create" className="lag-role-create">Create Role</Link>
+    </section>
   );
 }


### PR DESCRIPTION
## Purpose

Apply the approved Stage 3 Enterprise Dual Theme v7 Role visual direction while preserving the real Role, Person, RoleRelation, and RoleEvent domain boundaries.

Closes #58

## Delivered

- canonical v7 Role selector
- duplicate Role-list composition removal
- selected Role summary/surface hierarchy
- v7 Role Overview treatment
- semantic Role edit/create/archive controls
- v7 Person / RoleRelation presentation
- v7 RoleEvent list/detail/form presentation
- progressive Role staged disclosure
- stable Role-switch/reset behavior
- desktop Astral / Warm Beige Role fidelity
- mobile Astral / Warm Beige Role fidelity
- accessible semantic controls and state treatment

## Source of Truth

Reference-only visual authority:

```text
LifeAsGame_Stage3_UI_VisualDesigner_Enterprise_Dual_Theme_Result_v7
```

Primary Role references:

- DT7-05 Role Astral
- DT7-05 Role Warm Beige
- MT7-05 Role Astral
- MT7-05 Role Warm Beige
- shared v7 semantic/token handoff

Reference artifacts are not committed or shipped.

## Domain Authority

The approved Role screenshots contain visual sample metrics such as Knowledge, Consistency, Connection, and Confidence percentages.

Those values are not part of the current canonical Role contract and are intentionally not fabricated.

The implementation uses real Role data only:

- name
- roleType
- description
- status

Real RoleEvent data may be used for recent-event presentation where supported by the existing API.

## Role Composition

The existing Role LeftContext becomes the canonical Role-node selector rather than rendering an equivalent duplicate selector in the workspace.

Desktop:

```text
Role selector / context
-> selected Role
-> active Role surface
```

Mobile/compact preserves the same logical parent-child flow with one-screen-one-purpose navigation.

Selecting a Role does not automatically open Overview, Relations, or Events.

Changing Role clears stale deeper UI state.

## Person / RoleRelation

Person remains a private real-person record.

```text
Person != Service User
```

Optional linked-account metadata does not replace Person identity.

RoleRelation remains the explicit relation between a Role context and a Person.

Existing create/update/archive behavior is preserved.

## RoleEvent

RoleEvent remains event structure.

Existing create/update/complete/cancel behavior is preserved.

RoleEvent completion does not automatically create a LifeLog.

Role Chat is not introduced.

## Theme / Responsive Architecture

Astral and Warm Beige share one component tree.

The existing shared LeftContext geometry, mobile bottom OrbNav, and stage-camera foundation remain intact.

Global camera composition tuning remains deferred.

## Scope Boundaries

This PR does not implement:

- synthetic Role statistics
- Role ranking/scoring
- Role Chat
- automatic LifeLog generation
- Growth fidelity
- Inventory/Gear fidelity
- Connections/Direct Chat fidelity
- Notification fidelity
- Economy fidelity
- backend changes
- global camera retuning

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a redesigned role selector with selectable role nodes, status details, and role creation access.
  * Added staged role summaries with navigation, editing, relations, events, and archive actions.
  * Added retry controls for role-loading errors.
  * Added responsive layouts and reduced-motion support for role interfaces.

* **Bug Fixes**
  * Preserved unsaved edits when role updates fail, with Cancel navigation back to the summary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->