### PR TITLE
[Notification] Refine inbox hierarchy and explicit read interactions

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -183,7 +183,11 @@ body {
 .lag-connection-row,
 .lag-chat-channel,
 .lag-chat-message,
-.lag-chat-composer {
+.lag-chat-composer,
+.lag-notification-action,
+.lag-notification-row,
+.lag-notification-detail,
+.lag-notification-load-older {
   transition:
     background-color var(--lag-motion-normal) ease,
     border-color var(--lag-motion-normal) ease,
@@ -2010,6 +2014,375 @@ body {
   border-color: var(--lag-cyan);
 }
 
+/* Notification inbox utility and local detail. */
+.lag-notification-anchor {
+  position: relative;
+}
+
+.lag-notification-trigger {
+  position: relative;
+  overflow: visible;
+  font-size: 0.88rem;
+}
+
+.lag-notification-trigger[data-active="true"],
+.lag-notification-trigger[data-unread="true"] {
+  border-color: var(--lag-focus);
+}
+
+.lag-notification-trigger[data-active="true"] {
+  background: var(--lag-selected-surface);
+}
+
+.lag-notification-trigger[data-unread="true"] {
+  box-shadow: 0 0 10px color-mix(in srgb, var(--lag-focus) 24%, transparent);
+}
+
+.lag-notification-badge {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  display: grid;
+  min-width: 18px;
+  height: 18px;
+  place-items: center;
+  padding-inline: var(--lag-space-1);
+  border: 2px solid var(--lag-raised-surface);
+  border-radius: 999px;
+  background: var(--lag-state-error);
+  color: var(--lag-text);
+  font-size: 0.6rem;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.lag-notification-dropdown {
+  display: flex;
+  width: min(430px, calc(100vw - 32px));
+  max-height: calc(100dvh - 32px);
+  flex-direction: column;
+  overflow: hidden;
+  border-radius: var(--lag-radius-md);
+}
+
+.lag-notification-dropdown[data-detail="true"] {
+  width: min(780px, calc(100vw - 32px));
+}
+
+.lag-notification-header {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--lag-space-3);
+  padding: var(--lag-space-3) var(--lag-space-4);
+  border-bottom: 1px solid var(--lag-divider);
+  background: var(--lag-panel-2);
+}
+
+.lag-notification-header > div:first-child {
+  min-width: 0;
+}
+
+.lag-notification-header > div:first-child span,
+.lag-notification-summary span,
+.lag-notification-row-meta,
+.lag-notification-detail-content > span {
+  color: var(--lag-text-2);
+  font-size: 0.66rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.lag-notification-header h2 {
+  color: var(--lag-text);
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.lag-notification-header > div:last-child {
+  display: flex;
+  flex: 0 0 auto;
+  gap: var(--lag-space-2);
+}
+
+.lag-notification-action,
+.lag-notification-load-older {
+  display: inline-flex;
+  min-height: 44px;
+  align-items: center;
+  justify-content: center;
+  padding: var(--lag-space-2) var(--lag-space-3);
+  border: 1px solid var(--lag-control-border);
+  border-radius: var(--lag-radius-sm);
+  background: var(--lag-control-bg);
+  color: var(--lag-control-text);
+  font-size: 0.7rem;
+  font-weight: 700;
+}
+
+.lag-notification-action:not(:disabled):hover,
+.lag-notification-load-older:not(:disabled):hover {
+  border-color: var(--lag-focus);
+  background: var(--lag-control-hover-bg);
+}
+
+.lag-notification-feedback-row {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: var(--lag-space-2);
+  padding: var(--lag-space-2) var(--lag-space-4) 0;
+}
+
+.lag-notification-feedback {
+  margin: var(--lag-space-2) var(--lag-space-4) 0;
+  padding: var(--lag-space-3);
+  border: 1px solid var(--lag-divider);
+  border-radius: var(--lag-radius-sm);
+  background: var(--lag-muted-surface);
+  color: var(--lag-text);
+  font-size: 0.72rem;
+}
+
+.lag-notification-feedback-row .lag-notification-feedback {
+  margin: 0;
+}
+
+.lag-notification-feedback[data-state="error"] {
+  border-color: var(--lag-state-error);
+  box-shadow: inset 4px 0 0 var(--lag-state-error);
+}
+
+.lag-notification-composition {
+  display: grid;
+  min-height: 0;
+  flex: 1 1 auto;
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.lag-notification-dropdown[data-detail="true"] .lag-notification-composition {
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+}
+
+.lag-notification-inbox,
+.lag-notification-detail {
+  display: flex;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.lag-notification-detail {
+  border-left: 4px solid var(--lag-violet);
+  background: var(--lag-panel);
+}
+
+.lag-notification-summary {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--lag-space-3);
+  padding: var(--lag-space-3) var(--lag-space-4);
+  border-bottom: 1px solid var(--lag-divider);
+}
+
+.lag-notification-summary strong {
+  color: var(--lag-text);
+  font-size: 0.72rem;
+}
+
+.lag-notification-list {
+  display: grid;
+  min-height: 0;
+  flex: 1 1 auto;
+  align-content: start;
+  gap: var(--lag-space-2);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding: var(--lag-space-3);
+}
+
+.lag-notification-empty {
+  padding: var(--lag-space-6) var(--lag-space-3);
+  color: var(--lag-text-2);
+  font-size: 0.76rem;
+  text-align: center;
+}
+
+.lag-notification-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  border: 1px solid var(--lag-divider);
+  border-left: 4px solid var(--lag-state-read-only);
+  border-radius: var(--lag-radius-md);
+  background: var(--lag-muted-surface);
+  color: var(--lag-text);
+}
+
+.lag-notification-row[data-read="false"] {
+  border-left-color: var(--lag-violet);
+  background: var(--lag-selected-surface);
+}
+
+.lag-notification-row[data-selected="true"] {
+  border-color: var(--lag-focus);
+  box-shadow: inset 0 -3px 0 var(--lag-state-selected);
+}
+
+.lag-notification-select {
+  display: grid;
+  min-width: 0;
+  min-height: 96px;
+  grid-template-columns: 42px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: var(--lag-space-3);
+  padding: var(--lag-space-3);
+  color: var(--lag-text);
+  text-align: left;
+}
+
+.lag-notification-select:hover {
+  background: var(--lag-control-hover-bg);
+}
+
+.lag-notification-type-mark {
+  display: grid;
+  width: 40px;
+  height: 40px;
+  place-items: center;
+  border: 1px solid var(--lag-state-read-only);
+  border-radius: 50%;
+  background: var(--lag-paper);
+  color: var(--lag-text-2);
+  font-size: 0.72rem;
+  font-weight: 700;
+}
+
+.lag-notification-type-mark[data-tone="info"] {
+  border-color: var(--lag-state-info);
+}
+
+.lag-notification-type-mark[data-tone="pending"] {
+  border-color: var(--lag-state-pending);
+}
+
+.lag-notification-type-mark[data-tone="success"] {
+  border-color: var(--lag-state-success);
+}
+
+.lag-notification-type-mark[data-tone="selected"] {
+  border-color: var(--lag-state-selected);
+}
+
+.lag-notification-copy {
+  display: grid;
+  min-width: 0;
+  gap: var(--lag-space-1);
+}
+
+.lag-notification-row-meta {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: var(--lag-space-2);
+}
+
+.lag-notification-copy strong {
+  overflow: hidden;
+  color: var(--lag-text);
+  font-size: 0.8rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.lag-notification-body {
+  display: -webkit-box;
+  overflow: hidden;
+  color: var(--lag-text-2);
+  font-size: 0.72rem;
+  line-height: 1.4;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.lag-notification-time {
+  color: var(--lag-text-2);
+  font-size: 0.7rem;
+  line-height: 1.4;
+}
+
+.lag-notification-arrow {
+  color: var(--lag-text-2);
+  font-size: 0.78rem;
+}
+
+.lag-notification-row > .lag-notification-action {
+  margin-right: var(--lag-space-3);
+}
+
+.lag-notification-load-older {
+  justify-self: center;
+}
+
+.lag-notification-detail > header {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--lag-space-3);
+  padding: var(--lag-space-3) var(--lag-space-4);
+  border-bottom: 1px solid var(--lag-divider);
+  background: var(--lag-panel-2);
+}
+
+.lag-notification-detail > header > span,
+.lag-notification-read-state {
+  padding: var(--lag-space-1) var(--lag-space-2);
+  border: 1px solid var(--lag-divider);
+  border-radius: 999px;
+  color: var(--lag-text-2);
+  font-size: 0.68rem;
+  font-weight: 700;
+}
+
+.lag-notification-detail-content {
+  display: grid;
+  min-height: 0;
+  align-content: start;
+  gap: var(--lag-space-3);
+  overflow-y: auto;
+  padding: var(--lag-space-6);
+}
+
+.lag-notification-detail-content h3 {
+  color: var(--lag-text);
+  font-size: 1.08rem;
+  font-weight: 700;
+}
+
+.lag-notification-detail-content p {
+  overflow-wrap: anywhere;
+  color: var(--lag-text);
+  font-size: 0.82rem;
+  line-height: 1.6;
+  white-space: pre-wrap;
+}
+
+.lag-notification-detail-content > div {
+  color: var(--lag-text-2);
+  font-size: 0.72rem;
+}
+
+.lag-notification-detail-content > .lag-notification-action,
+.lag-notification-detail-content > .lag-notification-read-state {
+  justify-self: start;
+}
+
 .lag-semantic-controls label {
   color: var(--lag-text-2) !important;
 }
@@ -3281,6 +3654,40 @@ textarea.lag-journal-control {
 
   .lag-notification-dropdown {
     width: calc(100vw - 32px) !important;
+    max-height: calc(100dvh - 112px - env(safe-area-inset-bottom) - max(16px, env(safe-area-inset-top))) !important;
+  }
+
+  .lag-notification-header {
+    align-items: flex-start;
+  }
+
+  .lag-notification-header > div:last-child {
+    flex-direction: column-reverse;
+  }
+
+  .lag-notification-dropdown[data-detail="true"] .lag-notification-composition {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .lag-notification-dropdown[data-view="detail"] .lag-notification-inbox {
+    display: none;
+  }
+
+  .lag-notification-row {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .lag-notification-row > .lag-notification-action {
+    width: calc(100% - 24px);
+    margin: 0 var(--lag-space-3) var(--lag-space-3);
+  }
+
+  .lag-notification-select {
+    min-height: 112px;
+  }
+
+  .lag-notification-detail-content {
+    padding: var(--lag-space-4);
   }
 
   .lag-chat-layout {
@@ -3408,6 +3815,13 @@ textarea.lag-journal-control {
   .lag-chat-channel,
   .lag-chat-message,
   .lag-chat-composer {
+    transition-duration: 0s;
+  }
+
+  .lag-notification-action,
+  .lag-notification-row,
+  .lag-notification-detail,
+  .lag-notification-load-older {
     transition-duration: 0s;
   }
 

--- a/features/notification/NotificationBell.test.tsx
+++ b/features/notification/NotificationBell.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { readFileSync } from "node:fs";
 import { renderToStaticMarkup } from "react-dom/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -35,26 +35,73 @@ vi.mock("./useNotifications", () => ({ useNotifications: () => state }));
 describe("NotificationBell canonical surface", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("uses unread authority, loads inbox on open without auto-reading, and exposes no clear/delete", () => {
+  it("uses unread authority and opens inbox without an implicit read mutation", () => {
     render(<NotificationBell />);
-    expect(screen.getByRole("button", { name: "알림 7건" })).toHaveTextContent("7");
+    const trigger = screen.getByRole("button", { name: "Notifications, 7 unread" });
+    expect(trigger).toHaveTextContent("7");
     expect(state.loadInbox).not.toHaveBeenCalled();
 
-    fireEvent.click(screen.getByRole("button", { name: "알림 7건" }));
+    fireEvent.click(trigger);
     expect(state.loadInbox).toHaveBeenCalledTimes(1);
+    expect(state.markRead).not.toHaveBeenCalled();
     expect(state.markAllRead).not.toHaveBeenCalled();
-    expect(screen.getAllByRole("button", { name: "Mark read" })).toHaveLength(1);
-    expect(screen.getByRole("button", { name: "모두 읽음" })).toBeEnabled();
+    expect(screen.getByRole("dialog", { name: "Notifications" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Mark all read" })).toBeEnabled();
     expect(screen.getByRole("button", { name: "Load older" })).toBeInTheDocument();
-    expect(screen.queryByText(/전체 삭제|clear|delete/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/clear|delete/i)).not.toBeInTheDocument();
+  });
+
+  it("selects a stable local detail without marking read, then reads only through explicit actions", () => {
+    render(<NotificationBell />);
+    fireEvent.click(screen.getByRole("button", { name: "Notifications, 7 unread" }));
+
+    fireEvent.click(screen.getByText("Canonical body").closest("button")!);
+    const detail = screen.getByLabelText("Notification detail");
+    expect(detail).toBeInTheDocument();
+    expect(within(detail).getByText("System notice")).toBeInTheDocument();
+    expect(within(detail).getByText("Canonical body")).toBeInTheDocument();
+    expect(state.markRead).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByText("Future body").closest("button")!);
+    expect(screen.getByLabelText("Notification detail")).toBe(detail);
+    expect(within(detail).getByRole("img", { name: "Notification" })).toHaveTextContent("!");
+    expect(state.markRead).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByText("Canonical body").closest("button")!);
+    fireEvent.click(within(detail).getByRole("button", { name: "Mark read" }));
+    expect(state.markRead).toHaveBeenCalledWith(2);
+    fireEvent.click(screen.getByRole("button", { name: "Mark all read" }));
+    expect(state.markAllRead).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(within(detail).getByRole("button", { name: /Back to inbox/ }));
+    expect(screen.queryByLabelText("Notification detail")).not.toBeInTheDocument();
+  });
+
+  it("renders canonical known/unknown rows with structural read state and readable timestamps", () => {
+    render(<NotificationBell />);
+    fireEvent.click(screen.getByRole("button", { name: "Notifications, 7 unread" }));
+
     expect(screen.getByText("Future title")).toBeInTheDocument();
     expect(screen.getByText("Future body")).toBeInTheDocument();
     expect(screen.getByRole("img", { name: "Notification" })).toHaveTextContent("!");
+    expect(screen.getByRole("img", { name: "Mail received" })).toHaveTextContent("✉");
+    expect(screen.getByText("Canonical body").closest("article")).toHaveAttribute("data-read", "false");
+    expect(screen.getByText("Older body").closest("article")).toHaveAttribute("data-read", "true");
+    expect(screen.getByText("2026-08-18 12:34 UTC").closest("time")).toHaveAttribute("dateTime", "2026-08-18T12:34:56Z");
+  });
 
-    fireEvent.click(screen.getByRole("button", { name: "Mark read" }));
-    expect(state.markRead).toHaveBeenCalledWith(2);
-    fireEvent.click(screen.getByRole("button", { name: "모두 읽음" }));
-    expect(state.markAllRead).toHaveBeenCalledTimes(1);
+  it("closes on outside click while retaining viewport placement wiring", async () => {
+    render(<NotificationBell />);
+    fireEvent.click(screen.getByRole("button", { name: "Notifications, 7 unread" }));
+    expect(screen.getByRole("dialog", { name: "Notifications" })).toBeInTheDocument();
+    fireEvent.mouseDown(document.body);
+    await waitFor(() => expect(screen.queryByRole("dialog", { name: "Notifications" })).not.toBeInTheDocument());
+
+    const source = readFileSync("features/notification/NotificationBell.tsx", "utf8");
+    expect(source).toContain("notificationPopupPosition");
+    expect(source).toContain("ResizeObserver");
+    const css = readFileSync("app/globals.css", "utf8");
+    expect(css).toContain("max-height: calc(100dvh - 112px - env(safe-area-inset-bottom)");
   });
 
   it("renders deterministic initial timestamp text without render-time Date.now", () => {
@@ -66,18 +113,17 @@ describe("NotificationBell canonical surface", () => {
     expect(now).not.toHaveBeenCalled();
   });
 
-  it("uses dual-theme semantic surfaces without the fixed dark/gold container", () => {
+  it("uses local semantic styling without filters, screenshot content, or theme branches", () => {
     const source = readFileSync("features/notification/NotificationBell.tsx", "utf8");
     const css = readFileSync("app/globals.css", "utf8");
+    const notificationCss = css.slice(css.indexOf("/* Notification inbox utility"), css.indexOf(".lag-semantic-controls"));
 
-    expect(source).toContain("lag-utility-button");
-    expect(source).toContain("lag-notification-dropdown");
-    expect(source).toContain("notificationPopupPosition");
-    expect(source).toContain("var(--lag-control-bg)");
-    expect(css).toMatch(/\.lag-notification-trigger\s*{[\s\S]*?overflow:\s*visible/);
-    expect(source).toContain('maxHeight: "calc(100dvh - 32px)"');
-    expect(source).toContain('className="lag-notification-list"');
-    expect(source).toContain("minHeight: 0, flex: 1, overflowY: \"auto\"");
-    expect(source).not.toMatch(/rgba\(|#[0-9a-fA-F]{3,8}/);
+    expect(source).not.toMatch(/RoleEvent|Archive Trace|Focus \/ Depth|Wish|data-theme|category filter|unread filter/i);
+    expect(source).not.toContain("--lag-meta");
+    expect(notificationCss).toContain(".lag-notification-time");
+    expect(notificationCss).toContain("color: var(--lag-text-2)");
+    expect(notificationCss).not.toContain("--lag-meta");
+    expect(notificationCss).not.toMatch(/#[0-9a-f]{3,8}|rgba?\(/i);
+    expect(css).toContain('.lag-notification-dropdown[data-view="detail"] .lag-notification-inbox');
   });
 });

--- a/features/notification/NotificationBell.tsx
+++ b/features/notification/NotificationBell.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { AnimatePresence, motion } from "framer-motion";
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 
 import type { NotificationInfo, NotificationType } from "@/shared/api/types";
@@ -8,19 +8,23 @@ import { notificationPopupPosition, type FloatingPosition } from "@/shared/lib/v
 import UtilityPortal from "@/shared/ui/UtilityPortal";
 import { useNotifications } from "./useNotifications";
 
-const TYPE_META: Record<NotificationType, { color: string; icon: string; label: string }> = {
-  MAIL_RECEIVED: { color: "var(--lag-state-info)", icon: "✉", label: "Mail received" },
-  QUEST_PROGRESS: { color: "var(--lag-state-pending)", icon: "⚔", label: "Quest progress" },
-  QUEST_COMPLETED: { color: "var(--lag-state-success)", icon: "✓", label: "Quest completed" },
-  QUEST_REWARD_READY: { color: "var(--lag-amber)", icon: "★", label: "Quest reward ready" },
-  LISTING_SOLD: { color: "var(--lag-state-success)", icon: "◆", label: "Listing sold" },
-  ACHIEVEMENT_UNLOCK: { color: "var(--lag-state-selected)", icon: "★", label: "Achievement unlocked" },
-  SYSTEM_NOTICE: { color: "var(--lag-text-2)", icon: "!", label: "System notice" },
+const TYPE_META: Record<NotificationType, { icon: string; label: string; tone: string }> = {
+  MAIL_RECEIVED: { icon: "✉", label: "Mail received", tone: "info" },
+  QUEST_PROGRESS: { icon: "⚔", label: "Quest progress", tone: "pending" },
+  QUEST_COMPLETED: { icon: "✓", label: "Quest completed", tone: "success" },
+  QUEST_REWARD_READY: { icon: "★", label: "Quest reward ready", tone: "pending" },
+  LISTING_SOLD: { icon: "◆", label: "Listing sold", tone: "success" },
+  ACHIEVEMENT_UNLOCK: { icon: "★", label: "Achievement unlocked", tone: "selected" },
+  SYSTEM_NOTICE: { icon: "!", label: "System notice", tone: "neutral" },
 };
-const UNKNOWN_TYPE_META = { color: "var(--lag-text-2)", icon: "!", label: "Notification" };
+const UNKNOWN_TYPE_META = { icon: "!", label: "Notification", tone: "neutral" };
 
 function isKnownNotificationType(type: string): type is NotificationType {
   return Object.prototype.hasOwnProperty.call(TYPE_META, type);
+}
+
+function metaFor(type: string) {
+  return isKnownNotificationType(type) ? TYPE_META[type] : UNKNOWN_TYPE_META;
 }
 
 export function NotificationTimestamp({ occurredAt }: { occurredAt: string }) {
@@ -28,61 +32,63 @@ export function NotificationTimestamp({ occurredAt }: { occurredAt: string }) {
   return <time dateTime={occurredAt}>{label}</time>;
 }
 
-function NotificationRow({ notification, pending, onMarkRead }: {
+function TypeMark({ notification }: { notification: NotificationInfo }) {
+  const meta = metaFor(notification.type);
+  return <span role="img" aria-label={meta.label} title={meta.label} className="lag-notification-type-mark" data-tone={meta.tone}>{meta.icon}</span>;
+}
+
+function NotificationRow({ notification, pending, selected, onSelect, onMarkRead }: {
   notification: NotificationInfo;
   pending: boolean;
+  selected: boolean;
+  onSelect: (id: number) => void;
   onMarkRead: (id: number) => void;
 }) {
-  const meta = isKnownNotificationType(notification.type) ? TYPE_META[notification.type] : UNKNOWN_TYPE_META;
+  const meta = metaFor(notification.type);
   return (
-    <motion.article
-      initial={{ opacity: 0, x: -6 }}
-      animate={{ opacity: 1, x: 0 }}
-      style={{
-        display: "flex",
-        alignItems: "flex-start",
-        gap: 10,
-        padding: "9px 14px",
-        borderBottom: "1px solid var(--lag-divider)",
-        background: notification.read ? "transparent" : "var(--lag-selected-surface)",
-      }}
-    >
-      <span role="img" aria-label={meta.label} title={meta.label} style={{ width: 22, height: 22, borderRadius: "50%", border: `1.5px solid ${meta.color}`, display: "flex", alignItems: "center", justifyContent: "center", fontSize: 10, color: meta.color, flexShrink: 0, marginTop: 1 }}>{meta.icon}</span>
-      <div style={{ flex: 1, minWidth: 0 }}>
-        <strong style={{ display: "block", fontSize: 11, fontWeight: notification.read ? 400 : 600, color: notification.read ? "var(--lag-text-2)" : "var(--lag-text)", lineHeight: 1.35, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{notification.title}</strong>
-        <p style={{ fontSize: 10, color: "var(--lag-text-2)", marginTop: 2, lineHeight: 1.3 }}>{notification.body}</p>
-        <div style={{ marginTop: 4, fontSize: 9, color: "var(--lag-meta)" }}><NotificationTimestamp occurredAt={notification.occurredAt} /></div>
-      </div>
-      {!notification.read ? <button type="button" className="lag-button-secondary" disabled={pending} onClick={() => onMarkRead(notification.id)} style={{ padding: "3px 6px", fontSize: 9, cursor: pending ? "default" : "pointer", opacity: pending ? 0.5 : 1 }}>{pending ? "Saving..." : "Mark read"}</button> : null}
-    </motion.article>
+    <article className="lag-notification-row" data-read={notification.read} data-selected={selected}>
+      <button type="button" className="lag-notification-select" aria-pressed={selected} onClick={() => onSelect(notification.id)}>
+        <TypeMark notification={notification} />
+        <span className="lag-notification-copy">
+          <span className="lag-notification-row-meta"><span>{meta.label}</span><span>{notification.read ? "Read" : "Unread"}</span></span>
+          <strong>{notification.title}</strong>
+          <span className="lag-notification-body">{notification.body}</span>
+          <span className="lag-notification-time"><NotificationTimestamp occurredAt={notification.occurredAt} /></span>
+        </span>
+        <span className="lag-notification-arrow" aria-hidden>→</span>
+      </button>
+      {!notification.read ? <button type="button" className="lag-notification-action" disabled={pending} onClick={() => onMarkRead(notification.id)}>{pending ? "Saving..." : "Mark read"}</button> : null}
+    </article>
   );
 }
 
 export function NotificationBell() {
   const state = useNotifications();
+  const reducedMotion = useReducedMotion();
   const [open, setOpen] = useState(false);
+  const [selectedId, setSelectedId] = useState<number | null>(null);
   const panelRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const popupRef = useRef<HTMLDivElement>(null);
   const [popupPosition, setPopupPosition] = useState<FloatingPosition | null>(null);
+  const selected = state.inbox.find(({ id }) => id === selectedId) ?? null;
+
+  const close = useCallback(() => {
+    setOpen(false);
+    setSelectedId(null);
+  }, []);
 
   const placePopup = useCallback(() => {
     const anchor = triggerRef.current?.getBoundingClientRect();
     const popup = popupRef.current?.getBoundingClientRect();
     if (!anchor || !popup) return;
-    setPopupPosition(notificationPopupPosition(
-      anchor,
-      { width: popup.width, height: popup.height },
-      { width: window.innerWidth, height: window.innerHeight },
-    ));
+    setPopupPosition(notificationPopupPosition(anchor, { width: popup.width, height: popup.height }, { width: window.innerWidth, height: window.innerHeight }));
   }, []);
 
   useLayoutEffect(() => {
     if (!open) return;
     placePopup();
-    const observer = typeof ResizeObserver === "undefined" || !popupRef.current
-      ? null
-      : new ResizeObserver(placePopup);
+    const observer = typeof ResizeObserver === "undefined" || !popupRef.current ? null : new ResizeObserver(placePopup);
     if (popupRef.current) observer?.observe(popupRef.current);
     window.addEventListener("resize", placePopup);
     return () => {
@@ -93,90 +99,96 @@ export function NotificationBell() {
 
   useEffect(() => {
     if (!open) return;
-    const close = (event: MouseEvent) => {
+    const closeOutside = (event: MouseEvent) => {
       const target = event.target as Node;
-      if (!panelRef.current?.contains(target) && !popupRef.current?.contains(target)) setOpen(false);
+      if (!panelRef.current?.contains(target) && !popupRef.current?.contains(target)) close();
     };
-    document.addEventListener("mousedown", close);
-    return () => document.removeEventListener("mousedown", close);
-  }, [open]);
+    document.addEventListener("mousedown", closeOutside);
+    return () => document.removeEventListener("mousedown", closeOutside);
+  }, [close, open]);
 
   const toggle = () => {
     if (!open && !state.inboxLoaded && !state.inboxLoading) void state.loadInbox();
-    setOpen((current) => !current);
+    if (open) close();
+    else setOpen(true);
   };
 
   return (
-    <div ref={panelRef} style={{ position: "relative" }}>
+    <div ref={panelRef} className="lag-notification-anchor">
       <motion.button
         ref={triggerRef}
         type="button"
         onClick={toggle}
-        whileHover={{ scale: 1.08 }}
-        whileTap={{ scale: 0.9 }}
-        aria-label={`알림 ${state.unreadCount}건`}
+        whileHover={reducedMotion ? undefined : { scale: 1.06 }}
+        whileTap={reducedMotion ? undefined : { scale: 0.94 }}
+        aria-label={`Notifications, ${state.unreadCount} unread`}
         aria-expanded={open}
         title="Notifications"
         className="lag-utility-button lag-notification-trigger"
-        style={{
-          borderColor: state.unreadCount > 0 || open ? "var(--lag-focus)" : "var(--lag-control-border)",
-          background: open ? "var(--lag-selected-surface)" : "var(--lag-control-bg)",
-          boxShadow: state.unreadCount > 0 ? "0 0 10px color-mix(in srgb, var(--lag-focus) 24%, transparent)" : "none",
-          cursor: "pointer",
-          fontSize: 14,
-          position: "relative",
-        }}
+        data-active={open}
+        data-unread={state.unreadCount > 0}
       >
-        ◈
+        <span aria-hidden>◈</span>
         <AnimatePresence>
-          {state.unreadCount > 0 ? <motion.span key="badge" initial={{ scale: 0 }} animate={{ scale: 1 }} exit={{ scale: 0 }} style={{ position: "absolute", top: -3, right: -3, minWidth: 16, height: 16, borderRadius: 8, background: "var(--lag-state-error)", color: "var(--lag-text)", fontSize: 9, fontWeight: 700, display: "flex", alignItems: "center", justifyContent: "center", padding: "0 3px", lineHeight: 1 }}>{state.unreadCount > 9 ? "9+" : state.unreadCount}</motion.span> : null}
+          {state.unreadCount > 0 ? <motion.span className="lag-notification-badge" key="badge" initial={reducedMotion ? false : { scale: 0 }} animate={{ scale: 1 }} exit={{ scale: 0 }} transition={{ duration: reducedMotion ? 0 : 0.12 }}>{state.unreadCount > 9 ? "9+" : state.unreadCount}</motion.span> : null}
         </AnimatePresence>
       </motion.button>
 
       <UtilityPortal>
         <AnimatePresence>
           {open ? (
-          <motion.div
-            ref={popupRef}
-            role="dialog"
-            aria-label="Notifications"
-            key="notification-dropdown"
-            initial={{ opacity: 0, y: -6, scale: 0.97 }}
-            animate={{ opacity: 1, y: 0, scale: 1 }}
-            exit={{ opacity: 0, y: -6, scale: 0.97 }}
-            transition={{ type: "spring", stiffness: 400, damping: 32 }}
-            className="lag-notification-dropdown"
-            style={{
-              position: "fixed",
-              left: popupPosition?.x ?? 16,
-              top: popupPosition?.y ?? 16,
-              width: "min(320px, calc(100vw - 32px))",
-              borderRadius: "var(--lag-radius-md)",
-              zIndex: 600100,
-              overflow: "hidden",
-              maxHeight: "calc(100dvh - 32px)",
-              display: "flex",
-              flexDirection: "column",
-              visibility: popupPosition ? "visible" : "hidden",
-            }}
-          >
-            <header style={{ display: "flex", flexShrink: 0, alignItems: "center", justifyContent: "space-between", gap: 8, padding: "9px 14px 8px", background: "var(--lag-panel-2)", borderBottom: "1px solid var(--lag-divider)" }}>
-              <span style={{ fontSize: 10, fontWeight: 700, color: "var(--lag-text)", letterSpacing: "0.1em" }}>NOTIFICATIONS</span>
-              <button type="button" disabled={state.markAllPending} onClick={() => void state.markAllRead()} style={{ fontSize: 9, color: "var(--lag-text-2)", background: "none", border: 0, cursor: "pointer", opacity: state.markAllPending ? 0.45 : 1 }}>{state.markAllPending ? "Saving..." : "모두 읽음"}</button>
-            </header>
+            <motion.div
+              ref={popupRef}
+              role="dialog"
+              aria-label="Notifications"
+              key="notification-dropdown"
+              initial={reducedMotion ? false : { opacity: 0, y: -6, scale: 0.98 }}
+              animate={{ opacity: 1, y: 0, scale: 1 }}
+              exit={reducedMotion ? { opacity: 0 } : { opacity: 0, y: -6, scale: 0.98 }}
+              transition={{ duration: reducedMotion ? 0 : 0.16, ease: "easeOut" }}
+              className="lag-notification-dropdown"
+              data-detail={selected !== null}
+              data-view={selected ? "detail" : "inbox"}
+              style={{ position: "fixed", left: popupPosition?.x ?? 16, top: popupPosition?.y ?? 16, zIndex: 600100, visibility: popupPosition ? "visible" : "hidden" }}
+            >
+              <header className="lag-notification-header">
+                <div><span>Current Player</span><h2>Notifications</h2></div>
+                <div>
+                  <button type="button" disabled={state.markAllPending} onClick={() => void state.markAllRead()} className="lag-notification-action">{state.markAllPending ? "Saving..." : "Mark all read"}</button>
+                  <button type="button" aria-label="Close Notifications" onClick={close} className="lag-notification-action">Close</button>
+                </div>
+              </header>
 
-            {state.unreadError ? <div style={{ padding: "8px 14px" }}><p role="alert" style={{ fontSize: 10, color: "var(--lag-state-error)" }}>{state.unreadError}</p><button type="button" className="lag-button-secondary" onClick={() => void state.unreadRetry()} style={{ fontSize: 9 }}>Retry count</button></div> : null}
-            {state.inboxError ? <div style={{ padding: "8px 14px" }}><p role="alert" style={{ fontSize: 10, color: "var(--lag-state-error)" }}>{state.inboxError}</p><button type="button" className="lag-button-secondary" onClick={() => void state.inboxRetry()} style={{ fontSize: 9 }}>Retry</button></div> : null}
-            {state.mutationError ? <p role="alert" style={{ padding: "8px 14px", fontSize: 10, color: "var(--lag-state-error)" }}>{state.mutationError}</p> : null}
+              {state.unreadError ? <div className="lag-notification-feedback-row"><p role="alert" className="lag-notification-feedback" data-state="error">{state.unreadError}</p><button type="button" className="lag-notification-action" onClick={() => void state.unreadRetry()}>Retry count</button></div> : null}
+              {state.inboxError ? <div className="lag-notification-feedback-row"><p role="alert" className="lag-notification-feedback" data-state="error">{state.inboxError}</p><button type="button" className="lag-notification-action" onClick={() => void state.inboxRetry()}>Retry</button></div> : null}
+              {state.mutationError ? <p role="alert" className="lag-notification-feedback" data-state="error">{state.mutationError}</p> : null}
 
-            <div className="lag-notification-list" style={{ maxHeight: 360, minHeight: 0, flex: 1, overflowY: "auto" }}>
-              {state.inboxLoading ? <p style={{ padding: "24px 14px", textAlign: "center", fontSize: 11, color: "var(--lag-text-2)" }}>Loading...</p> : null}
-              {!state.inboxLoading && state.inboxLoaded && state.inbox.length === 0 ? <p style={{ padding: "24px 14px", textAlign: "center", fontSize: 11, color: "var(--lag-text-2)" }}>알림이 없습니다</p> : null}
-              {state.inbox.map((notification) => <NotificationRow key={notification.id} notification={notification} pending={state.pendingId === notification.id} onMarkRead={(id) => void state.markRead(id)} />)}
-              {state.hasMore ? <button type="button" className="lag-button-secondary" disabled={state.olderLoading} onClick={() => void state.loadOlder()} style={{ display: "block", margin: "8px auto", padding: "4px 8px", fontSize: 9 }}>{state.olderLoading ? "Loading..." : "Load older"}</button> : null}
-            </div>
-            <div style={{ height: 2, background: "linear-gradient(90deg, transparent, var(--lag-focus), transparent)" }} />
-          </motion.div>
+              <div className="lag-notification-composition">
+                <section className="lag-notification-inbox" aria-label="Notification inbox">
+                  <div className="lag-notification-summary"><span>Durable inbox</span><strong>{state.unreadCount} unread</strong></div>
+                  <div className="lag-notification-list">
+                    {state.inboxLoading ? <p role="status" className="lag-notification-empty">Loading notifications...</p> : null}
+                    {!state.inboxLoading && state.inboxLoaded && state.inbox.length === 0 ? <p className="lag-notification-empty">No notifications</p> : null}
+                    {state.inbox.map((notification) => <NotificationRow key={notification.id} notification={notification} pending={state.pendingId === notification.id} selected={selectedId === notification.id} onSelect={setSelectedId} onMarkRead={(id) => void state.markRead(id)} />)}
+                    {state.hasMore ? <button type="button" className="lag-notification-load-older" disabled={state.olderLoading} onClick={() => void state.loadOlder()}>{state.olderLoading ? "Loading..." : "Load older"}</button> : null}
+                  </div>
+                </section>
+
+                {selected ? (
+                  <section className="lag-notification-detail" aria-label="Notification detail">
+                    <header><button type="button" className="lag-notification-action" onClick={() => setSelectedId(null)}>← Back to inbox</button><span>{selected.read ? "Read" : "Unread"}</span></header>
+                    <div className="lag-notification-detail-content">
+                      <TypeMark notification={selected} />
+                      <span>{metaFor(selected.type).label}</span>
+                      <h3>{selected.title}</h3>
+                      <p>{selected.body}</p>
+                      <div><NotificationTimestamp occurredAt={selected.occurredAt} /></div>
+                      {!selected.read ? <button type="button" className="lag-notification-action" disabled={state.pendingId === selected.id} onClick={() => void state.markRead(selected.id)}>{state.pendingId === selected.id ? "Saving..." : "Mark read"}</button> : <span className="lag-notification-read-state">Read</span>}
+                    </div>
+                  </section>
+                ) : null}
+              </div>
+            </motion.div>
           ) : null}
         </AnimatePresence>
       </UtilityPortal>

--- a/features/notification/useNotifications.test.tsx
+++ b/features/notification/useNotifications.test.tsx
@@ -61,6 +61,19 @@ describe("feature-owned Notification state", () => {
     expect(result.current.nextCursor).toBeNull();
   });
 
+  it("keeps loaded inbox rows when an older cursor request fails", async () => {
+    api.getNotificationsApi
+      .mockResolvedValueOnce(page([item(3), item(2)], true, 2))
+      .mockRejectedValueOnce(new Error("older failed"));
+    const { result } = renderHook(() => useNotifications());
+    await waitFor(() => expect(result.current.unreadCount).toBe(47));
+    await act(async () => { await result.current.loadInbox(); });
+    await act(async () => { await result.current.loadOlder(); });
+
+    expect(result.current.inbox.map(({ id }) => id)).toEqual([3, 2]);
+    expect(result.current.inboxError).toBe("older failed");
+  });
+
   it("mutates a loaded row only after read success, blocks duplicates, then reloads unread count", async () => {
     const command = deferred<void>();
     api.getNotificationsApi.mockResolvedValueOnce(page([item(3)]));


### PR DESCRIPTION
## Purpose

Refine the global Notification inbox visual hierarchy and read-state interactions while preserving the durable inbox contract.

Closes #66

## Delivered

- refined Notification utility trigger/header
- semantic unread/read inbox rows
- improved notification type markers
- readable timestamp/meta treatment
- explicit single-read interaction preservation
- server-wide Mark all read preservation
- cursor-based older loading preservation
- unknown-type fallback preservation
- viewport-bounded desktop composition
- mobile-safe inbox/detail composition
- accessible loading/error/read states

## Product Placement

Notification remains a global utility.

No Notification Orb, new main-navigation destination, or standalone Notification page is introduced.

## Data Authority

Real `NotificationInfo` remains authoritative:

- id
- type
- title
- body
- occurredAt
- read

No screenshot sample notification types, records, filters, or destination data are introduced.

Unknown server type strings continue to render through the safe fallback.

## Read Semantics

Opening the Notification utility does not mark anything as read.

Opening/selecting local detail does not mark anything as read.

Read state changes only through explicit commands:

```text
Mark read
Mark all read
```

Single-read success updates the loaded matching row and reloads unread count.

Mark-all remains the server-wide current-user unread command rather than a loaded-page-only action.

## Cursor Inbox

Existing cursor behavior remains intact:

- hasMore
- nextCursor
- Load older
- olderLoading
- dedupe

No page-number pagination or misleading partial-inbox category filter is introduced.

## Responsive / Theme

Astral and Warm Beige share one component tree and semantic token hierarchy.

Desktop remains a bounded global utility rather than a full-page surface.

Mobile preserves safe viewport height, internal scrolling, reachable read actions, and bottom-navigation clearance.

## Scope Boundaries

This PR does not add:

- realtime delivery
- deep links
- delete/clear/archive
- server-side filters
- new Notification types
- Notification Orb
- new Notification page
- backend changes
- global camera changes