### PR TITLE
[Social] Apply approved v7 Connections and Direct Chat fidelity

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -177,7 +177,13 @@ body {
 .lag-growth-action,
 .lag-growth-button,
 .lag-growth-change,
-.lag-growth-section {
+.lag-growth-section,
+.lag-social-button,
+.lag-connection-tabs button,
+.lag-connection-row,
+.lag-chat-channel,
+.lag-chat-message,
+.lag-chat-composer {
   transition:
     background-color var(--lag-motion-normal) ease,
     border-color var(--lag-motion-normal) ease,
@@ -1534,6 +1540,476 @@ body {
   box-shadow: inset 4px 0 0 var(--lag-state-error);
 }
 
+/* v7 Social utilities: directional peers and canonical one-to-one chat. */
+.lag-social-drawer {
+  display: flex;
+  gap: var(--lag-space-3);
+  flex-direction: column;
+  overflow: hidden;
+  padding: var(--lag-space-4);
+}
+
+.lag-connections-drawer {
+  width: min(430px, calc(100vw - 48px));
+  max-height: calc(100vh - 48px);
+}
+
+.lag-direct-chat-drawer {
+  width: min(760px, calc(100vw - 48px));
+  height: min(700px, calc(100vh - 48px));
+}
+
+.lag-social-header {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--lag-space-3);
+  padding-bottom: var(--lag-space-3);
+  border-bottom: 1px solid var(--lag-divider);
+}
+
+.lag-social-header p,
+.lag-chat-channels > header span,
+.lag-chat-conversation-header span {
+  color: var(--lag-text-2);
+  font-size: 0.64rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.lag-social-header h2 {
+  color: var(--lag-text);
+  font-size: 1.08rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+}
+
+.lag-social-button,
+.lag-connection-tabs button,
+.lag-chat-load-older,
+.lag-chat-composer button,
+.lag-chat-composer textarea {
+  min-height: 44px;
+  border: 1px solid var(--lag-control-border);
+  border-radius: var(--lag-radius-sm);
+  background: var(--lag-control-bg);
+  color: var(--lag-control-text);
+  font-size: 0.72rem;
+}
+
+.lag-social-button,
+.lag-connection-tabs button,
+.lag-chat-load-older,
+.lag-chat-composer button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--lag-space-2) var(--lag-space-3);
+  font-weight: 700;
+}
+
+.lag-social-button:not(:disabled):hover,
+.lag-connection-tabs button:not(:disabled):hover,
+.lag-chat-load-older:not(:disabled):hover,
+.lag-chat-composer button:not(:disabled):hover {
+  border-color: var(--lag-focus);
+  background: var(--lag-control-hover-bg);
+}
+
+.lag-social-button[data-variant="primary"] {
+  border-color: var(--lag-cyan);
+  background: color-mix(in srgb, var(--lag-cyan) 10%, var(--lag-control-bg));
+}
+
+.lag-social-button[data-variant="destructive"] {
+  border-color: var(--lag-state-error);
+}
+
+.lag-social-state {
+  display: flex;
+  align-items: center;
+  gap: var(--lag-space-2);
+}
+
+.lag-social-feedback,
+.lag-social-empty {
+  padding: var(--lag-space-3);
+  border: 1px solid var(--lag-divider);
+  border-radius: var(--lag-radius-sm);
+  background: var(--lag-muted-surface);
+  color: var(--lag-text-2);
+  font-size: 0.74rem;
+}
+
+.lag-social-feedback[data-state="error"] {
+  border-color: var(--lag-state-error);
+  box-shadow: inset 4px 0 0 var(--lag-state-error);
+  color: var(--lag-text);
+}
+
+.lag-social-feedback[data-state="pending"] {
+  border-color: var(--lag-state-pending);
+  box-shadow: inset 4px 0 0 var(--lag-state-pending);
+}
+
+.lag-connection-tabs {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--lag-space-2);
+}
+
+.lag-connection-tabs button {
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.lag-connection-tabs button[data-selected="true"] {
+  border-color: var(--lag-focus);
+  background: var(--lag-selected-surface);
+  box-shadow: inset 0 -3px 0 var(--lag-state-selected);
+}
+
+.lag-connections-summary,
+.lag-chat-channels > header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--lag-space-3);
+  color: var(--lag-text-2);
+  font-size: 0.7rem;
+}
+
+.lag-connections-summary strong,
+.lag-chat-channels > header strong {
+  color: var(--lag-text);
+  font-size: 0.72rem;
+}
+
+.lag-connection-list {
+  display: grid;
+  min-height: 112px;
+  flex: 1 1 auto;
+  align-content: start;
+  gap: var(--lag-space-3);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
+.lag-connection-row {
+  display: grid;
+  gap: var(--lag-space-3);
+  padding: var(--lag-space-3);
+  border: 1px solid var(--lag-divider);
+  border-radius: var(--lag-radius-md);
+  background: var(--lag-muted-surface);
+  color: var(--lag-text);
+}
+
+.lag-connection-row:hover {
+  border-color: var(--lag-focus);
+}
+
+.lag-connection-row-main {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--lag-space-3);
+}
+
+.lag-social-peer {
+  display: flex;
+  min-width: 0;
+  flex: 1 1 auto;
+  align-items: center;
+  gap: var(--lag-space-3);
+}
+
+.lag-social-peer-mark {
+  display: grid;
+  width: 44px;
+  height: 44px;
+  flex: 0 0 44px;
+  place-items: center;
+  border: 1px solid var(--lag-cyan);
+  border-radius: 50%;
+  background: var(--lag-paper);
+  color: var(--lag-text);
+  font-size: 0.72rem;
+  font-weight: 700;
+}
+
+.lag-social-peer-copy {
+  display: grid;
+  min-width: 0;
+  gap: var(--lag-space-1);
+}
+
+.lag-social-peer-copy strong,
+.lag-social-peer-copy small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.lag-social-peer-copy strong {
+  color: var(--lag-text);
+  font-size: 0.84rem;
+}
+
+.lag-social-peer-copy small,
+.lag-connection-state {
+  color: var(--lag-text-2);
+  font-size: 0.68rem;
+}
+
+.lag-connection-state {
+  flex: 0 0 auto;
+  padding: var(--lag-space-1) var(--lag-space-2);
+  border: 1px solid var(--lag-divider);
+  border-radius: 999px;
+  background: var(--lag-panel);
+}
+
+.lag-connection-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: var(--lag-space-2);
+}
+
+.lag-connection-pagination {
+  display: grid;
+  flex: 0 0 auto;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: var(--lag-space-3);
+  padding-top: var(--lag-space-3);
+  border-top: 1px solid var(--lag-divider);
+}
+
+.lag-connection-pagination span {
+  color: var(--lag-text-2);
+  font-size: 0.68rem;
+  text-align: center;
+}
+
+.lag-chat-layout {
+  display: grid;
+  min-height: 0;
+  flex: 1 1 auto;
+  grid-template-columns: 210px minmax(0, 1fr);
+  gap: var(--lag-space-3);
+}
+
+.lag-chat-channels {
+  display: flex;
+  min-height: 0;
+  flex-direction: column;
+  gap: var(--lag-space-3);
+  overflow: hidden;
+  padding-right: var(--lag-space-3);
+  border-right: 1px solid var(--lag-divider);
+}
+
+.lag-chat-channel-list {
+  display: grid;
+  gap: var(--lag-space-2);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
+.lag-chat-channel {
+  display: grid;
+  min-height: 76px;
+  grid-template-columns: 38px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: var(--lag-space-2);
+  padding: var(--lag-space-2);
+  border: 1px solid var(--lag-divider);
+  border-radius: var(--lag-radius-md);
+  background: var(--lag-muted-surface);
+  color: var(--lag-text);
+  text-align: left;
+}
+
+.lag-chat-channel .lag-social-peer-mark {
+  width: 38px;
+  height: 38px;
+  flex-basis: 38px;
+}
+
+.lag-chat-channel > span:nth-child(2) {
+  display: grid;
+  min-width: 0;
+  gap: var(--lag-space-1);
+}
+
+.lag-chat-channel strong,
+.lag-chat-channel small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.lag-chat-channel strong {
+  font-size: 0.78rem;
+}
+
+.lag-chat-channel small {
+  color: var(--lag-text-2);
+  font-size: 0.64rem;
+}
+
+.lag-chat-channel:hover,
+.lag-chat-channel[data-selected="true"] {
+  border-color: var(--lag-focus);
+  background: var(--lag-control-hover-bg);
+}
+
+.lag-chat-channel[data-selected="true"] {
+  box-shadow: inset 4px 0 0 var(--lag-state-selected);
+}
+
+.lag-chat-read-only {
+  color: var(--lag-state-read-only) !important;
+  text-transform: uppercase;
+}
+
+.lag-chat-conversation {
+  display: flex;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  overflow: hidden;
+  border: 1px solid var(--lag-border);
+  border-left: 4px solid var(--lag-cyan);
+  border-radius: var(--lag-radius-md);
+  background: var(--lag-panel);
+}
+
+.lag-chat-placeholder {
+  margin: auto;
+}
+
+.lag-chat-conversation-header {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--lag-space-3);
+  padding: var(--lag-space-3) var(--lag-space-4);
+  border-bottom: 1px solid var(--lag-divider);
+  background: var(--lag-panel-2);
+}
+
+.lag-chat-conversation-header h3 {
+  color: var(--lag-text);
+  font-size: 0.94rem;
+  font-weight: 700;
+}
+
+.lag-chat-conversation-header p,
+.lag-chat-conversation-header > strong {
+  color: var(--lag-text-2);
+  font-size: 0.68rem;
+}
+
+.lag-chat-conversation-header > strong {
+  padding: var(--lag-space-1) var(--lag-space-2);
+  border: 1px solid var(--lag-state-read-only);
+  border-radius: 999px;
+}
+
+.lag-chat-message-list {
+  display: flex;
+  min-height: 0;
+  flex: 1 1 auto;
+  flex-direction: column;
+  gap: var(--lag-space-3);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding: var(--lag-space-4);
+}
+
+.lag-chat-load-older {
+  align-self: center;
+}
+
+.lag-chat-message {
+  display: grid;
+  max-width: 82%;
+  gap: var(--lag-space-2);
+  padding: var(--lag-space-3);
+  border: 1px solid var(--lag-divider);
+  border-radius: var(--lag-radius-md);
+  background: var(--lag-muted-surface);
+  color: var(--lag-text);
+}
+
+.lag-chat-message[data-owner="mine"] {
+  align-self: flex-end;
+  border-right: 4px solid var(--lag-violet);
+  background: var(--lag-selected-surface);
+}
+
+.lag-chat-message[data-owner="peer"] {
+  align-self: flex-start;
+  border-left: 4px solid var(--lag-cyan);
+}
+
+.lag-chat-message > div {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--lag-space-2);
+  color: var(--lag-text-2);
+  font-size: 0.62rem;
+}
+
+.lag-chat-message > div strong {
+  color: var(--lag-text);
+}
+
+.lag-chat-message p {
+  overflow-wrap: anywhere;
+  color: var(--lag-text);
+  font-size: 0.82rem;
+  white-space: pre-wrap;
+}
+
+.lag-chat-composer {
+  display: grid;
+  flex: 0 0 auto;
+  gap: var(--lag-space-2);
+  padding: var(--lag-space-3);
+  border-top: 1px solid var(--lag-divider);
+  background: var(--lag-panel-2);
+}
+
+.lag-chat-composer > p {
+  color: var(--lag-text-2);
+  font-size: 0.7rem;
+}
+
+.lag-chat-composer > div {
+  display: flex;
+  gap: var(--lag-space-2);
+}
+
+.lag-chat-composer textarea {
+  min-width: 0;
+  flex: 1 1 auto;
+  resize: none;
+  padding: var(--lag-space-2) var(--lag-space-3);
+}
+
+.lag-chat-composer button {
+  min-width: 72px;
+  gap: var(--lag-space-2);
+  border-color: var(--lag-cyan);
+}
+
 .lag-semantic-controls label {
   color: var(--lag-text-2) !important;
 }
