### PR TITLE
[Inventory] Apply approved v7 Inventory and Gear fidelity

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -165,7 +165,15 @@ body {
 .lag-role-button,
 .lag-role-surface-card,
 .lag-role-section,
-.lag-role-event {
+.lag-role-event,
+.lag-inventory-filter,
+.lag-inventory-tile,
+.lag-inventory-action,
+.lag-inventory-button,
+.lag-inventory-section,
+.lag-gear-part,
+.lag-gear-card,
+.lag-gear-section {
   transition:
     background-color var(--lag-motion-normal) ease,
     border-color var(--lag-motion-normal) ease,
@@ -830,6 +838,355 @@ body {
 .lag-role-button:not(:disabled):hover {
   border-color: var(--lag-focus);
   background: var(--lag-control-hover-bg);
+}
+
+/* v7 Inventory/Gear: real entry tiles and three-stage equipment flow. */
+.lag-inventory-shell [data-stage-key$="-list"] .lag-panel-frame {
+  width: min(700px, calc(100vw - 32px)) !important;
+}
+
+.lag-inventory-shell [data-stage-key$="-detail"] .lag-panel-frame {
+  width: min(620px, calc(100vw - 32px)) !important;
+}
+
+.lag-inventory-surface,
+.lag-inventory-detail,
+.lag-inventory-state,
+.lag-gear-parts,
+.lag-gear-action-detail {
+  display: grid;
+  gap: var(--lag-space-4);
+  padding-inline: var(--lag-space-4);
+}
+
+.lag-inventory-surface > header,
+.lag-gear-parts > header {
+  padding: var(--lag-space-3) var(--lag-space-4);
+  border: 1px solid var(--lag-divider);
+  border-left: 4px solid var(--lag-amber);
+  border-radius: var(--lag-radius-md);
+  background: var(--lag-muted-surface);
+  color: var(--lag-text-2);
+  font-size: 0.76rem;
+}
+
+.lag-inventory-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--lag-space-2);
+}
+
+.lag-inventory-filter {
+  min-height: 44px;
+  padding: var(--lag-space-1) var(--lag-space-3);
+  border: 1px solid var(--lag-control-border);
+  border-radius: 999px;
+  background: var(--lag-control-bg);
+  color: var(--lag-control-text);
+  font-size: 0.68rem;
+  font-weight: 700;
+}
+
+.lag-inventory-filter:hover,
+.lag-inventory-filter[data-selected="true"] {
+  border-color: var(--lag-focus);
+  background: var(--lag-control-hover-bg);
+}
+
+.lag-inventory-filter[data-selected="true"] {
+  box-shadow: inset 0 -3px 0 var(--lag-state-selected);
+}
+
+.lag-inventory-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: var(--lag-space-4);
+}
+
+.lag-inventory-tile {
+  display: grid;
+  min-height: 164px;
+  align-content: space-between;
+  gap: var(--lag-space-3);
+  padding: var(--lag-space-4);
+  border: 1px solid var(--lag-divider);
+  border-radius: var(--lag-radius-md);
+  background: var(--lag-muted-surface);
+  color: var(--lag-text);
+  text-align: left;
+}
+
+.lag-inventory-tile:hover,
+.lag-inventory-tile[data-selected="true"] {
+  border-color: var(--lag-focus);
+  background: var(--lag-control-hover-bg);
+}
+
+.lag-inventory-tile[data-selected="true"] {
+  box-shadow: inset 4px 0 0 var(--lag-state-selected);
+}
+
+.lag-inventory-tile-mark {
+  display: grid;
+  width: 62px;
+  height: 62px;
+  place-items: center;
+  justify-self: center;
+  border: 1px solid var(--lag-violet);
+  border-radius: 50%;
+  background: var(--lag-paper);
+  color: var(--lag-text);
+  font-size: 0.8rem;
+  font-weight: 700;
+}
+
+.lag-inventory-tile-copy {
+  display: grid;
+  min-width: 0;
+  gap: var(--lag-space-1);
+}
+
+.lag-inventory-tile-copy strong {
+  overflow-wrap: anywhere;
+  font-size: 0.82rem;
+}
+
+.lag-inventory-tile-copy span,
+.lag-inventory-tile-copy small {
+  overflow-wrap: anywhere;
+  color: var(--lag-text-2);
+  font-size: 0.68rem;
+}
+
+.lag-inventory-hero {
+  display: grid;
+  gap: var(--lag-space-3);
+  padding: var(--lag-space-4);
+  border: 1px solid var(--lag-border);
+  border-left: 4px solid var(--lag-violet);
+  border-radius: var(--lag-radius-md);
+  background: var(--lag-muted-surface);
+}
+
+.lag-inventory-hero > span:first-child,
+.lag-inventory-data-row dt {
+  color: var(--lag-text-2);
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.lag-inventory-hero h4 {
+  color: var(--lag-text);
+  font-size: 1.16rem;
+  font-weight: 700;
+}
+
+.lag-inventory-hero > div {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--lag-space-2);
+}
+
+.lag-inventory-hero > div span {
+  padding: var(--lag-space-1) var(--lag-space-2);
+  border: 1px solid var(--lag-control-border);
+  border-radius: 999px;
+  background: var(--lag-control-bg);
+  color: var(--lag-text-2);
+  font-size: 0.68rem;
+  font-weight: 700;
+}
+
+.lag-inventory-section,
+.lag-gear-section {
+  overflow: hidden;
+  border: 1px solid var(--lag-divider);
+  border-radius: var(--lag-radius-md);
+  background: var(--lag-panel);
+}
+
+.lag-inventory-section > h4,
+.lag-gear-section > h4 {
+  padding: var(--lag-space-3) var(--lag-space-4);
+  border-bottom: 1px solid var(--lag-divider);
+  background: var(--lag-panel-2);
+  color: var(--lag-text);
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.lag-inventory-section > dl,
+.lag-gear-section > div {
+  display: grid;
+  gap: var(--lag-space-2);
+  padding: var(--lag-space-4);
+}
+
+.lag-inventory-data-row {
+  display: grid;
+  grid-template-columns: minmax(130px, 0.72fr) minmax(0, 1.28fr);
+  gap: var(--lag-space-3);
+  padding-block: var(--lag-space-2);
+  border-bottom: 1px solid var(--lag-divider);
+}
+
+.lag-inventory-data-row:last-child {
+  border-bottom: 0;
+}
+
+.lag-inventory-data-row dd {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  color: var(--lag-text);
+  font-size: 0.78rem;
+}
+
+.lag-inventory-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--lag-space-3);
+}
+
+.lag-inventory-action,
+.lag-inventory-button {
+  display: inline-flex;
+  min-height: 44px;
+  align-items: center;
+  justify-content: center;
+  padding: var(--lag-space-2) var(--lag-space-4);
+  border: 1px solid var(--lag-control-border);
+  border-radius: var(--lag-radius-sm);
+  background: var(--lag-control-bg);
+  color: var(--lag-control-text);
+  font-size: 0.76rem;
+  font-weight: 700;
+}
+
+.lag-inventory-action {
+  border-color: var(--lag-violet);
+  background: color-mix(in srgb, var(--lag-violet) 12%, var(--lag-control-bg));
+}
+
+.lag-inventory-button[data-variant="destructive"] {
+  border-color: var(--lag-state-error);
+}
+
+.lag-inventory-action:not(:disabled):hover,
+.lag-inventory-button:not(:disabled):hover {
+  border-color: var(--lag-focus);
+  background: var(--lag-control-hover-bg);
+}
+
+.lag-inventory-feedback {
+  padding: var(--lag-space-3);
+  border: 1px solid var(--lag-state-info);
+  border-radius: var(--lag-radius-sm);
+  background: var(--lag-muted-surface);
+  color: var(--lag-text);
+  font-size: 0.76rem;
+}
+
+.lag-inventory-feedback[data-state="error"] {
+  border-color: var(--lag-state-error);
+  box-shadow: inset 4px 0 0 var(--lag-state-error);
+}
+
+.lag-gear-shell [data-stage-key="inventory-gear-parts"] .lag-panel-frame {
+  width: min(360px, calc(100vw - 32px)) !important;
+}
+
+.lag-gear-shell [data-stage-key="inventory-gear-workspace"] .lag-panel-frame {
+  width: min(780px, calc(100vw - 32px)) !important;
+}
+
+.lag-gear-shell [data-stage-key="inventory-gear-action"] .lag-panel-frame {
+  width: min(560px, calc(100vw - 32px)) !important;
+}
+
+.lag-gear-parts > div,
+.lag-gear-card-list {
+  display: grid;
+  gap: var(--lag-space-3);
+}
+
+.lag-gear-part,
+.lag-gear-card {
+  display: grid;
+  min-height: 76px;
+  grid-template-columns: 42px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: var(--lag-space-3);
+  padding: var(--lag-space-3);
+  border: 1px solid var(--lag-divider);
+  border-radius: var(--lag-radius-md);
+  background: var(--lag-muted-surface);
+  color: var(--lag-text);
+  text-align: left;
+}
+
+.lag-gear-part:hover,
+.lag-gear-card:hover,
+.lag-gear-part[data-selected="true"],
+.lag-gear-card[data-selected="true"] {
+  border-color: var(--lag-focus);
+  background: var(--lag-control-hover-bg);
+}
+
+.lag-gear-part[data-selected="true"],
+.lag-gear-card[data-selected="true"] {
+  box-shadow: inset 4px 0 0 var(--lag-state-selected);
+}
+
+.lag-gear-part > span:first-child,
+.lag-gear-card > span:first-child {
+  display: grid;
+  width: 38px;
+  height: 38px;
+  place-items: center;
+  border: 1px solid var(--lag-violet);
+  border-radius: 50%;
+  background: var(--lag-paper);
+  color: var(--lag-text-2);
+  font-size: 0.68rem;
+  font-weight: 700;
+}
+
+.lag-gear-part strong,
+.lag-gear-part small {
+  grid-column: 2;
+}
+
+.lag-gear-part small,
+.lag-gear-card small {
+  color: var(--lag-text-2);
+  font-size: 0.68rem;
+}
+
+.lag-gear-part > span:last-child {
+  grid-row: 1 / span 2;
+  grid-column: 3;
+}
+
+.lag-gear-card > span:nth-child(2) {
+  display: grid;
+  min-width: 0;
+  gap: var(--lag-space-1);
+}
+
+.lag-gear-card strong,
+.lag-gear-card small {
+  overflow-wrap: anywhere;
+}
+
+.lag-gear-workspace {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--lag-space-4);
+  padding-inline: var(--lag-space-4);
 }
 
 .lag-semantic-controls label {
@@ -1971,6 +2328,44 @@ textarea.lag-journal-control {
     width: 100%;
   }
 
+  .lag-inventory-shell [data-stage-key$="-list"] .lag-panel-frame,
+  .lag-inventory-shell [data-stage-key$="-detail"] .lag-panel-frame,
+  .lag-gear-shell [data-stage-key="inventory-gear-parts"] .lag-panel-frame,
+  .lag-gear-shell [data-stage-key="inventory-gear-workspace"] .lag-panel-frame,
+  .lag-gear-shell [data-stage-key="inventory-gear-action"] .lag-panel-frame {
+    width: clamp(280px, calc(100vw - 32px), 344px) !important;
+  }
+
+  .lag-inventory-surface,
+  .lag-inventory-detail,
+  .lag-inventory-state,
+  .lag-gear-parts,
+  .lag-gear-action-detail,
+  .lag-gear-workspace {
+    padding-inline: var(--lag-space-3);
+  }
+
+  .lag-inventory-grid {
+    grid-template-columns: repeat(auto-fill, minmax(128px, 1fr));
+    gap: var(--lag-space-3);
+  }
+
+  .lag-inventory-tile {
+    min-height: 154px;
+    padding: var(--lag-space-3);
+  }
+
+  .lag-inventory-data-row,
+  .lag-gear-workspace {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .lag-inventory-actions,
+  .lag-inventory-action,
+  .lag-inventory-button {
+    width: 100%;
+  }
+
   .lag-left-anchor {
     --lag-left-lane-width: clamp(280px, calc(100vw - 32px), 344px);
     position: static;
@@ -2073,6 +2468,17 @@ textarea.lag-journal-control {
   .lag-role-surface-card,
   .lag-role-section,
   .lag-role-event {
+    transition-duration: 0s;
+  }
+
+  .lag-inventory-filter,
+  .lag-inventory-tile,
+  .lag-inventory-action,
+  .lag-inventory-button,
+  .lag-inventory-section,
+  .lag-gear-part,
+  .lag-gear-card,
+  .lag-gear-section {
     transition-duration: 0s;
   }
 

--- a/features/inventory/GearShell.test.tsx
+++ b/features/inventory/GearShell.test.tsx
@@ -8,11 +8,6 @@ import GearShell from "./GearShell";
 const hook = vi.hoisted(() => ({ current: {} as ReturnType<typeof makeState> }));
 
 vi.mock("./useEquipmentQueries", () => ({ useEquipmentQueries: () => hook.current }));
-vi.mock("@/shared/ui/PanelCard", () => ({
-  default: ({ label, slotLabel, subtitle, disabled, onClick }: { label: string; slotLabel: string; subtitle?: string; disabled?: boolean; onClick?: () => void }) => (
-    <button type="button" disabled={disabled} onClick={onClick}>{label} · {slotLabel} · {subtitle}</button>
-  ),
-}));
 
 const currentBlade: InventoryEntry = {
   itemInstanceId: 501,
@@ -32,6 +27,7 @@ const currentBlade: InventoryEntry = {
 const newBlade: InventoryEntry = { ...currentBlade, itemInstanceId: 502, slotIndex: 2, itemId: 102, itemName: "New Blade", rarity: "EPIC" };
 const armor: InventoryEntry = { ...currentBlade, itemInstanceId: 601, slotIndex: 3, itemId: 201, itemName: "Chest Armor", category: "ARMOR", type: "CHEST" };
 const boots: InventoryEntry = { ...armor, itemInstanceId: 602, itemName: "Windrunner Boots", type: "ETC" };
+const incompatibleArmor: InventoryEntry = { ...armor, itemInstanceId: 603, itemName: "Wrong Armor", type: "RING" };
 const equipment: EquipmentSlotInfo[] = [
   { slotId: 21, slotCode: "MAIN_HAND", slotName: "Main Hand", slotCategory: "WEAPON", slotRole: "MAIN", itemInstanceId: null },
   { slotId: 22, slotCode: "OFF_HAND", slotName: "Off Hand", slotCategory: "WEAPON", slotRole: "OFFHAND", itemInstanceId: 501 },
@@ -51,6 +47,10 @@ function makeState(slotData = equipment, entries = [currentBlade, newBlade, armo
   };
 }
 
+function expectData(label: string, value: string) {
+  expect(screen.getByText(label).nextElementSibling).toHaveTextContent(value);
+}
+
 describe("Gear surface를 사용할 때", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -58,13 +58,44 @@ describe("Gear surface를 사용할 때", () => {
     hook.current = makeState();
   });
 
+  it("keeps Parts -> combined workspace -> Action within three stable stages and honors Back/reset", async () => {
+    render(<GearShell />);
+    expect(document.querySelectorAll('[data-stage-key^="inventory-gear-"]')).toHaveLength(1);
+
+    fireEvent.click(screen.getByRole("button", { name: /Weapon/ }));
+    const workspace = document.querySelector('[data-stage-key="inventory-gear-workspace"]');
+    expect(workspace).toBeInTheDocument();
+    expect(document.querySelectorAll('[data-stage-key^="inventory-gear-"]')).toHaveLength(2);
+    fireEvent.click(screen.getByRole("button", { name: /Main Hand/ }));
+    expect(document.querySelectorAll('[data-stage-key^="inventory-gear-"]')).toHaveLength(3);
+
+    fireEvent.click(screen.getByRole("button", { name: /New Blade/ }));
+    const action = document.querySelector('[data-stage-key="inventory-gear-action"]');
+    fireEvent.click(screen.getByRole("button", { name: /Current Blade.*itemInstanceId 501/ }));
+    expect(document.querySelector('[data-stage-key="inventory-gear-action"]')).toBe(action);
+
+    fireEvent.click(screen.getByRole("button", { name: "Back to Weapon Workspace" }));
+    await waitFor(() => expect(document.querySelector('[data-stage-key="inventory-gear-action"]')).not.toBeInTheDocument());
+    expect(document.querySelector('[data-stage-key="inventory-gear-workspace"]')).toBe(workspace);
+
+    fireEvent.click(screen.getByRole("button", { name: /Armor/ }));
+    expect(document.querySelector('[data-stage-key="inventory-gear-workspace"]')).toBe(workspace);
+    expect(document.querySelector('[data-stage-key="inventory-gear-action"]')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Back to Gear Parts" }));
+    await waitFor(() => expect(document.querySelector('[data-stage-key="inventory-gear-workspace"]')).not.toBeInTheDocument());
+  });
+
   describe("여러 Weapon slot 중 target을 선택해 교체하면", () => {
     it("명시한 empty slot과 candidate를 확인한 뒤 실제 slotId로 equip한다", () => {
       render(<GearShell />);
       expect(document.querySelector('[data-stage-key="inventory-gear-parts"]')).toBeInTheDocument();
-      expect(document.querySelector('[data-stage-key="inventory-gear-slots"]')).not.toBeInTheDocument();
+      expect(document.querySelector('[data-stage-key="inventory-gear-workspace"]')).not.toBeInTheDocument();
       fireEvent.click(screen.getByRole("button", { name: /Weapon/ }));
-      expect(document.querySelector('[data-stage-key="inventory-gear-slots"]')).toBeInTheDocument();
+      expect(document.querySelector('[data-stage-key="inventory-gear-workspace"]')).toBeInTheDocument();
+      expect(document.querySelector('[data-stage-key="inventory-gear-slots"]')).not.toBeInTheDocument();
+      expect(document.querySelector('[data-stage-key="inventory-gear-candidates"]')).not.toBeInTheDocument();
+      expect(screen.getByRole("region", { name: "Equipment Slots" })).toBeInTheDocument();
+      expect(screen.getByRole("region", { name: "Inventory Candidates" })).toBeInTheDocument();
       fireEvent.click(screen.getByRole("button", { name: /Main Hand/ }));
       fireEvent.click(screen.getByRole("button", { name: /New Blade/ }));
       fireEvent.click(screen.getByRole("button", { name: "Equip" }));
@@ -98,7 +129,7 @@ describe("Gear surface를 사용할 때", () => {
       expect(slot).not.toHaveTextContent("Empty");
       fireEvent.click(slot);
 
-      expect(screen.getByText("Equipped: Item details unavailable · itemInstanceId 999")).toBeInTheDocument();
+      expectData("Equipped", "Item details unavailable · itemInstanceId 999");
       fireEvent.click(screen.getByRole("button", { name: "Unequip" }));
 
       expect(window.confirm).toHaveBeenCalledWith("Unequip itemInstanceId 999 from Chest?");
@@ -112,7 +143,7 @@ describe("Gear surface를 사용할 때", () => {
       render(<GearShell />);
       fireEvent.click(screen.getByRole("button", { name: /Boots/ }));
       fireEvent.click(screen.getByRole("button", { name: /Feet/ }));
-      fireEvent.click(screen.getByRole("button", { name: /^Windrunner Boots · x1/ }));
+      fireEvent.click(screen.getByRole("button", { name: /Windrunner Boots.*itemInstanceId 602/ }));
 
       expect(screen.getByRole("alert")).toHaveTextContent("Compatibility is not available for this slot in the current item contract.");
       expect(screen.getByRole("button", { name: "Equip" })).toBeDisabled();
@@ -121,6 +152,17 @@ describe("Gear surface를 사용할 때", () => {
 
       fireEvent.click(screen.getByRole("button", { name: "Unequip" }));
       expect(hook.current.unequip).toHaveBeenCalledWith(41);
+    });
+
+    it("INCOMPATIBLE reason을 표시하고 Equip을 비활성화한다", () => {
+      hook.current = makeState(equipment, [currentBlade, newBlade, armor, incompatibleArmor]);
+      render(<GearShell />);
+      fireEvent.click(screen.getByRole("button", { name: /Armor/ }));
+      fireEvent.click(screen.getByRole("button", { name: /Chest.*itemInstanceId 999/ }));
+      fireEvent.click(screen.getByRole("button", { name: /Wrong Armor.*itemInstanceId 603/ }));
+
+      expect(screen.getByRole("alert")).toHaveTextContent("INCOMPATIBLE: This item is incompatible with the selected Equipment slot.");
+      expect(screen.getByRole("button", { name: "Equip" })).toBeDisabled();
     });
   });
 
@@ -157,16 +199,16 @@ describe("Gear surface를 사용할 때", () => {
       fireEvent.click(screen.getByRole("button", { name: /Weapon/ }));
       fireEvent.click(screen.getByRole("button", { name: /Off Hand/ }));
       fireEvent.click(screen.getByRole("button", { name: /New Blade/ }));
-      expect(screen.getByText(/Candidate: New Blade/)).toBeInTheDocument();
+      expectData("Candidate", "New Blade");
 
       hook.current = makeState(equipment, [currentBlade, armor]);
       rerender(<GearShell />);
-      await waitFor(() => expect(screen.getByText("Select an Inventory candidate to equip.")).toBeInTheDocument());
+      await waitFor(() => expectData("Candidate", "Select an Inventory candidate to equip."));
       expect(screen.getByRole("button", { name: "Equip" })).toBeDisabled();
 
       hook.current = makeState([equipment[0], equipment[2]], [currentBlade, armor]);
       rerender(<GearShell />);
-      await waitFor(() => expect(screen.queryByText("Slot ID: 22")).not.toBeInTheDocument());
+      await waitFor(() => expect(document.querySelector('[data-stage-key="inventory-gear-action"]')).not.toBeInTheDocument());
     });
   });
 });

--- a/features/inventory/GearShell.tsx
+++ b/features/inventory/GearShell.tsx
@@ -5,33 +5,24 @@ import { AnimatePresence } from "framer-motion";
 
 import { INVENTORY_GEAR_PARTS } from "@/entities/nav";
 import type { InventoryGearPartId } from "@/entities/nav";
-import { SAO } from "@/shared/design/tokens";
 import { requestStageFocus } from "@/shared/hooks/useStageCamera";
-import PanelCard from "@/shared/ui/PanelCard";
 import PanelStage from "@/shared/ui/PanelStage";
 import { BackButton, PanelFrame } from "@/widgets/right-panels/ui/PanelFrame";
-import { GoldRow, InfoCard } from "@/widgets/right-panels/ui/Rows";
-import { actionBtnStyle } from "@/widgets/right-panels/ui/styles";
+import { InfoCard } from "@/widgets/right-panels/ui/Rows";
 import { candidatesForGearPart, getEquipCompatibility, slotsForGearPart } from "./model";
 import { useEquipmentQueries } from "./useEquipmentQueries";
 
-const secondaryButton = {
-  border: `1px solid ${SAO.color.border.panel}`,
-  background: SAO.color.bg.inset,
-  color: SAO.color.text.secondary,
-  borderRadius: SAO.radius.panel,
-  padding: "7px 10px",
-  fontSize: "0.68rem",
-  letterSpacing: "0.08em",
-} as const;
-
 function ErrorState({ text, retry }: { text: string; retry: () => void }) {
   return (
-    <div className="space-y-2 px-3">
-      <p role="alert" className="text-xs" style={{ color: SAO.color.action.red }}>{text}</p>
-      <button type="button" style={secondaryButton} onClick={retry}>Retry</button>
+    <div className="lag-inventory-state">
+      <p role="alert" className="lag-inventory-feedback" data-state="error">{text}</p>
+      <button type="button" className="lag-inventory-button" onClick={retry}>Retry</button>
     </div>
   );
+}
+
+function DataRow({ label, children }: { label: string; children: React.ReactNode }) {
+  return <div className="lag-inventory-data-row"><dt>{label}</dt><dd>{children}</dd></div>;
 }
 
 export default function GearShell({ onBack }: { onBack?: () => void }) {
@@ -59,95 +50,97 @@ export default function GearShell({ onBack }: { onBack?: () => void }) {
     if (selectedItemInstanceId !== null && !candidates.some(({ itemInstanceId }) => itemInstanceId === selectedItemInstanceId)) setSelectedItemInstanceId(null);
   }, [candidates, selectedItemInstanceId]);
 
+  const selectPart = (next: InventoryGearPartId) => {
+    setPart(next);
+    setSelectedSlotId(null);
+    setSelectedItemInstanceId(null);
+  };
+
+  const closeWorkspace = () => {
+    setPart(null);
+    setSelectedSlotId(null);
+    setSelectedItemInstanceId(null);
+    requestStageFocus("inventory-gear-parts", "center");
+  };
+
+  const closeAction = () => {
+    setSelectedSlotId(null);
+    setSelectedItemInstanceId(null);
+    requestStageFocus("inventory-gear-workspace", "center");
+  };
+
   return (
-    <div className="lag-panel-rail relative" data-testid="gear-shell">
+    <div className="lag-panel-rail lag-gear-shell relative" data-testid="gear-shell">
       <PanelStage stageKey="inventory-gear-parts">
-        <PanelFrame title="Gear Parts" depth={3} backButton={onBack ? <BackButton label="Back to Inventory" onClick={onBack} /> : undefined}>
-        <div className="space-y-2">
-          {INVENTORY_GEAR_PARTS.map((item, index) => (
-            <PanelCard
-              key={item.id}
-              label={item.label}
-              slotLabel={item.slotLabel}
-              selected={part === item.id}
-              index={index}
-              onClick={() => {
-                setPart(item.id as InventoryGearPartId);
-                setSelectedSlotId(null);
-                setSelectedItemInstanceId(null);
-              }}
-            />
-          ))}
-        </div>
+        <PanelFrame title="Gear Parts" depth={2} backButton={onBack ? <BackButton label="Back to Inventory" onClick={onBack} /> : undefined}>
+          <section className="lag-gear-parts" aria-label="Gear Parts">
+            <header><p>Select the real equipment taxonomy before choosing a slot.</p></header>
+            <div>
+              {INVENTORY_GEAR_PARTS.map((item) => (
+                <button key={item.id} type="button" className="lag-gear-part" aria-pressed={part === item.id} data-selected={part === item.id} onClick={() => selectPart(item.id as InventoryGearPartId)}>
+                  <span aria-hidden>{item.slotLabel}</span>
+                  <strong>{item.label}</strong>
+                  <small>{item.id}</small>
+                  <span aria-hidden>→</span>
+                </button>
+              ))}
+            </div>
+          </section>
         </PanelFrame>
       </PanelStage>
 
       <AnimatePresence initial={false}>
         {part ? (
-          <PanelStage stageKey="inventory-gear-slots" focusKey={part} index={1}>
-            <PanelFrame title="Equipment Slots" depth={2} contentKey={part} backButton={<BackButton label="Back to Gear Parts" onClick={() => {
-              setPart(null);
-              setSelectedSlotId(null);
-              setSelectedItemInstanceId(null);
-              requestStageFocus("inventory-gear-parts", "center");
-            }} />}>
-          <div className="space-y-3">
-            {queries.equipment.loading && queries.equipment.data.length === 0 ? <InfoCard>Loading Equipment...</InfoCard> : null}
-            {queries.equipment.error ? <ErrorState text={queries.equipment.error} retry={() => void queries.equipment.reload()} /> : null}
-            {!queries.equipment.loading && !queries.equipment.error && slots.length === 0 ? <InfoCard>No matching Equipment slots.</InfoCard> : null}
-            <div className="space-y-2">
-              {slots.map(({ slot, item, enrichmentMissing }, index) => (
-                <PanelCard
-                  key={slot.slotId}
-                  label={slot.slotName}
-                  slotLabel={slot.slotRole.slice(0, 2)}
-                  subtitle={slot.itemInstanceId === null
-                    ? `${slot.slotCode} · Empty`
-                    : enrichmentMissing
-                      ? `${slot.slotCode} · Occupied · Item details unavailable · itemInstanceId ${slot.itemInstanceId}`
-                      : `${slot.slotCode} · ${item?.itemName} · ${item?.rarity}`}
-                  selected={selectedSlotId === slot.slotId}
-                  index={index}
-                  onClick={() => {
-                    setSelectedSlotId(slot.slotId);
-                    setSelectedItemInstanceId(null);
-                  }}
-                />
-              ))}
-            </div>
-          </div>
-            </PanelFrame>
-          </PanelStage>
-        ) : null}
-      </AnimatePresence>
+          <PanelStage stageKey="inventory-gear-workspace" focusKey={part} index={1}>
+            <PanelFrame title={`${INVENTORY_GEAR_PARTS.find(({ id }) => id === part)?.label ?? part} Workspace`} depth={1} contentKey={part} backButton={<BackButton label="Back to Gear Parts" onClick={closeWorkspace} />}>
+              <div className="lag-gear-workspace">
+                <section className="lag-gear-section" aria-labelledby="gear-slots-title">
+                  <h4 id="gear-slots-title">Equipment Slots</h4>
+                  <div>
+                    {queries.equipment.loading && queries.equipment.data.length === 0 ? <InfoCard>Loading Equipment...</InfoCard> : null}
+                    {queries.equipment.error ? <ErrorState text={queries.equipment.error} retry={() => void queries.equipment.reload()} /> : null}
+                    {!queries.equipment.loading && !queries.equipment.error && slots.length === 0 ? <InfoCard>No matching Equipment slots.</InfoCard> : null}
+                    <div className="lag-gear-card-list">
+                      {slots.map(({ slot, item, enrichmentMissing }) => (
+                        <button key={slot.slotId} type="button" className="lag-gear-card" data-kind="slot" data-selected={selectedSlotId === slot.slotId} aria-pressed={selectedSlotId === slot.slotId} onClick={() => {
+                          setSelectedSlotId(slot.slotId);
+                          setSelectedItemInstanceId(null);
+                        }}>
+                          <span aria-hidden>{slot.slotRole.slice(0, 2)}</span>
+                          <span>
+                            <strong>{slot.slotName}</strong>
+                            <small>{slot.slotCode} · {slot.slotCategory} · {slot.slotRole}</small>
+                            <small>{slot.itemInstanceId === null
+                              ? "Empty"
+                              : enrichmentMissing
+                                ? `Occupied · Item details unavailable · itemInstanceId ${slot.itemInstanceId}`
+                                : `${item?.itemName} · ${item?.rarity}`}</small>
+                          </span>
+                          <span aria-hidden>→</span>
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                </section>
 
-      <AnimatePresence initial={false}>
-        {part ? (
-          <PanelStage stageKey="inventory-gear-candidates" focusKey={part} index={2}>
-            <PanelFrame title="Inventory Candidates" depth={1} contentKey={part} backButton={<BackButton label="Back to Gear Parts" onClick={() => {
-              setPart(null);
-              setSelectedSlotId(null);
-              setSelectedItemInstanceId(null);
-              requestStageFocus("inventory-gear-parts", "center");
-            }} />}>
-          <div className="space-y-3">
-            {queries.inventory.loading && queries.inventory.data.entries.length === 0 ? <InfoCard>Loading Inventory candidates...</InfoCard> : null}
-            {queries.inventory.error ? <ErrorState text={queries.inventory.error} retry={() => void queries.inventory.reload()} /> : null}
-            {!queries.inventory.loading && !queries.inventory.error && candidates.length === 0 ? <InfoCard>No candidate Items.</InfoCard> : null}
-            <div className="space-y-2">
-              {candidates.map((item, index) => (
-                <PanelCard
-                  key={item.itemInstanceId}
-                  label={item.itemName}
-                  slotLabel={`x${item.quantity}`}
-                  subtitle={`${item.rarity} · ${item.category} · ${item.type}`}
-                  selected={selectedItemInstanceId === item.itemInstanceId}
-                  index={index}
-                  onClick={() => setSelectedItemInstanceId(item.itemInstanceId)}
-                />
-              ))}
-            </div>
-          </div>
+                <section className="lag-gear-section" aria-labelledby="gear-candidates-title">
+                  <h4 id="gear-candidates-title">Inventory Candidates</h4>
+                  <div>
+                    {queries.inventory.loading && queries.inventory.data.entries.length === 0 ? <InfoCard>Loading Inventory candidates...</InfoCard> : null}
+                    {queries.inventory.error ? <ErrorState text={queries.inventory.error} retry={() => void queries.inventory.reload()} /> : null}
+                    {!queries.inventory.loading && !queries.inventory.error && candidates.length === 0 ? <InfoCard>No candidate Items.</InfoCard> : null}
+                    <div className="lag-gear-card-list">
+                      {candidates.map((item) => (
+                        <button key={item.itemInstanceId} type="button" className="lag-gear-card" data-kind="candidate" data-selected={selectedItemInstanceId === item.itemInstanceId} aria-pressed={selectedItemInstanceId === item.itemInstanceId} onClick={() => setSelectedItemInstanceId(item.itemInstanceId)}>
+                          <span aria-hidden>x{item.quantity}</span>
+                          <span><strong>{item.itemName}</strong><small>{item.rarity} · {item.category} · {item.type}</small><small>itemInstanceId {item.itemInstanceId}</small></span>
+                          <span aria-hidden>→</span>
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                </section>
+              </div>
             </PanelFrame>
           </PanelStage>
         ) : null}
@@ -155,52 +148,66 @@ export default function GearShell({ onBack }: { onBack?: () => void }) {
 
       <AnimatePresence initial={false}>
         {selectedSlot ? (
-          <PanelStage stageKey="inventory-gear-action" focusKey={`${selectedSlot.slot.slotId}-${selectedCandidate?.itemInstanceId ?? "none"}`} index={3}>
-            <PanelFrame title="Gear Action" depth={0} contentKey={`${selectedSlot.slot.slotId}-${selectedCandidate?.itemInstanceId ?? "none"}`} backButton={<BackButton label="Back to Inventory Candidates" onClick={() => {
-              setSelectedSlotId(null);
-              setSelectedItemInstanceId(null);
-              requestStageFocus("inventory-gear-candidates", "center");
-            }} />}>
-          <div className="space-y-2 px-3">
-            <InfoCard>{selectedSlot.slot.slotName}</InfoCard>
-            <GoldRow>Slot ID: {selectedSlot.slot.slotId}</GoldRow>
-            <GoldRow>Slot code: {selectedSlot.slot.slotCode}</GoldRow>
-            <GoldRow>Category: {selectedSlot.slot.slotCategory}</GoldRow>
-            <GoldRow>Role: {selectedSlot.slot.slotRole}</GoldRow>
-            {selectedSlot.slot.itemInstanceId === null ? <GoldRow>Equipped: Empty</GoldRow> : null}
-            {selectedSlot.item ? <GoldRow>Equipped: {selectedSlot.item.itemName} · {selectedSlot.item.rarity}</GoldRow> : null}
-            {selectedSlot.enrichmentMissing ? <GoldRow>Equipped: Item details unavailable · itemInstanceId {selectedSlot.slot.itemInstanceId}</GoldRow> : null}
-            {selectedCandidate ? <GoldRow>Candidate: {selectedCandidate.itemName} · itemInstanceId {selectedCandidate.itemInstanceId}</GoldRow> : <InfoCard>Select an Inventory candidate to equip.</InfoCard>}
-            {compatibility && compatibility.status !== "VERIFIED" ? <p role="alert" className="text-xs" style={{ color: SAO.color.action.red }}>{compatibility.reason}</p> : null}
-            {queries.mutationError ? <p role="alert" className="text-xs" style={{ color: SAO.color.action.red }}>{queries.mutationError}</p> : null}
-            <div className="flex gap-2 pt-2">
-              <button
-                type="button"
-                disabled={pending || compatibility?.status !== "VERIFIED" || selectedSlot.slot.itemInstanceId === selectedCandidate?.itemInstanceId}
-                style={{ ...actionBtnStyle, flex: 1 }}
-                onClick={() => {
-                  if (!selectedCandidate || compatibility?.status !== "VERIFIED") return;
-                  const current = selectedSlot.item?.itemName
-                    ?? (selectedSlot.slot.itemInstanceId === null ? null : `itemInstanceId ${selectedSlot.slot.itemInstanceId}`);
-                  const prompt = current
-                    ? `Replace ${current} in ${selectedSlot.slot.slotName} with ${selectedCandidate.itemName}?`
-                    : `Equip ${selectedCandidate.itemName} to ${selectedSlot.slot.slotName}?`;
-                  if (window.confirm(prompt)) void queries.equip(selectedSlot.slot.slotId, selectedCandidate.itemInstanceId);
-                }}
-              >{pending ? "Working..." : "Equip"}</button>
-              {selectedSlot.slot.itemInstanceId !== null ? (
-                <button
-                  type="button"
-                  disabled={pending}
-                  style={secondaryButton}
-                  onClick={() => {
-                    const item = selectedSlot.item?.itemName ?? `itemInstanceId ${selectedSlot.slot.itemInstanceId}`;
-                    if (window.confirm(`Unequip ${item} from ${selectedSlot.slot.slotName}?`)) void queries.unequip(selectedSlot.slot.slotId);
-                  }}
-                >Unequip</button>
-              ) : null}
-            </div>
-          </div>
+          <PanelStage stageKey="inventory-gear-action" focusKey={`${selectedSlot.slot.slotId}-${selectedCandidate?.itemInstanceId ?? "none"}`} index={2}>
+            <PanelFrame title="Gear Action" depth={0} contentKey={`${selectedSlot.slot.slotId}-${selectedCandidate?.itemInstanceId ?? "none"}`} backButton={<BackButton label={`Back to ${INVENTORY_GEAR_PARTS.find(({ id }) => id === part)?.label ?? "Part"} Workspace`} onClick={closeAction} />}>
+              <article className="lag-gear-action-detail">
+                <header className="lag-inventory-hero">
+                  <span>Selected Equipment Slot</span>
+                  <h4>{selectedSlot.slot.slotName}</h4>
+                  <div><span>{selectedSlot.slot.slotCategory}</span><span>{selectedSlot.slot.slotRole}</span></div>
+                </header>
+                <section className="lag-inventory-section">
+                  <h4>Slot</h4>
+                  <dl>
+                    <DataRow label="Slot ID">{selectedSlot.slot.slotId}</DataRow>
+                    <DataRow label="Slot code">{selectedSlot.slot.slotCode}</DataRow>
+                    <DataRow label="Category">{selectedSlot.slot.slotCategory}</DataRow>
+                    <DataRow label="Role">{selectedSlot.slot.slotRole}</DataRow>
+                    <DataRow label="Equipped">{selectedSlot.slot.itemInstanceId === null
+                      ? "Empty"
+                      : selectedSlot.item
+                        ? `${selectedSlot.item.itemName} · ${selectedSlot.item.rarity}`
+                        : `Item details unavailable · itemInstanceId ${selectedSlot.slot.itemInstanceId}`}</DataRow>
+                  </dl>
+                </section>
+                <section className="lag-inventory-section">
+                  <h4>Candidate and compatibility</h4>
+                  <dl>
+                    <DataRow label="Candidate">{selectedCandidate ? `${selectedCandidate.itemName} · itemInstanceId ${selectedCandidate.itemInstanceId}` : "Select an Inventory candidate to equip."}</DataRow>
+                    <DataRow label="Compatibility">{compatibility?.status ?? "Not evaluated"}</DataRow>
+                  </dl>
+                </section>
+                {compatibility && compatibility.status !== "VERIFIED" ? <p role="alert" className="lag-inventory-feedback" data-state="error">{compatibility.status}: {compatibility.reason}</p> : null}
+                {queries.mutationError ? <p role="alert" className="lag-inventory-feedback" data-state="error">{queries.mutationError}</p> : null}
+                <div className="lag-inventory-actions">
+                  <button
+                    type="button"
+                    disabled={pending || compatibility?.status !== "VERIFIED" || selectedSlot.slot.itemInstanceId === selectedCandidate?.itemInstanceId}
+                    className="lag-inventory-action"
+                    onClick={() => {
+                      if (!selectedCandidate || compatibility?.status !== "VERIFIED") return;
+                      const current = selectedSlot.item?.itemName
+                        ?? (selectedSlot.slot.itemInstanceId === null ? null : `itemInstanceId ${selectedSlot.slot.itemInstanceId}`);
+                      const prompt = current
+                        ? `Replace ${current} in ${selectedSlot.slot.slotName} with ${selectedCandidate.itemName}?`
+                        : `Equip ${selectedCandidate.itemName} to ${selectedSlot.slot.slotName}?`;
+                      if (window.confirm(prompt)) void queries.equip(selectedSlot.slot.slotId, selectedCandidate.itemInstanceId);
+                    }}
+                  >{pending ? "Working..." : "Equip"}</button>
+                  {selectedSlot.slot.itemInstanceId !== null ? (
+                    <button
+                      type="button"
+                      disabled={pending}
+                      className="lag-inventory-button"
+                      data-variant="destructive"
+                      onClick={() => {
+                        const item = selectedSlot.item?.itemName ?? `itemInstanceId ${selectedSlot.slot.itemInstanceId}`;
+                        if (window.confirm(`Unequip ${item} from ${selectedSlot.slot.slotName}?`)) void queries.unequip(selectedSlot.slot.slotId);
+                      }}
+                    >Unequip</button>
+                  ) : null}
+                </div>
+              </article>
             </PanelFrame>
           </PanelStage>
         ) : null}

--- a/features/inventory/InventoryShell.test.tsx
+++ b/features/inventory/InventoryShell.test.tsx
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -13,11 +14,6 @@ const api = vi.hoisted(() => ({
 }));
 
 vi.mock("@/lib/api/endpoints/inventory.api", () => api);
-vi.mock("@/shared/ui/PanelCard", () => ({
-  default: ({ label, slotLabel, subtitle, onClick }: { label: string; slotLabel: string; subtitle?: string; onClick?: () => void }) => (
-    <button type="button" data-testid="inventory-entry" onClick={onClick}>{label} · {slotLabel} · {subtitle}</button>
-  ),
-}));
 
 const item: InventoryEntry = {
   itemInstanceId: 501,
@@ -35,6 +31,7 @@ const item: InventoryEntry = {
   instanceAttrs: { atk: 12 },
 };
 const secondItem: InventoryEntry = { ...item, itemInstanceId: 502, slotIndex: 3, itemId: 102, itemName: "Second Sword" };
+const utilityItem: InventoryEntry = { ...item, itemInstanceId: 503, slotIndex: 4, itemId: 103, itemName: "Server Utility", category: "CONSUMABLE", type: "ETC", rarity: "COMMON", instanceAttrs: { active: false, nested: { source: "server" }, tags: ["a", "b"] } };
 
 const mail: MailEntry = {
   mailId: 701,
@@ -61,6 +58,10 @@ function deferred<T>() {
   return { promise, resolve };
 }
 
+function expectData(label: string, value: string) {
+  expect(screen.getByText(label).nextElementSibling).toHaveTextContent(value);
+}
+
 describe("Inventory Items와 Inbox surface를 사용할 때", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -71,7 +72,47 @@ describe("Inventory Items와 Inbox surface를 사용할 때", () => {
     api.deleteMailApi.mockResolvedValue(undefined);
   });
 
+  it("uses semantic Inventory/Gear classes without screenshot-only data or theme branches", () => {
+    const inventorySource = readFileSync("features/inventory/InventoryShell.tsx", "utf8");
+    const gearSource = readFileSync("features/inventory/GearShell.tsx", "utf8");
+    expect(`${inventorySource}\n${gearSource}`).not.toMatch(/SAO|PanelCard|GoldRow|MK300|Telecaster|Notebook|Owned Lv\.|MEMORY filter|LETTER filter|data-theme/i);
+
+    const css = readFileSync("app/globals.css", "utf8");
+    const fidelityCss = css.slice(css.indexOf("/* v7 Inventory/Gear"), css.indexOf(".lag-semantic-controls"));
+    expect(fidelityCss).toContain("repeat(auto-fill, minmax(150px, 1fr))");
+    expect(fidelityCss).not.toMatch(/#[0-9a-f]{3,8}|rgba?\(/i);
+  });
+
   describe("Items를 조회하고 itemInstanceId로 선택하면", () => {
+    it("real category에서 filter를 만들고 즉시 적용하며 제외된 detail을 닫는다", async () => {
+      api.getInventoryApi.mockResolvedValue({ entries: [item, secondItem, utilityItem] });
+      render(<InventoryShell surface="items" />);
+
+      expect(await screen.findAllByTestId("inventory-entry")).toHaveLength(3);
+      expect(screen.getByRole("button", { name: "ALL" })).toHaveAttribute("aria-pressed", "true");
+      expect(screen.getByRole("button", { name: "CONSUMABLE" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "WEAPON" })).toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: "MEMORY" })).not.toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole("button", { name: /Server Sword/ }));
+      expect(document.querySelector('[data-stage-key="inventory-items-detail"]')).toBeInTheDocument();
+      fireEvent.click(screen.getByRole("button", { name: "CONSUMABLE" }));
+
+      expect(screen.getAllByTestId("inventory-entry")).toHaveLength(1);
+      expect(screen.getByRole("button", { name: /Server Utility/ })).toBeInTheDocument();
+      await waitFor(() => expect(document.querySelector('[data-stage-key="inventory-items-detail"]')).not.toBeInTheDocument());
+    });
+
+    it("primitive와 nested instanceAttrs를 안전한 key/value로 표시한다", async () => {
+      api.getInventoryApi.mockResolvedValue({ entries: [utilityItem] });
+      render(<InventoryShell surface="items" />);
+      fireEvent.click(await screen.findByRole("button", { name: /Server Utility/ }));
+
+      expectData("active", "false");
+      expectData("nested", '{"source":"server"}');
+      expectData("tags", '["a","b"]');
+    });
+
     it("loading 후 server list/detail을 표시하고 generic sell/remove action은 노출하지 않는다", async () => {
       const response = deferred<InventoryEntriesResponse>();
       api.getInventoryApi.mockReturnValue(response.promise);
@@ -87,9 +128,9 @@ describe("Inventory Items와 Inbox surface를 사용할 때", () => {
       fireEvent.click(await screen.findByRole("button", { name: /Server Sword/ }));
 
       expect(document.querySelector('[data-stage-key="inventory-items-detail"]')).toBeInTheDocument();
-      expect(screen.getByText("Item instance ID: 501")).toBeInTheDocument();
-      expect(screen.getByText("Durability: 0")).toBeInTheDocument();
-      expect(screen.getByText(/Instance attrs:.*"atk":12/)).toBeInTheDocument();
+      expectData("Item instance ID", "501");
+      expectData("Durability", "0");
+      expectData("atk", "12");
       expect(screen.queryByRole("button", { name: /sell|remove/i })).not.toBeInTheDocument();
     });
 
@@ -116,7 +157,7 @@ describe("Inventory Items와 Inbox surface를 사용할 때", () => {
       expect(detail).toBeInTheDocument();
       fireEvent.click(entries[1]);
       expect(document.querySelector('[data-stage-key="inventory-items-detail"]')).toBe(detail);
-      expect(screen.getByText("Item instance ID: 502")).toBeInTheDocument();
+      expectData("Item instance ID", "502");
 
       focus.mockClear();
       fireEvent.click(screen.getByRole("button", { name: "Back to Items" }));
@@ -135,6 +176,19 @@ describe("Inventory Items와 Inbox surface를 사용할 때", () => {
   });
 
   describe("Inbox를 조회하고 mailId로 선택하면", () => {
+    it("mail 교체는 stable detail frame 안의 content만 바꾼다", async () => {
+      const secondMail = { ...mail, mailId: 702, slotIndex: 5, itemId: 302, itemName: "Second Server Mail" };
+      api.getMailboxApi.mockResolvedValue({ entries: [mail, secondMail] });
+      render(<InventoryShell surface="inbox" />);
+
+      fireEvent.click(await screen.findByRole("button", { name: /Server Potion/ }));
+      const detail = document.querySelector('[data-stage-key="inventory-inbox-detail"]');
+      fireEvent.click(screen.getByRole("button", { name: /Second Server Mail/ }));
+
+      expect(document.querySelector('[data-stage-key="inventory-inbox-detail"]')).toBe(detail);
+      expectData("Mail ID", "702");
+    });
+
     it("loading 후 server list/detail과 nullable durability를 표시한다", async () => {
       const response = deferred<MailboxEntriesResponse>();
       api.getMailboxApi.mockReturnValue(response.promise);
@@ -147,9 +201,9 @@ describe("Inventory Items와 Inbox surface를 사용할 때", () => {
       });
       fireEvent.click(await screen.findByRole("button", { name: /Server Potion/ }));
 
-      expect(screen.getByText("Mail ID: 701")).toBeInTheDocument();
-      expect(screen.getByText("Slot index: 4")).toBeInTheDocument();
-      expect(screen.getByText("Durability: Not recorded")).toBeInTheDocument();
+      expectData("Mail ID", "701");
+      expectData("Slot index", "4");
+      expectData("Durability", "Not recorded");
     });
 
     it("error의 Retry가 authoritative empty Inbox state를 표시한다", async () => {

--- a/features/inventory/InventoryShell.tsx
+++ b/features/inventory/InventoryShell.tsx
@@ -1,84 +1,132 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { AnimatePresence } from "framer-motion";
 
 import type { InventoryEntry, MailEntry } from "@/shared/api/types";
-import { SAO } from "@/shared/design/tokens";
 import { requestStageFocus } from "@/shared/hooks/useStageCamera";
-import PanelCard from "@/shared/ui/PanelCard";
 import PanelStage from "@/shared/ui/PanelStage";
 import { BackButton, PanelFrame } from "@/widgets/right-panels/ui/PanelFrame";
-import { GoldRow, InfoCard } from "@/widgets/right-panels/ui/Rows";
-import { actionBtnStyle } from "@/widgets/right-panels/ui/styles";
+import { InfoCard } from "@/widgets/right-panels/ui/Rows";
 import { useInventoryQueries } from "./useInventoryQueries";
 
 export type InventorySurface = "items" | "inbox";
 
-const secondaryButton = {
-  border: `1px solid ${SAO.color.border.panel}`,
-  background: SAO.color.bg.inset,
-  color: SAO.color.text.secondary,
-  borderRadius: SAO.radius.panel,
-  padding: "7px 10px",
-  fontSize: "0.68rem",
-  letterSpacing: "0.08em",
-} as const;
-
 function ErrorState({ text, retry }: { text: string; retry: () => void }) {
   return (
-    <div className="space-y-2 px-3">
-      <p role="alert" className="text-xs" style={{ color: SAO.color.action.red }}>{text}</p>
-      <button type="button" style={secondaryButton} onClick={retry}>Retry</button>
+    <div className="lag-inventory-state">
+      <p role="alert" className="lag-inventory-feedback" data-state="error">{text}</p>
+      <button type="button" className="lag-inventory-button" onClick={retry}>Retry</button>
     </div>
   );
 }
 
-function Attrs({ attrs }: { attrs: Record<string, unknown> }) {
-  return <GoldRow>Instance attrs: {Object.keys(attrs).length > 0 ? JSON.stringify(attrs) : "None"}</GoldRow>;
+function DataRow({ label, children }: { label: string; children: React.ReactNode }) {
+  return <div className="lag-inventory-data-row"><dt>{label}</dt><dd>{children}</dd></div>;
+}
+
+function DetailSection({ title, children }: { title: string; children: React.ReactNode }) {
+  return <section className="lag-inventory-section"><h4>{title}</h4><dl>{children}</dl></section>;
+}
+
+function attributeValue(value: unknown): string {
+  if (value === null) return "None";
+  if (["string", "number", "boolean"].includes(typeof value)) return String(value);
+  try {
+    const readable = JSON.stringify(value);
+    return readable ?? "Unsupported value";
+  } catch {
+    return "Unsupported nested value";
+  }
+}
+
+function Attributes({ attrs }: { attrs: Record<string, unknown> }) {
+  const entries = Object.entries(attrs);
+  return (
+    <DetailSection title="Instance attributes">
+      {entries.length > 0
+        ? entries.map(([key, value]) => <DataRow key={key} label={key}>{attributeValue(value)}</DataRow>)
+        : <DataRow label="Attributes">None</DataRow>}
+    </DetailSection>
+  );
+}
+
+function InventoryTile({ entry, selected, kind, onSelect }: { entry: InventoryEntry | MailEntry; selected: boolean; kind: "item" | "mail"; onSelect: () => void }) {
+  return (
+    <button type="button" className="lag-inventory-tile" data-testid="inventory-entry" data-selected={selected} aria-pressed={selected} onClick={onSelect}>
+      <span className="lag-inventory-tile-mark" aria-hidden>x{entry.quantity}</span>
+      <span className="lag-inventory-tile-copy">
+        <strong>{entry.itemName}</strong>
+        <span>{entry.rarity} · {entry.category}</span>
+        <small>{entry.type}{kind === "item" && entry.bound ? " · Bound" : ""}</small>
+      </span>
+      <span aria-hidden>→</span>
+    </button>
+  );
 }
 
 function ItemDetail({ item }: { item: InventoryEntry }) {
   return (
-    <div className="space-y-1.5 px-3">
-      <InfoCard>{item.itemName}</InfoCard>
-      <GoldRow>Item instance ID: {item.itemInstanceId}</GoldRow>
-      <GoldRow>Slot index: {item.slotIndex}</GoldRow>
-      <GoldRow>Item ID: {item.itemId}</GoldRow>
-      <GoldRow>Category: {item.category}</GoldRow>
-      <GoldRow>Type: {item.type}</GoldRow>
-      <GoldRow>Rarity: {item.rarity}</GoldRow>
-      <GoldRow>Quantity: {item.quantity}</GoldRow>
-      <GoldRow>Stackable: {String(item.stackable)}</GoldRow>
-      <GoldRow>Max stack: {item.maxStack}</GoldRow>
-      <GoldRow>Bound: {String(item.bound)}</GoldRow>
-      <GoldRow>Durability: {item.durability ?? "Not recorded"}</GoldRow>
-      <Attrs attrs={item.instanceAttrs} />
-    </div>
+    <article className="lag-inventory-detail">
+      <header className="lag-inventory-hero">
+        <span>Inventory Entry</span>
+        <h4>{item.itemName}</h4>
+        <div><span>{item.rarity}</span><span>{item.category}</span><span>{item.type}</span></div>
+      </header>
+      <DetailSection title="Identity">
+        <DataRow label="Item instance ID">{item.itemInstanceId}</DataRow>
+        <DataRow label="Item ID">{item.itemId}</DataRow>
+        <DataRow label="Item name">{item.itemName}</DataRow>
+      </DetailSection>
+      <DetailSection title="Inventory">
+        <DataRow label="Slot index">{item.slotIndex}</DataRow>
+        <DataRow label="Quantity">{item.quantity}</DataRow>
+        <DataRow label="Stackable">{String(item.stackable)}</DataRow>
+        <DataRow label="Max stack">{item.maxStack}</DataRow>
+        <DataRow label="Bound">{String(item.bound)}</DataRow>
+      </DetailSection>
+      <DetailSection title="Classification">
+        <DataRow label="Category">{item.category}</DataRow>
+        <DataRow label="Type">{item.type}</DataRow>
+        <DataRow label="Rarity">{item.rarity}</DataRow>
+      </DetailSection>
+      <DetailSection title="Condition">
+        <DataRow label="Durability">{item.durability ?? "Not recorded"}</DataRow>
+      </DetailSection>
+      <Attributes attrs={item.instanceAttrs} />
+    </article>
   );
 }
 
 function MailDetail({ mail, pending, onClaim, onDelete }: { mail: MailEntry; pending: boolean; onClaim: () => void; onDelete: () => void }) {
   return (
-    <div className="space-y-1.5 px-3">
-      <InfoCard>{mail.itemName}</InfoCard>
-      <GoldRow>Mail ID: {mail.mailId}</GoldRow>
-      <GoldRow>Slot index: {mail.slotIndex}</GoldRow>
-      <GoldRow>Item ID: {mail.itemId}</GoldRow>
-      <GoldRow>Category: {mail.category}</GoldRow>
-      <GoldRow>Type: {mail.type}</GoldRow>
-      <GoldRow>Rarity: {mail.rarity}</GoldRow>
-      <GoldRow>Quantity: {mail.quantity}</GoldRow>
-      <GoldRow>Stackable: {String(mail.stackable)}</GoldRow>
-      <GoldRow>Max stack: {mail.maxStack}</GoldRow>
-      <GoldRow>Bound: {String(mail.bound)}</GoldRow>
-      <GoldRow>Durability: {mail.durability ?? "Not recorded"}</GoldRow>
-      <Attrs attrs={mail.instanceAttrs} />
-      <div className="flex gap-2 pt-2">
-        <button type="button" disabled={pending} style={{ ...actionBtnStyle, flex: 1 }} onClick={onClaim}>{pending ? "Working..." : "Claim"}</button>
-        <button type="button" disabled={pending} style={secondaryButton} onClick={onDelete}>Delete</button>
+    <article className="lag-inventory-detail">
+      <header className="lag-inventory-hero">
+        <span>Inbox Entry · Not yet owned</span>
+        <h4>{mail.itemName}</h4>
+        <div><span>{mail.rarity}</span><span>{mail.category}</span><span>{mail.type}</span></div>
+      </header>
+      <DetailSection title="Mail identity">
+        <DataRow label="Mail ID">{mail.mailId}</DataRow>
+        <DataRow label="Slot index">{mail.slotIndex}</DataRow>
+        <DataRow label="Item ID">{mail.itemId}</DataRow>
+      </DetailSection>
+      <DetailSection title="Item data">
+        <DataRow label="Category">{mail.category}</DataRow>
+        <DataRow label="Type">{mail.type}</DataRow>
+        <DataRow label="Rarity">{mail.rarity}</DataRow>
+        <DataRow label="Quantity">{mail.quantity}</DataRow>
+        <DataRow label="Stackable">{String(mail.stackable)}</DataRow>
+        <DataRow label="Max stack">{mail.maxStack}</DataRow>
+        <DataRow label="Bound">{String(mail.bound)}</DataRow>
+        <DataRow label="Durability">{mail.durability ?? "Not recorded"}</DataRow>
+      </DetailSection>
+      <Attributes attrs={mail.instanceAttrs} />
+      <div className="lag-inventory-actions">
+        <button type="button" disabled={pending} className="lag-inventory-action" onClick={onClaim}>{pending ? "Working..." : "Claim"}</button>
+        <button type="button" disabled={pending} className="lag-inventory-button" data-variant="destructive" onClick={onDelete}>Delete</button>
       </div>
-    </div>
+    </article>
   );
 }
 
@@ -86,7 +134,15 @@ export default function InventoryShell({ surface, onBack }: { surface: Inventory
   const queries = useInventoryQueries();
   const [selectedItemInstanceId, setSelectedItemInstanceId] = useState<number | null>(null);
   const [selectedMailId, setSelectedMailId] = useState<number | null>(null);
+  const [category, setCategory] = useState("ALL");
   const items = surface === "items";
+  const categories = useMemo(
+    () => Array.from(new Set(queries.inventory.data.entries.map((entry) => entry.category))).sort(),
+    [queries.inventory.data.entries],
+  );
+  const visibleItems = category === "ALL"
+    ? queries.inventory.data.entries
+    : queries.inventory.data.entries.filter((entry) => entry.category === category);
   const selectedItem = items ? queries.inventory.data.entries.find(({ itemInstanceId }) => itemInstanceId === selectedItemInstanceId) ?? null : null;
   const selectedMail = items ? null : queries.mailbox.data.entries.find(({ mailId }) => mailId === selectedMailId) ?? null;
   const query = items ? queries.inventory : queries.mailbox;
@@ -96,52 +152,57 @@ export default function InventoryShell({ surface, onBack }: { surface: Inventory
     setSelectedMailId(null);
   }, [surface]);
 
+  useEffect(() => {
+    if (category !== "ALL" && !categories.includes(category)) {
+      setCategory("ALL");
+      setSelectedItemInstanceId(null);
+    } else if (category !== "ALL" && selectedItemInstanceId !== null && !queries.inventory.data.entries.some((entry) => entry.itemInstanceId === selectedItemInstanceId && entry.category === category)) {
+      setSelectedItemInstanceId(null);
+    }
+  }, [categories, category, queries.inventory.data.entries, selectedItemInstanceId]);
+
+  const selectCategory = (next: string) => {
+    setCategory(next);
+    if (selectedItem && next !== "ALL" && selectedItem.category !== next) setSelectedItemInstanceId(null);
+  };
+
+  const closeDetail = () => {
+    setSelectedItemInstanceId(null);
+    setSelectedMailId(null);
+    requestStageFocus(`inventory-${surface}-list`, "center");
+  };
+
   return (
-    <div className="lag-panel-rail relative" data-testid="inventory-shell">
+    <div className="lag-panel-rail lag-inventory-shell relative" data-testid="inventory-shell">
       <PanelStage stageKey={`inventory-${surface}-list`}>
         <PanelFrame title={items ? "Items" : "Inbox"} depth={1} backButton={onBack ? <BackButton label="Back to Inventory" onClick={onBack} /> : undefined}>
-        <div className="space-y-3">
-          {query.loading && query.data.entries.length === 0 ? <InfoCard>Loading {items ? "Items" : "Inbox"}...</InfoCard> : null}
-          {query.error ? <ErrorState text={query.error} retry={() => void query.reload()} /> : null}
-          {!query.loading && !query.error && query.data.entries.length === 0 ? <InfoCard>No {items ? "Items" : "mail"}.</InfoCard> : null}
-          {queries.mutationError ? <p role="alert" className="px-3 text-xs" style={{ color: SAO.color.action.red }}>{queries.mutationError}</p> : null}
-          <div className="space-y-2">
-            {items
-              ? queries.inventory.data.entries.map((item, index) => (
-                <PanelCard
-                  key={item.itemInstanceId}
-                  label={item.itemName}
-                  slotLabel={`x${item.quantity}`}
-                  subtitle={`${item.rarity} · ${item.category} · ${item.type} · Slot ${item.slotIndex}`}
-                  selected={selectedItemInstanceId === item.itemInstanceId}
-                  index={index}
-                  onClick={() => setSelectedItemInstanceId(item.itemInstanceId)}
-                />
-              ))
-              : queries.mailbox.data.entries.map((mail, index) => (
-                <PanelCard
-                  key={mail.mailId}
-                  label={mail.itemName}
-                  slotLabel={`x${mail.quantity}`}
-                  subtitle={`${mail.rarity} · ${mail.category} · ${mail.type} · Slot ${mail.slotIndex}`}
-                  selected={selectedMailId === mail.mailId}
-                  index={index}
-                  onClick={() => setSelectedMailId(mail.mailId)}
-                />
-              ))}
-          </div>
-        </div>
+          <section className="lag-inventory-surface" aria-label={items ? "Inventory Items" : "Inbox Mail"}>
+            <header><p>{items ? "Owned InventoryEntry data" : "Mailbox entries pending Claim or Delete"}</p></header>
+            {items && categories.length > 0 ? (
+              <div className="lag-inventory-filters" aria-label="Item category filters">
+                {["ALL", ...categories].map((filter) => (
+                  <button key={filter} type="button" className="lag-inventory-filter" aria-pressed={category === filter} data-selected={category === filter} onClick={() => selectCategory(filter)}>{filter}</button>
+                ))}
+              </div>
+            ) : null}
+            {query.loading && query.data.entries.length === 0 ? <InfoCard>Loading {items ? "Items" : "Inbox"}...</InfoCard> : null}
+            {query.error ? <ErrorState text={query.error} retry={() => void query.reload()} /> : null}
+            {!query.loading && !query.error && query.data.entries.length === 0 ? <InfoCard>No {items ? "Items" : "mail"}.</InfoCard> : null}
+            {items && !query.loading && !query.error && query.data.entries.length > 0 && visibleItems.length === 0 ? <InfoCard>No Items in this category.</InfoCard> : null}
+            {queries.mutationError ? <p role="alert" className="lag-inventory-feedback" data-state="error">{queries.mutationError}</p> : null}
+            <div className="lag-inventory-grid">
+              {items
+                ? visibleItems.map((item) => <InventoryTile key={item.itemInstanceId} entry={item} kind="item" selected={selectedItemInstanceId === item.itemInstanceId} onSelect={() => setSelectedItemInstanceId(item.itemInstanceId)} />)
+                : queries.mailbox.data.entries.map((mail) => <InventoryTile key={mail.mailId} entry={mail} kind="mail" selected={selectedMailId === mail.mailId} onSelect={() => setSelectedMailId(mail.mailId)} />)}
+            </div>
+          </section>
         </PanelFrame>
       </PanelStage>
 
       <AnimatePresence initial={false}>
         {selectedItem || selectedMail ? (
           <PanelStage stageKey={`inventory-${surface}-detail`} focusKey={selectedItemInstanceId ?? selectedMailId} index={1}>
-            <PanelFrame title={items ? "Item Detail" : "Mail Detail"} depth={0} contentKey={selectedItemInstanceId ?? selectedMailId ?? undefined} backButton={<BackButton label={`Back to ${items ? "Items" : "Inbox"}`} onClick={() => {
-              setSelectedItemInstanceId(null);
-              setSelectedMailId(null);
-              requestStageFocus(`inventory-${surface}-list`, "center");
-            }} />}>
+            <PanelFrame title={items ? "Item Detail" : "Mail Detail"} depth={0} contentKey={selectedItemInstanceId ?? selectedMailId ?? undefined} backButton={<BackButton label={`Back to ${items ? "Items" : "Inbox"}`} onClick={closeDetail} />}>
               {items && selectedItem ? <ItemDetail item={selectedItem} /> : null}
               {!items && selectedMail ? (
                 <MailDetail


### PR DESCRIPTION
## Purpose

Apply the approved Stage 3 Enterprise Dual Theme v7 Inventory / Gear visual direction to the real Inventory, Mailbox, and Equipment flows.

Closes #60

## Delivered

- v7 Inventory item grid
- real-data category filtering
- semantic Item Detail
- v7 Inbox / Mail Detail
- preserved Claim/Delete recovery semantics
- three-stage Gear composition
- v7 Gear Parts / Slots / Candidates / Action treatment
- preserved compatibility authority
- preserved Equip / Replace / Unequip behavior
- desktop Astral / Warm Beige fidelity
- mobile Astral / Warm Beige fidelity
- accessible semantic item/state treatment

## Source of Truth

Reference-only visual authority:

```text
LifeAsGame_Stage3_UI_VisualDesigner_Enterprise_Dual_Theme_Result_v7
```

Primary references:

- DT7-06 Inventory / Gear Astral
- DT7-06 Inventory / Gear Warm Beige
- MT7-06 Inventory / Gear Astral
- MT7-06 Inventory / Gear Warm Beige
- AB7-D04 Inventory / Gear
- shared v7 semantic/token handoff

Reference artifacts are not committed or shipped.

## Data Authority

The screenshots define visual composition only.

Sample names, levels, and category chips are not hard-coded.

Real `InventoryEntry`, `MailEntry`, and `EquipmentSlotInfo` data remain authoritative.

```text
Item Definition != InventoryEntry
```

## Inventory

The Items surface uses real owned item instances.

Category filters, when present, are derived from loaded real categories and update locally/immediately.

Item Detail preserves canonical instance/classification/quantity/bound/durability/attribute data.

## Inbox

Mailbox entries remain distinct from owned Inventory entries.

Claim and Delete preserve their existing API contracts and authoritative recovery behavior.

No optimistic success state becomes correctness authority.

## Gear

Gear now respects the product max-three-panel rule:

```text
Gear Parts
-> selected Part workspace
   - Equipment Slots
   - Inventory Candidates
-> Gear Action
```

Slots and candidates remain derived from the current real model.

Compatibility remains authoritative:

```text
VERIFIED
INCOMPATIBLE
UNVERIFIABLE
```

Only VERIFIED candidates may be equipped.

Equip/replace/unequip keep their existing confirmation and reload behavior.

## Responsive / Theme

Astral and Warm Beige use one component tree.

Desktop adopts the approved v7 inventory-grid/material hierarchy.

Mobile preserves one-screen-one-purpose navigation, bottom OrbNav, responsive item tiles, and explicit Back behavior.

## Camera Scope

This PR does not retune global camera mathematics, breakpoint profiles, or OrbNav positioning.

Inventory/Gear only use the existing stage-focus/Back contract.

## Scope Boundaries

This PR does not implement:

- fake item levels
- screenshot sample inventory records
- new item catalog APIs
- marketplace/economy redesign
- final global camera tuning
- Growth fidelity
- Connections/Direct Chat fidelity
- Notification fidelity
- Economy fidelity
- backend changes