### PR TITLE
[Growth] Apply approved v7 Growth fidelity with canonical data

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -173,7 +173,11 @@ body {
 .lag-inventory-section,
 .lag-gear-part,
 .lag-gear-card,
-.lag-gear-section {
+.lag-gear-section,
+.lag-growth-action,
+.lag-growth-button,
+.lag-growth-change,
+.lag-growth-section {
   transition:
     background-color var(--lag-motion-normal) ease,
     border-color var(--lag-motion-normal) ease,
@@ -1187,6 +1191,347 @@ body {
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: var(--lag-space-4);
   padding-inline: var(--lag-space-4);
+}
+
+/* v7 Growth: canonical profile, EXP history and stable selected detail. */
+.lag-growth-shell [data-stage-key="player-growth-profile"] .lag-panel-frame {
+  width: min(480px, calc(100vw - 32px)) !important;
+}
+
+.lag-growth-shell [data-stage-key="player-growth-history"] .lag-panel-frame {
+  width: min(410px, calc(100vw - 32px)) !important;
+}
+
+.lag-growth-shell [data-stage-key="player-growth-change-detail"] .lag-panel-frame {
+  width: min(560px, calc(100vw - 32px)) !important;
+}
+
+.lag-growth-shell .lag-panel-header button {
+  width: 44px;
+  height: 44px;
+}
+
+.lag-growth-profile,
+.lag-growth-history,
+.lag-growth-detail,
+.lag-growth-state {
+  display: grid;
+  gap: var(--lag-space-4);
+  padding-inline: var(--lag-space-4);
+}
+
+.lag-growth-identity {
+  display: grid;
+  justify-items: center;
+  gap: var(--lag-space-3);
+  padding: var(--lag-space-6) var(--lag-space-4);
+  border: 1px solid var(--lag-border);
+  border-left: 4px solid var(--lag-cyan);
+  border-radius: var(--lag-radius-lg);
+  background: var(--lag-muted-surface);
+}
+
+.lag-growth-identity > span,
+.lag-growth-history > header p,
+.lag-growth-data-row dt,
+.lag-growth-detail > header > span {
+  color: var(--lag-text-2);
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.lag-growth-level-mark {
+  position: relative;
+  display: grid;
+  width: 184px;
+  height: 184px;
+  place-items: center;
+}
+
+.lag-growth-rings,
+.lag-growth-rings i {
+  position: absolute;
+  inset: 0;
+  border: 3px solid var(--lag-divider);
+  border-radius: 50%;
+}
+
+.lag-growth-rings::after {
+  position: absolute;
+  inset: 20px;
+  border: 3px solid var(--lag-violet);
+  border-radius: 50%;
+  content: "";
+}
+
+.lag-growth-rings i:first-child {
+  inset: 40px;
+  border-color: var(--lag-cyan);
+}
+
+.lag-growth-level-mark > div {
+  z-index: 1;
+  display: grid;
+  justify-items: center;
+  gap: var(--lag-space-1);
+}
+
+.lag-growth-level-mark small,
+.lag-growth-identity p span,
+.lag-growth-change small,
+.lag-growth-change time,
+.lag-growth-meta {
+  color: var(--lag-text-2);
+  font-size: 0.68rem;
+}
+
+.lag-growth-level-mark strong {
+  color: var(--lag-text);
+  font-size: 2.25rem;
+  line-height: 1;
+}
+
+.lag-growth-identity p {
+  display: flex;
+  align-items: baseline;
+  gap: var(--lag-space-2);
+}
+
+.lag-growth-identity p strong {
+  color: var(--lag-text);
+  font-size: 1rem;
+}
+
+.lag-growth-section {
+  overflow: hidden;
+  border: 1px solid var(--lag-divider);
+  border-radius: var(--lag-radius-md);
+  background: var(--lag-panel);
+}
+
+.lag-growth-section > h4 {
+  padding: var(--lag-space-3) var(--lag-space-4);
+  border-bottom: 1px solid var(--lag-divider);
+  background: var(--lag-panel-2);
+  color: var(--lag-text);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.lag-growth-stat-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--lag-space-3);
+  padding: var(--lag-space-4);
+}
+
+.lag-growth-stat {
+  display: grid;
+  min-height: 72px;
+  place-items: center;
+  gap: var(--lag-space-1);
+  padding: var(--lag-space-2);
+  border: 1px solid var(--lag-divider);
+  border-radius: var(--lag-radius-sm);
+  background: var(--lag-muted-surface);
+}
+
+.lag-growth-stat dt {
+  color: var(--lag-text-2);
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+}
+
+.lag-growth-stat dd {
+  color: var(--lag-text);
+  font-size: 1.08rem;
+  font-weight: 700;
+}
+
+.lag-growth-extra-list,
+.lag-growth-detail .lag-growth-section dl {
+  display: grid;
+  gap: var(--lag-space-2);
+  padding: var(--lag-space-4);
+}
+
+.lag-growth-data-row {
+  display: grid;
+  grid-template-columns: minmax(130px, 0.72fr) minmax(0, 1.28fr);
+  gap: var(--lag-space-3);
+  padding-block: var(--lag-space-2);
+  border-bottom: 1px solid var(--lag-divider);
+}
+
+.lag-growth-data-row:last-child {
+  border-bottom: 0;
+}
+
+.lag-growth-data-row dd {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  color: var(--lag-text);
+  font-size: 0.78rem;
+}
+
+.lag-growth-empty {
+  margin: var(--lag-space-4);
+  padding: var(--lag-space-3);
+  border: 1px dashed var(--lag-border);
+  border-radius: var(--lag-radius-sm);
+  background: var(--lag-muted-surface);
+  color: var(--lag-text-2);
+  font-size: 0.76rem;
+}
+
+.lag-growth-meta {
+  padding-inline: var(--lag-space-1);
+}
+
+.lag-growth-action,
+.lag-growth-button {
+  display: inline-flex;
+  min-height: 44px;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--lag-space-3);
+  padding: var(--lag-space-2) var(--lag-space-4);
+  border: 1px solid var(--lag-control-border);
+  border-radius: var(--lag-radius-sm);
+  background: var(--lag-control-bg);
+  color: var(--lag-control-text);
+  font-size: 0.76rem;
+  font-weight: 700;
+}
+
+.lag-growth-action {
+  border-color: var(--lag-cyan);
+  background: color-mix(in srgb, var(--lag-cyan) 10%, var(--lag-control-bg));
+}
+
+.lag-growth-action:hover,
+.lag-growth-button:hover {
+  border-color: var(--lag-focus);
+  background: var(--lag-control-hover-bg);
+}
+
+.lag-growth-history > header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--lag-space-3);
+  padding: var(--lag-space-3) var(--lag-space-4);
+  border: 1px solid var(--lag-divider);
+  border-left: 4px solid var(--lag-amber);
+  border-radius: var(--lag-radius-md);
+  background: var(--lag-muted-surface);
+}
+
+.lag-growth-history > header span {
+  color: var(--lag-text-2);
+  font-size: 0.68rem;
+}
+
+.lag-growth-change-list {
+  display: grid;
+  gap: var(--lag-space-3);
+}
+
+.lag-growth-change {
+  display: grid;
+  min-height: 100px;
+  grid-template-columns: 48px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: var(--lag-space-3);
+  padding: var(--lag-space-3);
+  border: 1px solid var(--lag-divider);
+  border-radius: var(--lag-radius-md);
+  background: var(--lag-muted-surface);
+  color: var(--lag-text);
+  text-align: left;
+}
+
+.lag-growth-change:hover,
+.lag-growth-change[data-selected="true"] {
+  border-color: var(--lag-focus);
+  background: var(--lag-control-hover-bg);
+}
+
+.lag-growth-change[data-selected="true"] {
+  box-shadow: inset 4px 0 0 var(--lag-state-selected);
+}
+
+.lag-growth-change-mark {
+  display: grid;
+  width: 46px;
+  height: 46px;
+  place-items: center;
+  border: 1px solid var(--lag-amber);
+  border-radius: 50%;
+  background: var(--lag-paper);
+  color: var(--lag-text);
+  font-size: 0.68rem;
+  font-weight: 700;
+}
+
+.lag-growth-change > span:nth-child(2) {
+  display: grid;
+  min-width: 0;
+  gap: var(--lag-space-1);
+}
+
+.lag-growth-change > span:nth-child(2) strong {
+  font-size: 0.86rem;
+}
+
+.lag-growth-change time {
+  overflow-wrap: anywhere;
+}
+
+.lag-growth-change > span:last-child {
+  display: grid;
+  justify-items: end;
+  gap: var(--lag-space-2);
+}
+
+.lag-growth-detail > header {
+  display: grid;
+  gap: var(--lag-space-2);
+  padding: var(--lag-space-4);
+  border: 1px solid var(--lag-border);
+  border-left: 4px solid var(--lag-violet);
+  border-radius: var(--lag-radius-md);
+  background: var(--lag-muted-surface);
+}
+
+.lag-growth-detail > header h4 {
+  color: var(--lag-text);
+  font-size: 1.3rem;
+  font-weight: 700;
+}
+
+.lag-growth-detail > header p {
+  color: var(--lag-text-2);
+  font-size: 0.76rem;
+}
+
+.lag-growth-feedback {
+  padding: var(--lag-space-3);
+  border: 1px solid var(--lag-state-info);
+  border-radius: var(--lag-radius-sm);
+  background: var(--lag-muted-surface);
+  color: var(--lag-text);
+  font-size: 0.76rem;
+}
+
+.lag-growth-feedback[data-state="error"] {
+  border-color: var(--lag-state-error);
+  box-shadow: inset 4px 0 0 var(--lag-state-error);
 }
 
 .lag-semantic-controls label {
@@ -2366,6 +2711,37 @@ textarea.lag-journal-control {
     width: 100%;
   }
 
+  .lag-growth-shell [data-stage-key="player-growth-profile"] .lag-panel-frame,
+  .lag-growth-shell [data-stage-key="player-growth-history"] .lag-panel-frame,
+  .lag-growth-shell [data-stage-key="player-growth-change-detail"] .lag-panel-frame {
+    width: clamp(280px, calc(100vw - 32px), 344px) !important;
+  }
+
+  .lag-growth-profile,
+  .lag-growth-history,
+  .lag-growth-detail,
+  .lag-growth-state {
+    padding-inline: var(--lag-space-3);
+  }
+
+  .lag-growth-level-mark {
+    width: 164px;
+    height: 164px;
+  }
+
+  .lag-growth-stat-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .lag-growth-data-row {
+    grid-template-columns: minmax(108px, 0.8fr) minmax(0, 1.2fr);
+  }
+
+  .lag-growth-action,
+  .lag-growth-button {
+    width: 100%;
+  }
+
   .lag-left-anchor {
     --lag-left-lane-width: clamp(280px, calc(100vw - 32px), 344px);
     position: static;
@@ -2478,7 +2854,11 @@ textarea.lag-journal-control {
   .lag-inventory-section,
   .lag-gear-part,
   .lag-gear-card,
-  .lag-gear-section {
+  .lag-gear-section,
+  .lag-growth-action,
+  .lag-growth-button,
+  .lag-growth-change,
+  .lag-growth-section {
     transition-duration: 0s;
   }
 

--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -237,16 +237,19 @@ describe("Home shell에서 feature surface를 routing할 때", () => {
       fireEvent.click(screen.getByRole("button", { name: "Growth" }));
 
       expect(await screen.findByTestId("growth-shell")).toBeInTheDocument();
-      expect(screen.getByText("Level: 8")).toBeInTheDocument();
-      expect(screen.getByText("EXP: 842")).toBeInTheDocument();
+      expect(document.querySelector(".lag-growth-level-mark")).toHaveTextContent("Level8");
+      expect(screen.getByText("Current EXP").parentElement).toHaveTextContent("842");
       expect(screen.getByText("No extra stats.")).toBeInTheDocument();
-      expect(screen.getByText("Requested EXP: 100")).toBeInTheDocument();
-      expect(screen.getByText("Applied EXP: 80")).toBeInTheDocument();
-      expect(screen.getByText("Leftover EXP: 20")).toBeInTheDocument();
-      expect(screen.getByText("Source Type: QUEST")).toBeInTheDocument();
-      expect(screen.getByText("Source ID: 31")).toBeInTheDocument();
-      expect(screen.getByText("Source unavailable.")).toBeInTheDocument();
-      expect(screen.queryByText("Source ID: 999")).not.toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /\+80 EXP/ })).toHaveTextContent("QUEST");
+      expect(screen.getByText("Source unavailable")).toBeInTheDocument();
+      fireEvent.click(screen.getByRole("button", { name: /\+80 EXP/ }));
+      expect(document.querySelector('[data-stage-key="player-growth-change-detail"]')).toBeInTheDocument();
+      expect(screen.getByText("Requested EXP").parentElement).toHaveTextContent("100");
+      expect(screen.getByText("Applied EXP").parentElement).toHaveTextContent("80");
+      expect(screen.getByText("Leftover EXP").parentElement).toHaveTextContent("20");
+      expect(screen.getByText("Source type").parentElement).toHaveTextContent("QUEST");
+      expect(screen.getByText("Source ID").parentElement).toHaveTextContent("31");
+      expect(screen.queryByText("999")).not.toBeInTheDocument();
       expect(screen.queryByText(/next level|percentage|remaining exp|radar/i)).not.toBeInTheDocument();
       expect(growthApi.getPlayerGrowthApi).toHaveBeenCalledTimes(1);
     });

--- a/features/player/GrowthShell.test.tsx
+++ b/features/player/GrowthShell.test.tsx
@@ -1,0 +1,128 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { readFileSync } from "node:fs";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { PlayerGrowthOverview } from "@/shared/api/types";
+import { STAGE_FOCUS_EVENT } from "@/shared/hooks/useStageCamera";
+import GrowthShell from "./GrowthShell";
+
+const api = vi.hoisted(() => ({ getPlayerGrowthApi: vi.fn() }));
+vi.mock("./api", () => api);
+
+const overview = {
+  current: {
+    level: 8,
+    exp: 842,
+    str: 21,
+    agi: 22,
+    dex: 23,
+    intel: 24,
+    vit: 25,
+    luc: 26,
+    extraStats: { Focus: 7, Balance: 9 },
+    representativeTitleId: 41,
+  },
+  recentExpChanges: [
+    { changeId: 71, requestedExp: 100, appliedExp: 80, leftoverExp: 20, beforeLevel: 7, afterLevel: 8, beforeTotalExp: 762, afterTotalExp: 842, occurredAt: "2026-08-20T09:00:00Z", sourceType: "QUEST", sourceId: 31 },
+    { changeId: 70, requestedExp: 30, appliedExp: 30, leftoverExp: 0, beforeLevel: 7, afterLevel: 7, beforeTotalExp: 732, afterTotalExp: 762, occurredAt: "2026-08-19T09:00:00Z", sourceType: null, sourceId: 999 },
+  ],
+} satisfies PlayerGrowthOverview;
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => { resolve = resolvePromise; });
+  return { promise, resolve };
+}
+
+describe("v7 Growth surface를 사용할 때", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api.getPlayerGrowthApi.mockResolvedValue(overview);
+  });
+
+  it("canonical Growth 값만 semantic dual-theme composition으로 표시한다", async () => {
+    render(<GrowthShell />);
+
+    expect(await screen.findByText("842")).toBeInTheDocument();
+    for (const value of ["21", "22", "23", "24", "25", "26", "7", "9"]) expect(screen.getByText(value)).toBeInTheDocument();
+    expect(screen.getByText("Focus")).toBeInTheDocument();
+    expect(screen.getByText("Balance")).toBeInTheDocument();
+    expect(screen.getByText("Representative title ID · 41")).toBeInTheDocument();
+    expect(screen.queryByText(/1,230|1,600|Knowledge|Health|Relation|Creativity|Achievement|progress|%/i)).not.toBeInTheDocument();
+
+    const source = readFileSync("features/player/GrowthShell.tsx", "utf8");
+    expect(source).not.toMatch(/AchievementShell|getPlayerAchievements|GoldRow|InfoCard|data-theme/);
+    const css = readFileSync("app/globals.css", "utf8");
+    const growthCss = css.slice(css.indexOf("/* v7 Growth"), css.indexOf(".lag-semantic-controls"));
+    expect(growthCss).not.toMatch(/#[0-9a-f]{3,8}|rgba?\(/i);
+    expect(css).toContain('@media (max-width: 767px)');
+    expect(css).toContain('[data-stage-key="player-growth-change-detail"]');
+  });
+
+  it("empty extra stats와 real history를 표시하되 첫 change를 자동 선택하지 않는다", async () => {
+    api.getPlayerGrowthApi.mockResolvedValue({ ...overview, current: { ...overview.current, extraStats: {} } });
+    render(<GrowthShell />);
+
+    expect(await screen.findByText("No extra stats.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /\+80 EXP/ })).toHaveAttribute("aria-pressed", "false");
+    expect(screen.getByText("QUEST")).toBeInTheDocument();
+    expect(screen.getByText("Source unavailable")).toBeInTheDocument();
+    expect(document.querySelector('[data-stage-key="player-growth-change-detail"]')).not.toBeInTheDocument();
+  });
+
+  it("명시 선택으로 canonical detail을 열고 change 교체 시 outer frame을 유지한다", async () => {
+    render(<GrowthShell />);
+    fireEvent.click(await screen.findByRole("button", { name: /\+80 EXP/ }));
+
+    const detail = document.querySelector('[data-stage-key="player-growth-change-detail"]');
+    expect(detail).toBeInTheDocument();
+    for (const value of ["71", "100", "80", "20", "762", "842", "2026-08-20T09:00:00Z", "QUEST", "31"]) {
+      expect(screen.getAllByText(value).length).toBeGreaterThan(0);
+    }
+
+    fireEvent.click(screen.getByRole("button", { name: /\+30 EXP/ }));
+    expect(document.querySelector('[data-stage-key="player-growth-change-detail"]')).toBe(detail);
+    expect(screen.getAllByText("70").length).toBeGreaterThan(0);
+    expect(screen.getByText("Not available without source type")).toBeInTheDocument();
+    expect(screen.queryByText("999")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Back to EXP History" }));
+    await waitFor(() => expect(document.querySelector('[data-stage-key="player-growth-change-detail"]')).not.toBeInTheDocument());
+  });
+
+  it("Profile → History → Detail focus와 fresh mount reset을 유지한다", async () => {
+    const focus = vi.fn();
+    window.addEventListener(STAGE_FOCUS_EVENT, focus);
+    const view = render(<GrowthShell />);
+    await screen.findByText("842");
+
+    focus.mockClear();
+    fireEvent.click(screen.getByRole("button", { name: /View EXP History/ }));
+    expect(focus.mock.calls.at(-1)?.[0]).toMatchObject({ detail: { key: "player-growth-history", align: "center" } });
+    fireEvent.click(screen.getByRole("button", { name: /\+80 EXP/ }));
+    expect(document.querySelector('[data-stage-key="player-growth-change-detail"]')).toBeInTheDocument();
+
+    view.unmount();
+    render(<GrowthShell />);
+    await screen.findByText("842");
+    expect(document.querySelector('[data-stage-key="player-growth-change-detail"]')).not.toBeInTheDocument();
+    window.removeEventListener(STAGE_FOCUS_EVENT, focus);
+  });
+
+  it("loading/error/retry query semantics를 보존한다", async () => {
+    const pending = deferred<PlayerGrowthOverview>();
+    api.getPlayerGrowthApi.mockReturnValueOnce(pending.promise);
+    const view = render(<GrowthShell />);
+    expect(screen.getByText("Loading Growth...")).toHaveAttribute("role", "status");
+
+    await act(async () => { pending.resolve(overview); await pending.promise; });
+    await screen.findByText("842");
+    view.unmount();
+
+    api.getPlayerGrowthApi.mockRejectedValueOnce(new Error("Growth unavailable")).mockResolvedValueOnce({ ...overview, recentExpChanges: [] });
+    render(<GrowthShell />);
+    expect(await screen.findByRole("alert")).toHaveTextContent("Growth unavailable");
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(await screen.findByText("No recent EXP changes.")).toBeInTheDocument();
+  });
+});

--- a/features/player/GrowthShell.tsx
+++ b/features/player/GrowthShell.tsx
@@ -1,8 +1,12 @@
 "use client";
 
-import { BackButton, PanelFrame } from "@/widgets/right-panels/ui/PanelFrame";
-import { GoldRow, InfoCard } from "@/widgets/right-panels/ui/Rows";
+import { AnimatePresence } from "framer-motion";
+import { useState } from "react";
+
+import { requestStageFocus } from "@/shared/hooks/useStageCamera";
+import type { PlayerGrowthOverview } from "@/shared/api/types";
 import PanelStage from "@/shared/ui/PanelStage";
+import { BackButton, PanelFrame } from "@/widgets/right-panels/ui/PanelFrame";
 import { useGrowthQuery } from "./useGrowthQuery";
 
 const CORE_STATS = [
@@ -10,50 +14,153 @@ const CORE_STATS = [
   ["INT", "intel"], ["VIT", "vit"], ["LUC", "luc"],
 ] as const;
 
+type ExpChange = PlayerGrowthOverview["recentExpChanges"][number];
+
+function ErrorState({ text, retry }: { text: string; retry: () => void }) {
+  return (
+    <div className="lag-growth-state">
+      <p role="alert" className="lag-growth-feedback" data-state="error">{text}</p>
+      <button type="button" className="lag-growth-button" onClick={retry}>Retry</button>
+    </div>
+  );
+}
+
+function DetailRow({ label, children }: { label: string; children: React.ReactNode }) {
+  return <div className="lag-growth-data-row"><dt>{label}</dt><dd>{children}</dd></div>;
+}
+
+function signedExp(value: number) {
+  return `${value > 0 ? "+" : ""}${value} EXP`;
+}
+
 export default function GrowthShell({ onBack }: { onBack?: () => void }) {
   const growth = useGrowthQuery();
+  const [selectedChangeId, setSelectedChangeId] = useState<number | null>(null);
   const current = growth.data?.current;
   const changes = growth.data?.recentExpChanges ?? [];
+  const selectedChange = changes.find(({ changeId }) => changeId === selectedChangeId) ?? null;
+
+  const openHistory = () => requestStageFocus("player-growth-history", "center");
+  const closeDetail = () => {
+    setSelectedChangeId(null);
+    requestStageFocus("player-growth-history", "center");
+  };
 
   return (
-    <div className="lag-panel-rail relative" data-testid="growth-shell">
-      <PanelStage stageKey="player-growth-current">
-        <PanelFrame title="Current Growth" depth={1} backButton={onBack ? <BackButton label="Back to Player" onClick={onBack} /> : undefined}>
-        <div className="space-y-2 px-3">
-          {growth.loading && !growth.data ? <InfoCard>Loading Growth...</InfoCard> : null}
-          {growth.error ? <><p role="alert" className="text-xs text-red-400">{growth.error}</p><button type="button" onClick={() => void growth.retry()}>Retry</button></> : null}
-          {current ? <>
-            <GoldRow>Level: {current.level}</GoldRow>
-            <GoldRow>EXP: {current.exp}</GoldRow>
-            {CORE_STATS.map(([label, key]) => <GoldRow key={key}>{label}: {current[key]}</GoldRow>)}
-            {Object.keys(current.extraStats).length === 0 ? <InfoCard>No extra stats.</InfoCard> : null}
-            {Object.entries(current.extraStats).map(([name, value]) => <GoldRow key={name}>{name}: {value}</GoldRow>)}
-          </> : null}
-        </div>
+    <div className="lag-panel-rail lag-growth-shell relative" data-testid="growth-shell">
+      <PanelStage stageKey="player-growth-profile">
+        <PanelFrame title="Growth Profile" depth={2} backButton={onBack ? <BackButton label="Back to Player" onClick={onBack} /> : undefined}>
+          <section className="lag-growth-profile" aria-label="Growth Profile">
+            {growth.loading && !growth.data ? <div role="status" className="lag-growth-state">Loading Growth...</div> : null}
+            {growth.error ? <ErrorState text={growth.error} retry={() => void growth.retry()} /> : null}
+            {current ? (
+              <>
+                <header className="lag-growth-identity">
+                  <span>Current Growth</span>
+                  <div className="lag-growth-level-mark">
+                    <span className="lag-growth-rings" aria-hidden><i /></span>
+                    <div><small>Level</small><strong>{current.level}</strong></div>
+                  </div>
+                  <p><span>Current EXP</span><strong>{current.exp}</strong></p>
+                </header>
+
+                <section className="lag-growth-section" aria-labelledby="growth-core-stats">
+                  <h4 id="growth-core-stats">Core Stats</h4>
+                  <dl className="lag-growth-stat-grid">
+                    {CORE_STATS.map(([label, key]) => (
+                      <div key={key} className="lag-growth-stat"><dt>{label}</dt><dd>{current[key]}</dd></div>
+                    ))}
+                  </dl>
+                </section>
+
+                <section className="lag-growth-section" aria-labelledby="growth-extra-stats">
+                  <h4 id="growth-extra-stats">Extra Stats</h4>
+                  {Object.keys(current.extraStats).length === 0
+                    ? <p className="lag-growth-empty">No extra stats.</p>
+                    : <dl className="lag-growth-extra-list">{Object.entries(current.extraStats).map(([name, value]) => <DetailRow key={name} label={name}>{value}</DetailRow>)}</dl>}
+                </section>
+
+                {current.representativeTitleId === null ? null : <p className="lag-growth-meta">Representative title ID · {current.representativeTitleId}</p>}
+                <button type="button" className="lag-growth-action" onClick={openHistory}>View EXP History <span aria-hidden>→</span></button>
+              </>
+            ) : null}
+          </section>
         </PanelFrame>
       </PanelStage>
 
-      <PanelStage stageKey="player-growth-history" index={1}>
-        <PanelFrame title="Recent EXP Changes" depth={0}>
-        <div className="space-y-3 px-3">
-          {growth.data && changes.length === 0 ? <InfoCard>No recent EXP changes.</InfoCard> : null}
-          {changes.map((change) => (
-            <InfoCard key={change.changeId} label={`Change #${change.changeId}`}>
-              <div>Requested EXP: {change.requestedExp}</div>
-              <div>Applied EXP: {change.appliedExp}</div>
-              <div>Leftover EXP: {change.leftoverExp}</div>
-              <div>Level: {change.beforeLevel} → {change.afterLevel}</div>
-              <div>Total EXP: {change.beforeTotalExp} → {change.afterTotalExp}</div>
-              <div>Occurred: {change.occurredAt}</div>
-              {change.sourceType === null ? <div>Source unavailable.</div> : <>
-                <div>Source Type: {change.sourceType}</div>
-                {change.sourceId === null ? null : <div>Source ID: {change.sourceId}</div>}
-              </>}
-            </InfoCard>
-          ))}
-        </div>
+      <PanelStage stageKey="player-growth-history" autoFocus={false}>
+        <PanelFrame title="Recent EXP Changes" depth={1} backButton={<BackButton label="Back to Growth Profile" onClick={() => requestStageFocus("player-growth-profile", "center")} />}>
+          <section className="lag-growth-history" aria-label="Recent EXP Changes">
+            <header><p>Canonical EXP history</p><span>{changes.length} changes</span></header>
+            {growth.loading && !growth.data ? <div role="status" className="lag-growth-state">Loading EXP history...</div> : null}
+            {growth.data && changes.length === 0 ? <p className="lag-growth-empty">No recent EXP changes.</p> : null}
+            <div className="lag-growth-change-list">
+              {changes.map((change) => (
+                <button
+                  key={change.changeId}
+                  type="button"
+                  className="lag-growth-change"
+                  aria-pressed={selectedChangeId === change.changeId}
+                  data-selected={selectedChangeId === change.changeId}
+                  onClick={() => setSelectedChangeId(change.changeId)}
+                >
+                  <span className="lag-growth-change-mark" aria-hidden>XP</span>
+                  <span><strong>{signedExp(change.appliedExp)}</strong><small>Level {change.beforeLevel} → {change.afterLevel}</small><time dateTime={change.occurredAt}>{change.occurredAt}</time></span>
+                  <span><small>{change.sourceType ?? "Source unavailable"}</small><b aria-hidden>→</b></span>
+                </button>
+              ))}
+            </div>
+          </section>
         </PanelFrame>
       </PanelStage>
+
+      <AnimatePresence initial={false}>
+        {selectedChange ? (
+          <PanelStage stageKey="player-growth-change-detail" focusKey={selectedChange.changeId}>
+            <PanelFrame title="EXP Change Detail" depth={0} contentKey={selectedChange.changeId} backButton={<BackButton label="Back to EXP History" onClick={closeDetail} />}>
+              <ExpChangeDetail change={selectedChange} />
+            </PanelFrame>
+          </PanelStage>
+        ) : null}
+      </AnimatePresence>
     </div>
+  );
+}
+
+function ExpChangeDetail({ change }: { change: ExpChange }) {
+  return (
+    <article className="lag-growth-detail">
+      <header>
+        <span>Change #{change.changeId}</span>
+        <h4>{signedExp(change.appliedExp)}</h4>
+        <p>Level {change.beforeLevel} → {change.afterLevel}</p>
+      </header>
+      <section className="lag-growth-section">
+        <h4>EXP Application</h4>
+        <dl>
+          <DetailRow label="Change ID">{change.changeId}</DetailRow>
+          <DetailRow label="Requested EXP">{change.requestedExp}</DetailRow>
+          <DetailRow label="Applied EXP">{change.appliedExp}</DetailRow>
+          <DetailRow label="Leftover EXP">{change.leftoverExp}</DetailRow>
+        </dl>
+      </section>
+      <section className="lag-growth-section">
+        <h4>Growth Transition</h4>
+        <dl>
+          <DetailRow label="Before level">{change.beforeLevel}</DetailRow>
+          <DetailRow label="After level">{change.afterLevel}</DetailRow>
+          <DetailRow label="Before total EXP">{change.beforeTotalExp}</DetailRow>
+          <DetailRow label="After total EXP">{change.afterTotalExp}</DetailRow>
+        </dl>
+      </section>
+      <section className="lag-growth-section">
+        <h4>Record Context</h4>
+        <dl>
+          <DetailRow label="Occurred at"><time dateTime={change.occurredAt}>{change.occurredAt}</time></DetailRow>
+          <DetailRow label="Source type">{change.sourceType ?? "Source unavailable"}</DetailRow>
+          <DetailRow label="Source ID">{change.sourceType === null ? "Not available without source type" : change.sourceId ?? "Not recorded"}</DetailRow>
+        </dl>
+      </section>
+    </article>
   );
 }


### PR DESCRIPTION
## Purpose

Apply the approved Stage 3 Enterprise Dual Theme v7 Growth visual direction to the real Player Growth surface without fabricating progression data or duplicating the separate Achievement domain.

Closes #62

## Delivered

- v7 Growth Profile treatment
- canonical level / EXP presentation
- real numeric core-stat presentation
- dynamic extra-stat treatment
- v7 Recent EXP Changes history
- staged EXP Change Detail
- stable detail-frame replacement
- desktop Astral / Warm Beige fidelity
- shared-system-derived mobile/compact Growth adaptation
- accessible loading/error/retry and staged navigation

## Source of Truth

Reference-only visual authority:

```text
LifeAsGame_Stage3_UI_VisualDesigner_Enterprise_Dual_Theme_Result_v7
```

Growth desktop references:

- DT7-07 Growth Astral
- DT7-07 Growth Warm Beige

The v7 package does not contain a dedicated MT7 Growth screenshot.

Mobile/compact behavior is therefore derived from the shared v7 design system and the existing one-screen-one-purpose product contract rather than a fabricated mobile reference.

## Data Authority

The real `PlayerGrowthOverview` contract remains authoritative:

```text
level
exp
STR / AGI / DEX / INT / VIT / LUC
extraStats
representativeTitleId
recentExpChanges
```

The implementation does not fabricate:

- next-level EXP denominator
- level-progress percentage
- normalized stat percentages
- Knowledge / Health / Relation / Creativity metrics
- fake Achievement records
- fake XP rewards
- fake unlock state

## Achievement Boundary

Achievement remains a separate Player submenu/domain.

The screenshot's illustrative Achievement column is not duplicated inside Growth.

Instead, the v7 three-depth visual grammar is translated with canonical Growth data:

```text
Growth Profile
-> Recent EXP Changes
-> EXP Change Detail
```

## Growth Profile

The Growth Profile uses real level, EXP, six core stats, and extraStats.

Any decorative level-ring treatment does not imply a synthetic percentage.

Core stats remain numeric rather than being normalized against an invented maximum.

## Recent EXP Changes

History is driven exclusively by the canonical `recentExpChanges` response.

No first record is automatically selected.

Selecting a real change opens detail.

## EXP Change Detail

Detail preserves:

- changeId
- requestedExp
- appliedExp
- leftoverExp
- before/after Level
- before/after Total EXP
- occurredAt
- sourceType
- sourceId

Selecting another history record keeps the semantic detail stage frame mounted and replaces only its inner content.

## Responsive / Theme

Astral and Warm Beige share one component tree.

Desktop follows the approved DT7-07 Growth material hierarchy.

Mobile preserves:

```text
Growth Profile
-> Recent EXP Changes
-> EXP Change Detail
```

with one-screen-one-purpose staged navigation and the existing bottom OrbNav.

## Camera Scope

This PR does not retune global stage-camera mathematics, breakpoint profiles, parent-exposure ratios, or OrbNav positioning.

Final global camera composition tuning remains deferred.

## Scope Boundaries

This PR does not implement:

- Achievement fidelity
- Title fidelity
- Credentials fidelity
- Interests fidelity
- synthetic growth formulas
- new Growth backend APIs
- global camera final tuning
- Connections / Direct Chat fidelity
- Notification fidelity
- Economy fidelity