@@ -2777,20 +3253,84 @@ textarea.lag-journal-control {
     max-height: calc(100dvh - 112px - env(safe-area-inset-bottom) - max(16px, env(safe-area-inset-top))) !important;
   }
 
+  .lag-social-drawer {
+    padding: var(--lag-space-3);
+  }
+
+  .lag-direct-chat-drawer {
+    height: calc(100dvh - 112px - env(safe-area-inset-bottom) - max(16px, env(safe-area-inset-top))) !important;
+  }
+
+  .lag-connection-row-main {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .lag-connection-state {
+    align-self: flex-start;
+  }
+
+  .lag-connection-actions {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .lag-connection-actions .lag-social-button:last-child:nth-child(odd) {
+    grid-column: 1 / -1;
+  }
+
   .lag-notification-dropdown {
     width: calc(100vw - 32px) !important;
   }
 
   .lag-chat-layout {
     grid-template-columns: minmax(0, 1fr) !important;
-    grid-template-rows: minmax(96px, 32%) minmax(0, 1fr);
+    grid-template-rows: auto minmax(0, 1fr);
+    overflow: hidden;
   }
 
   .lag-chat-channels {
+    max-height: 112px;
     border-right: 0;
     border-bottom: 1px solid var(--lag-divider);
     padding-right: 0;
     padding-bottom: var(--lag-space-3);
+  }
+
+  .lag-chat-channel-list {
+    display: flex;
+    overflow-x: auto;
+    overflow-y: hidden;
+  }
+
+  .lag-chat-channel {
+    min-width: min(210px, calc(100vw - 80px));
+  }
+
+  .lag-chat-conversation-header,
+  .lag-chat-message-list {
+    padding-inline: var(--lag-space-3);
+  }
+
+  .lag-chat-message {
+    max-width: 88%;
+  }
+
+  .lag-chat-composer > div {
+    align-items: stretch;
+  }
+
+  .lag-chat-composer button {
+    min-width: 56px;
+    padding-inline: var(--lag-space-2);
+  }
+
+  .lag-chat-composer button span {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip-path: inset(50%);
   }
 }
 
@@ -2859,6 +3399,15 @@ textarea.lag-journal-control {
   .lag-growth-button,
   .lag-growth-change,
   .lag-growth-section {
+    transition-duration: 0s;
+  }
+
+  .lag-social-button,
+  .lag-connection-tabs button,
+  .lag-connection-row,
+  .lag-chat-channel,
+  .lag-chat-message,
+  .lag-chat-composer {
     transition-duration: 0s;
   }
 

--- a/features/social/ConnectionsDrawer.test.tsx
+++ b/features/social/ConnectionsDrawer.test.tsx
@@ -22,7 +22,7 @@ describe("Connections utility drawer surface", () => {
     expect(screen.getByRole("dialog", { name: "Current Player Connections" })).toBeInTheDocument();
     expect(await screen.findByText("Asuna")).toBeInTheDocument();
     expect(screen.getByText("Fencer · Level 76")).toBeInTheDocument();
-    expect(screen.queryByText(/online|last seen/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/online|last seen|presence|unread|group/i)).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /message|gift/i })).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("tab", { name: "Followers" }));
@@ -34,6 +34,12 @@ describe("Connections utility drawer surface", () => {
     expect(screen.queryByRole("button", { name: /^mute|unmute|block|unblock$/i })).not.toBeInTheDocument();
     fireEvent.click(screen.getAllByRole("button", { name: "Follow back" })[0]);
     await waitFor(() => expect(screen.getAllByRole("button", { name: "Unfollow" }).length).toBeGreaterThan(1));
+
+    const source = readFileSync("features/social/ConnectionsDrawer.tsx", "utf8");
+    expect(source).not.toMatch(/data-theme|민준|서연|현우|밴드 선배|가족 그룹|Backend Study/);
+    const css = readFileSync("app/globals.css", "utf8");
+    const socialCss = css.slice(css.indexOf("/* v7 Social utilities"), css.indexOf(".lag-semantic-controls"));
+    expect(socialCss).not.toMatch(/#[0-9a-f]{3,8}|rgba?\(/i);
   });
 
   it("active-tab read failure exposes a direction-specific Retry", async () => {

--- a/features/social/ConnectionsDrawer.tsx
+++ b/features/social/ConnectionsDrawer.tsx
@@ -7,19 +7,13 @@ import { useDraggableWindow } from "@/shared/hooks/useDraggableWindow";
 import UtilityPortal from "@/shared/ui/UtilityPortal";
 import { useConnectionsQueries } from "./useConnectionsQueries";
 
-const buttonStyle = {
-  border: "1px solid var(--lag-control-border)",
-  background: "var(--lag-control-bg)",
-  color: "var(--lag-control-text)",
-  borderRadius: "var(--lag-radius-sm)",
-} as const;
-
 function Peer({ peer }: { peer: ConnectionPeer }) {
   return (
-    <div className="min-w-0 flex-1">
-      <strong className="block truncate text-sm" style={{ color: "var(--lag-text)" }}>{peer.name}</strong>
-      <span className="block truncate text-xs" style={{ color: "var(--lag-text-2)" }}>
-        {peer.job ? `${peer.job} · ` : ""}Level {peer.level}
+    <div className="lag-social-peer">
+      <span className="lag-social-peer-mark" aria-hidden>{peer.name.trim().charAt(0).toUpperCase() || "?"}</span>
+      <span className="lag-social-peer-copy">
+        <strong>{peer.name}</strong>
+        <small>{peer.job ? `${peer.job} · ` : ""}Level {peer.level}</small>
       </span>
     </div>
   );
@@ -56,99 +50,71 @@ export default function ConnectionsDrawer({ open: controlledOpen, onOpenChange, 
 
   return (
     <>
-      <button
-        type="button"
-        aria-label="Connections"
-        aria-expanded={open}
-        title="Connections"
-        onClick={() => setOpen(!open)}
-        className="lag-utility-button"
-      >
+      <button type="button" aria-label="Connections" aria-expanded={open} title="Connections" onClick={() => setOpen(!open)} className="lag-utility-button">
         <span className="lag-utility-label">CN</span>
       </button>
 
       {open ? (
         <UtilityPortal>
-          <aside
-          ref={floating.windowRef}
-          role="dialog"
-          aria-label="Current Player Connections"
-          className="lag-utility-drawer flex max-h-[calc(100vh-3rem)] w-[min(420px,calc(100vw-3rem))] flex-col overflow-hidden p-4"
-          style={floating.windowStyle}
-        >
-          <header className="lag-utility-drag-handle flex shrink-0 items-center justify-between gap-3" {...floating.dragHandleProps}>
-            <div>
-              <p className="text-[10px] uppercase tracking-[0.2em]" style={{ color: "var(--lag-text-2)" }}>Current Player</p>
-              <h2 className="text-lg font-semibold tracking-[0.08em]" style={{ color: "var(--lag-text)" }}>Connections</h2>
+          <aside ref={floating.windowRef} role="dialog" aria-label="Current Player Connections" aria-busy={locked} className="lag-utility-drawer lag-social-drawer lag-connections-drawer" style={floating.windowStyle}>
+            <header className="lag-utility-drag-handle lag-social-header" {...floating.dragHandleProps}>
+              <div><p>Current Player</p><h2>Connections</h2></div>
+              <button type="button" aria-label="Close Connections" onClick={() => setOpen(false)} className="lag-social-button">Close</button>
+            </header>
+
+            <div className="lag-connection-tabs" role="tablist" aria-label="Connection direction">
+              {(["followings", "followers"] as const).map((tab) => (
+                <button key={tab} type="button" role="tab" aria-selected={state.activeTab === tab} data-selected={state.activeTab === tab} onClick={() => state.setActiveTab(tab)}>
+                  {tab === "followings" ? "Followings" : "Followers"}
+                </button>
+              ))}
             </div>
-            <button type="button" aria-label="Close Connections" onClick={() => setOpen(false)} className="px-3 py-2 text-xs" style={buttonStyle}>Close</button>
-          </header>
 
-          <div className="mt-4 grid grid-cols-2 gap-2" role="tablist" aria-label="Connection direction">
-            {(["followings", "followers"] as const).map((tab) => (
-              <button
-                key={tab}
-                type="button"
-                role="tab"
-                aria-selected={state.activeTab === tab}
-                onClick={() => state.setActiveTab(tab)}
-                className="px-3 py-2 text-xs font-semibold uppercase tracking-[0.12em]"
-                style={{ ...buttonStyle, background: state.activeTab === tab ? "var(--lag-selected-surface)" : "var(--lag-control-bg)", borderColor: state.activeTab === tab ? "var(--lag-focus)" : "var(--lag-control-border)" }}
-              >
-                {tab === "followings" ? "Followings" : "Followers"}
-              </button>
-            ))}
-          </div>
+            <div className="lag-connections-summary"><span>{state.activeTab === "followings" ? "People you follow" : "People following you"}</span><strong>{page.totalElements} total</strong></div>
+            {queryError ? <div className="lag-social-state"><p role="alert" className="lag-social-feedback" data-state="error">{queryError}</p><button type="button" className="lag-social-button" onClick={() => void retry()}>Retry</button></div> : null}
+            {state.mutationError ? <p role="alert" className="lag-social-feedback" data-state="error">{state.mutationError}</p> : null}
+            {locked ? <p role="status" className="lag-social-feedback" data-state="pending">Updating relationship...</p> : null}
 
-          <p className="mt-3 text-xs" style={{ color: "var(--lag-text-2)" }}>{page.totalElements} total</p>
-          {queryError ? <div className="mt-2 flex items-center gap-2"><p role="alert" className="text-xs" style={{ color: "var(--lag-state-error)" }}>{queryError}</p><button type="button" className="px-2 py-1 text-xs" style={buttonStyle} onClick={() => void retry()}>Retry</button></div> : null}
-          {state.mutationError ? <p role="alert" className="mt-2 text-xs" style={{ color: "var(--lag-state-error)" }}>{state.mutationError}</p> : null}
+            <div className="lag-connection-list">
+              {state.loading[state.activeTab] ? <p role="status" className="lag-social-empty">Loading connections...</p> : null}
+              {!state.loading[state.activeTab] && page.contents.length === 0 ? <p className="lag-social-empty">No connections.</p> : null}
 
-          <div className="mt-3 min-h-28 flex-1 space-y-2 overflow-y-auto">
-            {state.loading[state.activeTab] ? <p className="py-6 text-center text-sm" style={{ color: "var(--lag-text-2)" }}>Loading...</p> : null}
-            {!state.loading[state.activeTab] && page.contents.length === 0 ? <p className="py-6 text-center text-sm" style={{ color: "var(--lag-text-2)" }}>No connections.</p> : null}
-
-            {state.activeTab === "followings" ? state.followings.contents.map((following) => (
-              <article key={following.followId} className="lag-utility-row rounded-sm border p-3">
-                <div className="flex items-start gap-3">
-                  <Peer peer={following.peer} />
-                  <span className="text-[10px] uppercase" style={{ color: "var(--lag-text-2)" }}>
-                    {[following.muted && "Muted", following.blocked && "Blocked"].filter(Boolean).join(" · ") || "Following"}
-                  </span>
-                </div>
-                <div className="mt-3 flex flex-wrap gap-2">
-                  <button type="button" disabled={locked} onClick={() => void state.toggleMute(following)} className="px-2 py-1 text-xs disabled:opacity-40" style={buttonStyle}>{following.muted ? "Unmute" : "Mute"}</button>
-                  <button type="button" disabled={locked} onClick={() => void state.toggleBlock(following)} className="px-2 py-1 text-xs disabled:opacity-40" style={buttonStyle}>{following.blocked ? "Unblock" : "Block"}</button>
-                  <button type="button" disabled={locked} onClick={() => void state.unfollowFollowing(following)} className="px-2 py-1 text-xs disabled:opacity-40" style={{ ...buttonStyle, color: "var(--lag-state-error)" }}>Unfollow</button>
-                </div>
-              </article>
-            )) : state.followers.contents.map((follower) => {
-              const inconsistent = follower.followedBack && follower.outboundFollowId === null;
-              return (
-                <article key={follower.peer.playerId} className="lag-utility-row flex items-center gap-3 rounded-sm border p-3">
-                  <Peer peer={follower.peer} />
-                  <div className="flex flex-wrap justify-end gap-2">
-                    {follower.followedBack && onMessage ? <button type="button" onClick={() => onMessage(follower.peer.playerId)} className="px-2 py-1 text-xs" style={buttonStyle}>Message</button> : null}
-                    <button
-                      type="button"
-                      disabled={locked || inconsistent}
-                      onClick={() => void (follower.followedBack ? state.unfollowFollower(follower) : state.followBack(follower))}
-                      className="px-2 py-1 text-xs disabled:opacity-40"
-                      style={buttonStyle}
-                    >
-                      {inconsistent ? "Unavailable" : follower.followedBack ? "Unfollow" : "Follow back"}
-                    </button>
+              {state.activeTab === "followings" ? state.followings.contents.map((following) => (
+                <article key={following.followId} className="lag-connection-row">
+                  <div className="lag-connection-row-main">
+                    <Peer peer={following.peer} />
+                    <span className="lag-connection-state">{[following.muted && "Muted", following.blocked && "Blocked"].filter(Boolean).join(" · ") || "Following"}</span>
+                  </div>
+                  <div className="lag-connection-actions">
+                    <button type="button" disabled={locked} onClick={() => void state.toggleMute(following)} className="lag-social-button">{following.muted ? "Unmute" : "Mute"}</button>
+                    <button type="button" disabled={locked} onClick={() => void state.toggleBlock(following)} className="lag-social-button">{following.blocked ? "Unblock" : "Block"}</button>
+                    <button type="button" disabled={locked} onClick={() => void state.unfollowFollowing(following)} className="lag-social-button" data-variant="destructive">Unfollow</button>
                   </div>
                 </article>
-              );
-            })}
-          </div>
+              )) : state.followers.contents.map((follower) => {
+                const inconsistent = follower.followedBack && follower.outboundFollowId === null;
+                return (
+                  <article key={follower.peer.playerId} className="lag-connection-row">
+                    <div className="lag-connection-row-main">
+                      <Peer peer={follower.peer} />
+                      <span className="lag-connection-state">{follower.followedBack ? "Followed back" : "Follower"}</span>
+                    </div>
+                    <div className="lag-connection-actions">
+                      {follower.followedBack && onMessage ? <button type="button" onClick={() => onMessage(follower.peer.playerId)} className="lag-social-button" data-variant="primary">Message</button> : null}
+                      <button type="button" disabled={locked || inconsistent} onClick={() => void (follower.followedBack ? state.unfollowFollower(follower) : state.followBack(follower))} className="lag-social-button">
+                        {inconsistent ? "Unavailable" : follower.followedBack ? "Unfollow" : "Follow back"}
+                      </button>
+                    </div>
+                  </article>
+                );
+              })}
+            </div>
 
-          <footer className="mt-3 flex shrink-0 items-center justify-between gap-3 border-t pt-3" style={{ borderColor: "var(--lag-divider)" }}>
-            <button type="button" disabled={pageIndex === 0} onClick={() => setPage((current) => current - 1)} className="px-3 py-1.5 text-xs disabled:opacity-40" style={buttonStyle}>Previous</button>
-            <span className="text-xs" style={{ color: "var(--lag-text-2)" }}>Page {page.totalPages === 0 ? 0 : page.page + 1} of {page.totalPages}</span>
-            <button type="button" disabled={pageIndex + 1 >= page.totalPages} onClick={() => setPage((current) => current + 1)} className="px-3 py-1.5 text-xs disabled:opacity-40" style={buttonStyle}>Next</button>
-          </footer>
+            <footer className="lag-connection-pagination">
+              <button type="button" disabled={pageIndex === 0} onClick={() => setPage((current) => current - 1)} className="lag-social-button">Previous</button>
+              <span>Page {page.totalPages === 0 ? 0 : page.page + 1} of {page.totalPages}</span>
+              <button type="button" disabled={pageIndex + 1 >= page.totalPages} onClick={() => setPage((current) => current + 1)} className="lag-social-button">Next</button>
+            </footer>
           </aside>
         </UtilityPortal>
       ) : null}

--- a/features/social/SocialUtilityHub.test.tsx
+++ b/features/social/SocialUtilityHub.test.tsx
@@ -1,0 +1,45 @@
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { directChatMock } from "./chat/mock";
+import { connectionsMock } from "./mock";
+import SocialUtilityHub from "./SocialUtilityHub";
+
+vi.mock("@/features/auth/AuthContext", () => ({ useAuth: () => ({ playerId: 6 }) }));
+
+describe("global Social utility ownership", () => {
+  beforeEach(() => {
+    connectionsMock.reset();
+    directChatMock.reset();
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: 1200 });
+    Object.defineProperty(window, "innerHeight", { configurable: true, value: 800 });
+  });
+
+  it("Connections와 Direct Chat을 상호 배타적으로 열고 Escape로 닫는다", async () => {
+    render(<SocialUtilityHub />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Connections" }));
+    expect(screen.getByRole("dialog", { name: "Current Player Connections" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Direct Chat" }));
+    expect(screen.queryByRole("dialog", { name: "Current Player Connections" })).not.toBeInTheDocument();
+    expect(screen.getByRole("dialog", { name: "Direct Friend Chat" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Connections" }));
+    expect(screen.queryByRole("dialog", { name: "Direct Friend Chat" })).not.toBeInTheDocument();
+    expect(screen.getByRole("dialog", { name: "Current Player Connections" })).toBeInTheDocument();
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(screen.queryByRole("dialog", { name: "Current Player Connections" })).not.toBeInTheDocument();
+  });
+
+  it("eligible Follower Message가 Connections를 닫고 canonical friend channel을 선택한다", async () => {
+    render(<SocialUtilityHub />);
+    fireEvent.click(screen.getByRole("button", { name: "Connections" }));
+    fireEvent.click(screen.getByRole("tab", { name: "Followers" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Message" }));
+
+    expect(screen.queryByRole("dialog", { name: "Current Player Connections" })).not.toBeInTheDocument();
+    const chat = screen.getByRole("dialog", { name: "Direct Friend Chat" });
+    await waitFor(() => expect(within(chat).getByRole("button", { name: /Asuna/ })).toHaveAttribute("aria-pressed", "true"));
+    expect(within(chat).getByText("Canonical message 55")).toBeInTheDocument();
+  });
+});

--- a/features/social/chat/DirectChatDrawer.test.tsx
+++ b/features/social/chat/DirectChatDrawer.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { readFileSync } from "node:fs";
 import { renderToString } from "react-dom/server";
 import { expect, it, vi } from "vitest";
 
@@ -22,7 +23,10 @@ it("renders canonical identity fields and opens an existing read-only channel wi
     channelsRetry: vi.fn(),
     selectedChannelId: 20,
     selectChannel,
-    messages: [{ id: 1, channelId: 20, senderId: 6, content: "canonical", edited: false, createdAt: "2026-08-18T00:00:00Z" }],
+    messages: [
+      { id: 1, channelId: 20, senderId: 80, content: "peer canonical", edited: true, createdAt: "2026-08-17T00:00:00Z" },
+      { id: 2, channelId: 20, senderId: 6, content: "my canonical", edited: false, createdAt: "2026-08-18T00:00:00Z" },
+    ],
     messagesLoading: false,
     messagesError: null,
     loadLatest: vi.fn(),
@@ -42,14 +46,27 @@ it("renders canonical identity fields and opens an existing read-only channel wi
 
   render(<DirectChatDrawer chat={chat} />);
   expect(screen.getByRole("dialog", { name: "Direct Friend Chat" })).toBeInTheDocument();
-  expect(screen.getByText("Mage · Level 2")).toBeInTheDocument();
+  expect(screen.getAllByText("Mage · Level 2")).toHaveLength(2);
   expect(screen.getByText("You")).toBeInTheDocument();
+  expect(screen.getByLabelText("Message from you")).toHaveAttribute("data-owner", "mine");
+  expect(screen.getByLabelText("Message from B")).toHaveAttribute("data-owner", "peer");
+  expect(screen.getByText("Edited")).toBeInTheDocument();
   expect(screen.getByRole("textbox", { name: "Message" })).toBeDisabled();
+  expect(screen.getByRole("button", { name: "Send message" })).toBeDisabled();
+  expect(screen.getByText("This channel is read-only.")).toHaveAttribute("role", "status");
   expect(screen.queryByText(/presence|typing|unread/i)).not.toBeInTheDocument();
 
   fireEvent.click(screen.getByRole("button", { name: /A\s*Level 1/i }));
   expect(selectChannel).toHaveBeenCalledWith(10);
   expect(openFriendChat).not.toHaveBeenCalled();
+
+  const source = readFileSync("features/social/chat/DirectChatDrawer.tsx", "utf8");
+  expect(source).not.toMatch(/group|guild|party|Role Relation|presence|unread|read receipt|data-theme/i);
+  const css = readFileSync("app/globals.css", "utf8");
+  const socialCss = css.slice(css.indexOf("/* v7 Social utilities"), css.indexOf(".lag-semantic-controls"));
+  expect(socialCss).not.toMatch(/#[0-9a-f]{3,8}|rgba?\(/i);
+  expect(css).toContain("grid-template-rows: auto minmax(0, 1fr)");
+  expect(css).toContain("height: calc(100dvh - 112px - env(safe-area-inset-bottom)");
 });
 
 it("renders an authoritative deterministic timestamp before client localization", () => {

--- a/features/social/chat/DirectChatDrawer.tsx
+++ b/features/social/chat/DirectChatDrawer.tsx
@@ -7,13 +7,6 @@ import { useDraggableWindow } from "@/shared/hooks/useDraggableWindow";
 import UtilityPortal from "@/shared/ui/UtilityPortal";
 import type { DirectChatState } from "./useDirectChat";
 
-const buttonStyle = {
-  border: "1px solid var(--lag-control-border)",
-  background: "var(--lag-control-bg)",
-  color: "var(--lag-control-text)",
-  borderRadius: "var(--lag-radius-sm)",
-} as const;
-
 export function MessageTimestamp({ createdAt }: { createdAt: string }) {
   const [label, setLabel] = useState(createdAt);
   useEffect(() => setLabel(new Date(createdAt).toLocaleString()), [createdAt]);
@@ -35,90 +28,75 @@ export default function DirectChatDrawer({ chat, onOpen }: { chat: DirectChatSta
 
   return (
     <>
-      <button
-        type="button"
-        aria-label="Direct Chat"
-        aria-expanded={chat.open}
-        title="Direct Chat"
-        onClick={() => {
-          if (!chat.open) onOpen?.();
-          chat.setOpen(!chat.open);
-        }}
-        className="lag-utility-button"
-      >
+      <button type="button" aria-label="Direct Chat" aria-expanded={chat.open} title="Direct Chat" onClick={() => {
+        if (!chat.open) onOpen?.();
+        chat.setOpen(!chat.open);
+      }} className="lag-utility-button">
         <span className="lag-utility-label">CH</span>
       </button>
 
       {chat.open ? (
         <UtilityPortal>
-          <aside
-          ref={floating.windowRef}
-          role="dialog"
-          aria-label="Direct Friend Chat"
-          className="lag-utility-drawer flex h-[min(680px,calc(100vh-3rem))] w-[min(720px,calc(100vw-3rem))] flex-col overflow-hidden p-4"
-          style={floating.windowStyle}
-        >
-          <header className="lag-utility-drag-handle flex shrink-0 items-center justify-between gap-3" {...floating.dragHandleProps}>
-            <div>
-              <p className="text-[10px] uppercase tracking-[0.2em]" style={{ color: "var(--lag-text-2)" }}>Current Player</p>
-              <h2 className="text-lg font-semibold tracking-[0.08em]" style={{ color: "var(--lag-text)" }}>Direct Chat</h2>
-            </div>
-            <button type="button" aria-label="Close Direct Chat" onClick={() => chat.setOpen(false)} className="px-3 py-2 text-xs" style={buttonStyle}>Close</button>
-          </header>
+          <aside ref={floating.windowRef} role="dialog" aria-label="Direct Friend Chat" className="lag-utility-drawer lag-social-drawer lag-direct-chat-drawer" style={floating.windowStyle}>
+            <header className="lag-utility-drag-handle lag-social-header" {...floating.dragHandleProps}>
+              <div><p>Current Player</p><h2>Direct Chat</h2></div>
+              <button type="button" aria-label="Close Direct Chat" onClick={() => chat.setOpen(false)} className="lag-social-button">Close</button>
+            </header>
 
-          {chat.openError ? <p role="alert" className="mt-2 text-xs" style={{ color: "var(--lag-state-error)" }}>{chat.openError}</p> : null}
-          <div className="lag-chat-layout mt-4 grid min-h-0 flex-1 grid-cols-[190px_1fr] gap-3">
-            <section aria-label="Friend channels" className="lag-chat-channels min-h-0 overflow-y-auto border-r pr-3" style={{ borderColor: "var(--lag-divider)" }}>
-              {chat.channelsLoading ? <p className="py-4 text-xs" style={{ color: "var(--lag-text-2)" }}>Loading channels...</p> : null}
-              {chat.channelsError ? <div><p role="alert" className="text-xs" style={{ color: "var(--lag-state-error)" }}>{chat.channelsError}</p><button type="button" className="mt-2 px-2 py-1 text-xs" style={buttonStyle} onClick={() => void chat.channelsRetry()}>Retry</button></div> : null}
-              {!chat.channelsLoading && !chat.channelsError && chat.channels.length === 0 ? <p className="py-4 text-xs" style={{ color: "var(--lag-text-2)" }}>No friend channels.</p> : null}
-              <div className="space-y-2">
-                {chat.channels.map((channel) => (
-                  <button
-                    key={channel.channelId}
-                    type="button"
-                    aria-pressed={channel.channelId === chat.selectedChannelId}
-                    onClick={() => void chat.selectChannel(channel.channelId)}
-                    className="w-full p-2 text-left"
-                    style={{ ...buttonStyle, background: channel.channelId === chat.selectedChannelId ? "var(--lag-selected-surface)" : "var(--lag-control-bg)", borderColor: channel.channelId === chat.selectedChannelId ? "var(--lag-focus)" : "var(--lag-control-border)" }}
-                  >
-                    <strong className="block truncate text-xs">{channel.peer.name}</strong>
-                    <span className="block truncate text-[10px]" style={{ color: "var(--lag-text-2)" }}>{channel.peer.job ? `${channel.peer.job} · ` : ""}Level {channel.peer.level}</span>
-                    {channel.readOnly ? <span className="text-[10px] uppercase" style={{ color: "var(--lag-state-error)" }}>Read only</span> : null}
-                  </button>
-                ))}
-              </div>
-            </section>
+            {chat.openError ? <p role="alert" className="lag-social-feedback" data-state="error">{chat.openError}</p> : null}
+            <div className="lag-chat-layout">
+              <section aria-label="Friend channels" className="lag-chat-channels">
+                <header><span>Friend Channels</span><strong>{chat.channels.length}</strong></header>
+                {chat.channelsLoading ? <p role="status" className="lag-social-empty">Loading channels...</p> : null}
+                {chat.channelsError ? <div className="lag-social-state"><p role="alert" className="lag-social-feedback" data-state="error">{chat.channelsError}</p><button type="button" className="lag-social-button" onClick={() => void chat.channelsRetry()}>Retry</button></div> : null}
+                {!chat.channelsLoading && !chat.channelsError && chat.channels.length === 0 ? <p className="lag-social-empty">No friend channels.</p> : null}
+                <div className="lag-chat-channel-list">
+                  {chat.channels.map((channel) => (
+                    <button key={channel.channelId} type="button" aria-pressed={channel.channelId === chat.selectedChannelId} data-selected={channel.channelId === chat.selectedChannelId} onClick={() => void chat.selectChannel(channel.channelId)} className="lag-chat-channel">
+                      <span className="lag-social-peer-mark" aria-hidden>{channel.peer.name.trim().charAt(0).toUpperCase() || "?"}</span>
+                      <span><strong>{channel.peer.name}</strong><small>{channel.peer.job ? `${channel.peer.job} · ` : ""}Level {channel.peer.level}</small>{channel.readOnly ? <small className="lag-chat-read-only">Read only</small> : null}</span>
+                      <b aria-hidden>→</b>
+                    </button>
+                  ))}
+                </div>
+              </section>
 
-            <section aria-label="Messages" className="flex min-h-0 flex-col">
-              {!selected ? <p className="m-auto text-sm" style={{ color: "var(--lag-text-2)" }}>Select a friend channel.</p> : playerId === null ? <p role="alert" className="m-auto text-sm" style={{ color: "var(--lag-state-error)" }}>Authenticated player identity is unavailable.</p> : (
-                <>
-                  <div className="min-h-0 flex-1 space-y-2 overflow-y-auto">
-                    {chat.hasMore ? <button type="button" disabled={chat.olderLoading} onClick={() => void chat.loadOlder()} className="mx-auto block px-3 py-1 text-xs disabled:opacity-40" style={buttonStyle}>{chat.olderLoading ? "Loading..." : "Load older"}</button> : null}
-                    {chat.messagesError ? <div className="text-center"><p role="alert" className="text-xs" style={{ color: "var(--lag-state-error)" }}>{chat.messagesError}</p><button type="button" className="mt-2 px-2 py-1 text-xs" style={buttonStyle} onClick={() => void chat.loadLatest()}>Retry</button></div> : null}
-                    {chat.messagesLoading ? <p className="py-8 text-center text-sm" style={{ color: "var(--lag-text-2)" }}>Loading messages...</p> : null}
-                    {!chat.messagesLoading && chat.messages.map((message) => {
-                      const mine = message.senderId === playerId;
-                      return (
-                        <article key={message.id} className={`lag-utility-row max-w-[85%] rounded-sm border p-2 ${mine ? "ml-auto" : "mr-auto"}`}>
-                          <div className="flex gap-2 text-[10px]" style={{ color: "var(--lag-text-2)" }}><span>{mine ? "You" : selected.peer.name}</span><MessageTimestamp createdAt={message.createdAt} />{message.edited ? <span>Edited</span> : null}</div>
-                          <p className="mt-1 whitespace-pre-wrap break-words text-sm" style={{ color: "var(--lag-text)" }}>{message.content}</p>
-                        </article>
-                      );
-                    })}
-                  </div>
-                  <form className="mt-3 border-t pt-3" style={{ borderColor: "var(--lag-divider)" }} onSubmit={(event) => { event.preventDefault(); void chat.send(); }}>
-                    {selected.readOnly ? <p className="mb-2 text-xs" style={{ color: "var(--lag-text-2)" }}>This channel is read-only.</p> : null}
-                    {chat.sendError ? <p role="alert" className="mb-2 text-xs" style={{ color: "var(--lag-state-error)" }}>{chat.sendError}</p> : null}
-                    <div className="flex gap-2">
-                      <textarea aria-label="Message" rows={2} disabled={selected.readOnly || chat.sending} value={chat.draft} onChange={(event) => chat.setDraft(event.target.value)} className="min-w-0 flex-1 resize-none px-3 py-2 text-sm disabled:opacity-40" style={buttonStyle} />
-                      <button type="submit" disabled={selected.readOnly || chat.sending || !chat.draft.trim()} className="px-4 text-xs disabled:opacity-40" style={buttonStyle}>{chat.sending ? "Sending..." : "Send"}</button>
+              <section aria-label="Messages" className="lag-chat-conversation">
+                {!selected ? <p className="lag-social-empty lag-chat-placeholder">Select a friend channel.</p> : playerId === null ? <p role="alert" className="lag-social-feedback" data-state="error">Authenticated player identity is unavailable.</p> : (
+                  <>
+                    <header className="lag-chat-conversation-header">
+                      <div><span>Direct Chat</span><h3>{selected.peer.name}</h3><p>{selected.peer.job ? `${selected.peer.job} · ` : ""}Level {selected.peer.level}</p></div>
+                      {selected.readOnly ? <strong>Read only</strong> : null}
+                    </header>
+
+                    <div className="lag-chat-message-list">
+                      {chat.hasMore ? <button type="button" disabled={chat.olderLoading} onClick={() => void chat.loadOlder()} className="lag-chat-load-older">{chat.olderLoading ? "Loading..." : "Load older"}</button> : null}
+                      {chat.messagesError ? <div className="lag-social-state"><p role="alert" className="lag-social-feedback" data-state="error">{chat.messagesError}</p><button type="button" className="lag-social-button" onClick={() => void chat.loadLatest()}>Retry</button></div> : null}
+                      {chat.messagesLoading ? <p role="status" className="lag-social-empty">Loading messages...</p> : null}
+                      {!chat.messagesLoading && !chat.messagesError && chat.messages.length === 0 ? <p className="lag-social-empty">No messages yet.</p> : null}
+                      {!chat.messagesLoading && chat.messages.map((message) => {
+                        const mine = message.senderId === playerId;
+                        return (
+                          <article key={message.id} className="lag-chat-message" data-owner={mine ? "mine" : "peer"} aria-label={mine ? "Message from you" : `Message from ${selected.peer.name}`}>
+                            <div><strong>{mine ? "You" : selected.peer.name}</strong><MessageTimestamp createdAt={message.createdAt} />{message.edited ? <span>Edited</span> : null}</div>
+                            <p>{message.content}</p>
+                          </article>
+                        );
+                      })}
                     </div>
-                  </form>
-                </>
-              )}
-            </section>
-          </div>
+
+                    <form className="lag-chat-composer" onSubmit={(event) => { event.preventDefault(); void chat.send(); }}>
+                      {selected.readOnly ? <p role="status">This channel is read-only.</p> : null}
+                      {chat.sendError ? <p role="alert" className="lag-social-feedback" data-state="error">{chat.sendError}</p> : null}
+                      <div>
+                        <textarea aria-label="Message" rows={2} placeholder={selected.readOnly ? "Read-only channel" : "Write a message"} disabled={selected.readOnly || chat.sending} value={chat.draft} onChange={(event) => chat.setDraft(event.target.value)} />
+                        <button type="submit" aria-label="Send message" disabled={selected.readOnly || chat.sending || !chat.draft.trim()}>{chat.sending ? "Sending..." : <><span>Send</span><b aria-hidden>↑</b></>}</button>
+                      </div>
+                    </form>
+                  </>
+                )}
+              </section>
+            </div>
           </aside>
         </UtilityPortal>
       ) : null}


### PR DESCRIPTION
## Purpose

Apply the approved Stage 3 Enterprise Dual Theme v7 Connections / Direct Chat visual direction to the existing global social utilities while preserving current directional Follow and one-to-one Friend Chat contracts.

Closes #64

## Delivered

- v7 Connections utility treatment
- semantic Followings / Followers direction control
- real peer identity/action row treatment
- preserved mute/block/unfollow/follow-back behavior
- v7 Direct Chat channel-context treatment
- v7 mine/peer message-bubble hierarchy
- preserved cursor-based older-message loading
- preserved read-only and send/recovery behavior
- desktop draggable utility fidelity
- mobile Astral / Warm Beige utility fidelity
- accessible semantic social controls/states

## Source of Truth

Reference-only visual authority:

```text
LifeAsGame_Stage3_UI_VisualDesigner_Enterprise_Dual_Theme_Result_v7
```

Primary references:

- DT7-08 Connections / Direct Chat Astral
- DT7-08 Connections / Direct Chat Warm Beige
- MT7-07 Connections / Direct Chat Astral
- MT7-07 Connections / Direct Chat Warm Beige
- AB7-M04 Connections / Direct Chat
- shared v7 semantic/token handoff

Reference artifacts are not committed or shipped.

## Product Placement

Connections and Direct Chat remain global utilities.

No Social Orb, new top-level social navigation item, or new full-page route is introduced.

The desktop reference is used for material/anatomy hierarchy rather than as permission to change navigation ownership.

## Connections

Directional semantics remain canonical:

```text
Followings != Followers
```

Real `ConnectionPeer`, `ConnectionFollowing`, and `ConnectionFollower` data remain authoritative.

Existing:
- Mute / Unmute
- Block / Unblock
- Unfollow
- Follow back
- pagination
- loading/error/retry
- authoritative post-mutation reload

remain intact.

No screenshot-only relationship labels, groups, presence state, or unread counts are invented.

## Connections -> Direct Chat

Existing safe friend-chat transition remains authoritative:

```text
eligible mutual connection
-> open canonical friend channel
-> reload canonical channel list
-> select canonical opened channel
```

No synthetic local channel is created.

## Direct Chat

Direct Chat remains the existing one-to-one Friend Chat model.

Real:
- FriendChatChannel
- ChatMessage
- authenticated player identity
- readOnly
- cursor pagination
- draft/send state

remain authoritative.

No group chat, Role Chat, guild/party chat, presence, read receipts, reactions, or unsupported message mutation UI is introduced.

## Message Semantics

Mine/peer distinction remains based on authenticated `playerId`.

Existing:
- explicit channel selection
- stale-response guards
- Load older
- message dedupe
- send success
- failed-send recovery
- draft preservation on failure
- read-only behavior

remain intact.

## Responsive / Theme

Astral and Warm Beige share one component tree.

Desktop preserves the stabilized draggable utility-window foundation.

Mobile follows the approved MT7-07 visual grammar while keeping the header, message scroll area, composer, safe-area reservation, and bottom navigation usable.

## Scope Boundaries

This PR does not implement:

- Social Orb
- group chat
- Role Chat
- guild/party chat
- presence
- fake unread counters
- read receipts
- reactions
- notification fidelity
- economy fidelity
- settings fidelity
- backend changes
- global camera final tuning

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Redesigned the Connections drawer with clearer relationship summaries, status feedback, peer details, pagination, and responsive layouts.
  - Enhanced direct messaging with channel counts, selection indicators, conversation headers, empty states, read-only guidance, and improved composer controls.
  - Added mobile-friendly chat navigation with horizontally scrollable channels and compact controls.
  - Added reduced-motion support for social and chat interactions.

- **Bug Fixes**
  - Improved loading, error, retry, accessibility, and pending-action feedback across connections and chat.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->