### PR TITLE
[Exchange] Build canonical Wallet, Shop, Marketplace, and Trade surfaces

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -603,7 +603,7 @@ export default function AdminPage() {
       .finally(() => { if (!cancelled) setIsDataLoading(false); });
 
     return () => { cancelled = true; };
-  }, [selectedMenu, currentUser]);
+  }, [selectedMenu, currentUser, router]);
 
   // ─── Helpers ─────────────────────────────────────────────────────────────
 
@@ -845,8 +845,8 @@ export default function AdminPage() {
               [
                 { key: "amount",   label: "Amount",   type: "number", required: true },
                 { key: "currency", label: "Currency", type: "select", required: true, options: [
-                  { value: "col", label: "Col" },
-                  { value: "gem", label: "Gem" },
+                  { value: "GOLD", label: "Gold" },
+                  { value: "GEM", label: "Gem" },
                 ]},
                 { key: "debit",  label: "Type",     type: "select", required: true, options: [
                   { value: "false", label: "Credit (add)" },
@@ -1656,8 +1656,8 @@ export default function AdminPage() {
             { key: "itemId",               label: "Item ID",             type: "number", required: true },
             { key: "price",                label: "Price",               type: "number", required: true },
             { key: "currency",             label: "Currency",            type: "select", required: true, options: [
-              { value: "col", label: "Col" },
-              { value: "gem", label: "Gem" },
+              { value: "GOLD", label: "Gold" },
+              { value: "GEM", label: "Gem" },
             ]},
             { key: "globalLimit",          label: "Global Stock Limit",  type: "number", placeholder: "Unlimited" },
             { key: "perPlayerLimit",       label: "Per Player Limit",    type: "number", placeholder: "Unlimited" },

--- a/app/globals.css
+++ b/app/globals.css
@@ -2568,7 +2568,7 @@ body {
   text-align: left;
 }
 
-.lag-exchange-row:hover,
+.lag-exchange-row:not(:disabled):hover,
 .lag-exchange-row[data-selected="true"] {
   border-color: var(--lag-focus);
   background: var(--lag-control-hover-bg);
@@ -2706,7 +2706,7 @@ body {
   margin-bottom: var(--lag-space-2);
 }
 
-.lag-exchange-entry:hover,
+.lag-exchange-entry:not(:disabled):hover,
 .lag-exchange-entry[data-selected="true"] {
   border-color: var(--lag-focus);
   background: var(--lag-control-hover-bg);

--- a/app/globals.css
+++ b/app/globals.css
@@ -187,7 +187,13 @@ body {
 .lag-notification-action,
 .lag-notification-row,
 .lag-notification-detail,
-.lag-notification-load-older {
+.lag-notification-load-older,
+.lag-exchange-row,
+.lag-exchange-entry,
+.lag-exchange-action,
+.lag-exchange-button,
+.lag-exchange-section,
+.lag-exchange-tabs button {
   transition:
     background-color var(--lag-motion-normal) ease,
     border-color var(--lag-motion-normal) ease,
@@ -2411,6 +2417,360 @@ body {
   transition: color var(--lag-motion-normal) ease;
 }
 
+/* Exchange uses the reference material hierarchy without its personal-finance samples. */
+.lag-exchange-shell [data-stage-key="market-stage-1"] .lag-panel-frame {
+  width: min(620px, calc(100vw - 32px)) !important;
+}
+
+.lag-exchange-shell [data-stage-key="market-stage-2"] .lag-panel-frame {
+  width: min(560px, calc(100vw - 32px)) !important;
+}
+
+.lag-exchange-surface,
+.lag-exchange-detail,
+.lag-exchange-state {
+  display: grid;
+  gap: var(--lag-space-4);
+  min-width: 0;
+  padding: 0 var(--lag-space-4);
+}
+
+.lag-exchange-header {
+  display: grid;
+  gap: var(--lag-space-1);
+  padding: var(--lag-space-3) var(--lag-space-4);
+  border: 1px solid var(--lag-divider);
+  border-left: 4px solid var(--lag-cyan);
+  border-radius: var(--lag-radius-sm);
+  background: var(--lag-raised-surface);
+}
+
+.lag-exchange-header[data-accent="amber"] {
+  border-left-color: var(--lag-amber);
+}
+
+.lag-exchange-header[data-accent="violet"] {
+  border-left-color: var(--lag-violet);
+}
+
+.lag-exchange-header > span {
+  color: var(--lag-text-2);
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.lag-exchange-header h4 {
+  color: var(--lag-text);
+  font-size: 1.1rem;
+  font-weight: 750;
+}
+
+.lag-exchange-header p {
+  color: var(--lag-text-2);
+  font-size: 0.76rem;
+  line-height: 1.5;
+}
+
+.lag-exchange-balance {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: var(--lag-space-2) var(--lag-space-4);
+  align-items: end;
+  padding: var(--lag-space-6);
+  border: 1px solid var(--lag-control-border);
+  border-radius: var(--lag-radius-md);
+  background:
+    linear-gradient(120deg, color-mix(in srgb, var(--lag-cyan) 12%, transparent), transparent 58%),
+    var(--lag-panel-2);
+}
+
+.lag-exchange-balance span {
+  grid-column: 1 / -1;
+  color: var(--lag-text-2);
+  font-size: 0.7rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.lag-exchange-balance strong {
+  color: var(--lag-text);
+  font-size: clamp(2rem, 7vw, 3.8rem);
+  font-weight: 300;
+  letter-spacing: -0.05em;
+  line-height: 1;
+}
+
+.lag-exchange-balance em,
+.lag-exchange-value,
+.lag-exchange-trade em {
+  color: var(--lag-amber);
+  font-style: normal;
+  font-weight: 750;
+}
+
+.lag-exchange-tabs {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--lag-space-2);
+}
+
+.lag-exchange-tabs button,
+.lag-exchange-action,
+.lag-exchange-button,
+.lag-exchange-field :where(input, select) {
+  min-height: 44px;
+  border: 1px solid var(--lag-control-border);
+  border-radius: var(--lag-radius-sm);
+  background: var(--lag-control-bg);
+  color: var(--lag-control-text);
+}
+
+.lag-exchange-tabs button,
+.lag-exchange-action,
+.lag-exchange-button {
+  padding: var(--lag-space-2) var(--lag-space-3);
+  font-size: 0.74rem;
+  font-weight: 700;
+}
+
+.lag-exchange-tabs button:hover,
+.lag-exchange-tabs button[data-selected="true"],
+.lag-exchange-action:not(:disabled):hover,
+.lag-exchange-button:not(:disabled):hover {
+  border-color: var(--lag-focus);
+  background: var(--lag-control-hover-bg);
+}
+
+.lag-exchange-tabs button[data-selected="true"] {
+  box-shadow: inset 0 -3px 0 var(--lag-violet);
+}
+
+.lag-exchange-list,
+.lag-exchange-entry-picker {
+  display: grid;
+  gap: var(--lag-space-2);
+  min-width: 0;
+}
+
+.lag-exchange-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto;
+  gap: var(--lag-space-3);
+  align-items: center;
+  min-height: 68px;
+  padding: var(--lag-space-3);
+  border: 1px solid var(--lag-divider);
+  border-radius: var(--lag-radius-sm);
+  background: var(--lag-muted-surface);
+  color: var(--lag-text);
+  text-align: left;
+}
+
+.lag-exchange-row:hover,
+.lag-exchange-row[data-selected="true"] {
+  border-color: var(--lag-focus);
+  background: var(--lag-control-hover-bg);
+}
+
+.lag-exchange-row[data-selected="true"] {
+  box-shadow: inset 4px 0 0 var(--lag-violet);
+}
+
+.lag-exchange-row-mark {
+  color: var(--lag-violet);
+}
+
+.lag-exchange-row-copy {
+  display: grid;
+  min-width: 0;
+}
+
+.lag-exchange-row-copy strong,
+.lag-exchange-row-copy small,
+.lag-exchange-row-copy em {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.lag-exchange-row-copy small {
+  color: var(--lag-text-2);
+  font-size: 0.7rem;
+}
+
+.lag-exchange-row-copy em {
+  color: var(--lag-state-info);
+  font-size: 0.65rem;
+  font-style: normal;
+}
+
+.lag-exchange-section {
+  overflow: hidden;
+  border: 1px solid var(--lag-divider);
+  border-radius: var(--lag-radius-sm);
+  background: var(--lag-panel);
+}
+
+.lag-exchange-section h5,
+.lag-exchange-entry-picker legend {
+  width: 100%;
+  padding: var(--lag-space-2) var(--lag-space-3);
+  background: var(--lag-panel-2);
+  color: var(--lag-text);
+  font-size: 0.72rem;
+  font-weight: 750;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.lag-exchange-section dl {
+  padding: 0 var(--lag-space-3);
+}
+
+.lag-exchange-data-row {
+  display: grid;
+  grid-template-columns: minmax(120px, 0.8fr) minmax(0, 1.2fr);
+  gap: var(--lag-space-3);
+  padding: var(--lag-space-3) 0;
+  border-bottom: 1px solid var(--lag-divider);
+}
+
+.lag-exchange-data-row:last-child {
+  border-bottom: 0;
+}
+
+.lag-exchange-data-row dt,
+.lag-exchange-trade small {
+  color: var(--lag-text-2);
+}
+
+.lag-exchange-data-row dd {
+  overflow-wrap: anywhere;
+  color: var(--lag-text);
+  text-align: right;
+}
+
+.lag-exchange-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--lag-space-2);
+}
+
+.lag-exchange-action {
+  border-color: color-mix(in srgb, var(--lag-amber) 62%, var(--lag-control-border));
+  background: color-mix(in srgb, var(--lag-amber) 12%, var(--lag-control-bg));
+}
+
+.lag-exchange-button[data-variant="destructive"] {
+  border-color: var(--lag-state-error);
+}
+
+.lag-exchange-feedback {
+  padding: var(--lag-space-2) var(--lag-space-3);
+  border-left: 3px solid var(--lag-state-error);
+  color: var(--lag-text);
+  font-size: 0.76rem;
+}
+
+.lag-exchange-feedback[data-state="info"] {
+  border-left-color: var(--lag-state-info);
+}
+
+.lag-exchange-entry-picker {
+  margin: 0;
+  padding: 0;
+  border: 1px solid var(--lag-divider);
+  border-radius: var(--lag-radius-sm);
+}
+
+.lag-exchange-entry-picker legend {
+  float: left;
+  margin-bottom: var(--lag-space-2);
+}
+
+.lag-exchange-entry {
+  display: grid;
+  gap: 2px;
+  margin-inline: var(--lag-space-2);
+  padding: var(--lag-space-3);
+  border: 1px solid var(--lag-divider);
+  border-radius: var(--lag-radius-sm);
+  background: var(--lag-muted-surface);
+  color: var(--lag-text);
+  text-align: left;
+}
+
+.lag-exchange-entry:last-child {
+  margin-bottom: var(--lag-space-2);
+}
+
+.lag-exchange-entry:hover,
+.lag-exchange-entry[data-selected="true"] {
+  border-color: var(--lag-focus);
+  background: var(--lag-control-hover-bg);
+}
+
+.lag-exchange-entry[data-selected="true"] {
+  box-shadow: inset 4px 0 0 var(--lag-amber);
+}
+
+.lag-exchange-entry span,
+.lag-exchange-entry small {
+  color: var(--lag-text-2);
+  font-size: 0.7rem;
+}
+
+.lag-exchange-field {
+  display: grid;
+  gap: var(--lag-space-1);
+  color: var(--lag-text-2);
+  font-size: 0.72rem;
+  font-weight: 700;
+}
+
+.lag-exchange-field :where(input, select) {
+  width: 100%;
+  padding: var(--lag-space-2) var(--lag-space-3);
+}
+
+.lag-exchange-trade {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: var(--lag-space-2) var(--lag-space-3);
+  align-items: center;
+  padding: var(--lag-space-3);
+  border: 1px solid var(--lag-divider);
+  border-left: 4px solid var(--lag-violet);
+  border-radius: var(--lag-radius-sm);
+  background: var(--lag-muted-surface);
+}
+
+.lag-exchange-trade > span {
+  color: var(--lag-state-info);
+  font-size: 0.68rem;
+  font-weight: 750;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.lag-exchange-trade strong {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.lag-exchange-trade small {
+  grid-column: 2;
+}
+
+.lag-exchange-trade em {
+  grid-column: 3;
+  grid-row: 1 / 3;
+}
+
 @media (min-width: 768px) and (max-width: 1199px) {
   .lag-app-shell {
     min-width: max-content;
@@ -3313,6 +3673,65 @@ textarea.lag-journal-control {
     padding: var(--lag-space-4) var(--lag-space-4) calc(140px + env(safe-area-inset-bottom)) !important;
   }
 
+  .lag-exchange-route {
+    align-items: center;
+  }
+
+  .lag-exchange-shell [data-stage-key="market-stage-1"] .lag-panel-frame,
+  .lag-exchange-shell [data-stage-key="market-stage-2"] .lag-panel-frame {
+    width: clamp(280px, calc(100vw - 32px), 344px) !important;
+  }
+
+  .lag-exchange-surface,
+  .lag-exchange-detail,
+  .lag-exchange-state {
+    padding-inline: var(--lag-space-3);
+  }
+
+  .lag-exchange-tabs {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .lag-exchange-row {
+    grid-template-columns: auto minmax(0, 1fr) auto;
+  }
+
+  .lag-exchange-row .lag-exchange-value {
+    grid-column: 2;
+  }
+
+  .lag-exchange-row > span:last-child {
+    grid-column: 3;
+    grid-row: 1 / 3;
+  }
+
+  .lag-exchange-data-row {
+    grid-template-columns: minmax(96px, 0.85fr) minmax(0, 1.15fr);
+  }
+
+  .lag-exchange-action,
+  .lag-exchange-button {
+    width: 100%;
+  }
+
+  .lag-exchange-trade {
+    grid-template-columns: minmax(0, 1fr) auto;
+  }
+
+  .lag-exchange-trade > span {
+    grid-column: 1;
+  }
+
+  .lag-exchange-trade strong,
+  .lag-exchange-trade small {
+    grid-column: 1;
+  }
+
+  .lag-exchange-trade em {
+    grid-column: 2;
+    grid-row: 1 / 4;
+  }
+
   .lag-orb-column {
     display: block;
     position: fixed !important;
@@ -3821,7 +4240,13 @@ textarea.lag-journal-control {
   .lag-notification-action,
   .lag-notification-row,
   .lag-notification-detail,
-  .lag-notification-load-older {
+  .lag-notification-load-older,
+  .lag-exchange-row,
+  .lag-exchange-entry,
+  .lag-exchange-action,
+  .lag-exchange-button,
+  .lag-exchange-section,
+  .lag-exchange-tabs button {
     transition-duration: 0s;
   }
 

--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -76,6 +76,11 @@ vi.mock("@/shared/ui/SaoAlert", () => ({ default: () => null }));
 vi.mock("@/features/notification/NotificationBell", () => ({ NotificationBell: () => null }));
 vi.mock("@/features/social/SocialUtilityHub", () => ({ default: () => <div data-testid="social-utility" /> }));
 vi.mock("@/features/system/settings/SettingsShell", () => ({ default: () => <div data-testid="settings-shell">Canonical Settings</div> }));
+vi.mock("@/features/market/ExchangeShell", () => ({
+  default: ({ surface, playerId }: { surface: string | null; playerId: number }) => surface
+    ? <div data-testid="exchange-shell">Exchange · {surface} · Player #{playerId}</div>
+    : null,
+}));
 
 describe("Home shell에서 feature surface를 routing할 때", () => {
   beforeEach(() => {
@@ -320,6 +325,27 @@ describe("Home shell에서 feature surface를 routing할 때", () => {
       const css = readFileSync("app/globals.css", "utf8");
       expect(css).not.toMatch(/\.lag-settings-route\s*>\s*:first-child\s*{[\s\S]*?display:\s*none/);
       expect(css).toContain("width: max-content !important");
+    });
+  });
+
+  describe("인증된 player가 Exchange를 선택하면", () => {
+    it("market internal key는 유지하고 feature-owned canonical surface로 routing한다", () => {
+      render(<Home />);
+
+      fireEvent.click(screen.getByRole("button", { name: "Exchange" }));
+      expect(screen.getByRole("button", { name: "Wallet" })).toBeInTheDocument();
+      fireEvent.click(screen.getByRole("button", { name: "Shop" }));
+
+      expect(screen.getByTestId("exchange-shell")).toHaveTextContent("Exchange · shop · Player #7");
+    });
+
+    it("page orchestration에서 generated Market presentation과 Economy mutations를 소유하지 않는다", () => {
+      const page = readFileSync("app/page.tsx", "utf8");
+
+      expect(page).toContain('selectedMain === "market"');
+      expect(page).toContain("<ExchangeShell");
+      expect(page).not.toContain("MARKET_");
+      expect(page).not.toMatch(/(?:getWallet|createListing|reserveListing|purchaseListing|confirmShopPurchase)Api/);
     });
   });
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -24,6 +24,7 @@ import CertificationShell from "@/features/player/CertificationShell";
 import TitleShell from "@/features/player/TitleShell";
 import HobbyShell from "@/features/player/HobbyShell";
 import GrowthShell from "@/features/player/GrowthShell";
+import ExchangeShell from "@/features/market/ExchangeShell";
 import SocialUtilityHub from "@/features/social/SocialUtilityHub";
 import SettingsShell from "@/features/system/settings/SettingsShell";
 import { useRoles } from "@/features/role/useRoles";
@@ -34,13 +35,12 @@ import {
   DEFAULT_SUB_SELECTIONS,
   MAIN_NAV_ITEMS,
   MAIN_PANEL_TITLES,
-  MARKET_SHOP_SECTIONS,
-  MARKET_TRADE_WINDOW_ACTIONS,
   SUBMENUS_BY_MAIN,
 } from "@/entities/nav";
 import type {
   FormFieldSpec,
   MainNavId,
+  MarketSubId,
   PanelDataItem,
   PanelStackItem,
   QuestsSubId,
@@ -51,13 +51,6 @@ import {
   PARTY_FORM_FIELDS,
   SOCIAL_LISTS,
 } from "@/features/social/model";
-import { LISTING_FORM_FIELDS } from "@/features/market/model";
-import {
-  MARKET_SHOP_CATALOG_LIST,
-  MARKET_SHOP_MY_LISTINGS,
-  MARKET_TRADE_FRIENDS,
-  MARKET_WALLET_SUMMARY_LIST,
-} from "@/features/market/model";
 import { SKILLS_LISTS } from "@/features/skills/model";
 import { SYSTEM_PANEL_ROWS } from "@/features/system/model";
 import { bringToFrontStable } from "@/shared/lib/reorder";
@@ -65,8 +58,6 @@ import { UI_CONSTS } from "@/shared/lib/uiConsts";
 import { useToast } from "@/context/ToastContext";
 import { NotificationBell } from "@/features/notification/NotificationBell";
 import { requestJoinPartyApi, requestJoinGuildApi } from "@/lib/api/endpoints/social.api";
-import { reserveShopItemApi, confirmShopPurchaseApi, cancelListingApi, createListingApi } from "@/lib/api/endpoints/market.api";
-import { MOCK_SHOP_ITEMS } from "@/lib/api/mock/market.mock";
 
 type SurfaceFocusState = {
   counter: number;
@@ -77,12 +68,7 @@ type DetailSelectionKey =
   | "player"
   | "skills"
   | "social"
-  | "lifelog"
-  | "marketWallet"
-  | "marketCatalog"
-  | "marketMyListings"
-  | "marketTradeFriend"
-  | "marketTradeAction";
+  | "lifelog";
 
 const SURFACE_GROUP_BASE_Z = {
   left: 100000,
@@ -96,11 +82,6 @@ function createDefaultDetailSelections(): Record<DetailSelectionKey, string | nu
     skills: null,
     social: null,
     lifelog: null,
-    marketWallet: null,
-    marketCatalog: null,
-    marketMyListings: null,
-    marketTradeFriend: null,
-    marketTradeAction: null,
   };
 }
 
@@ -119,7 +100,6 @@ function selectedSubForMain(selectedMain: MainNavId, selectedSubByMain: Record<M
 function buildPanels(
   selectedMain: MainNavId,
   selectedSubByMain: Record<MainNavId, string | null>,
-  selectedMarketShopSectionId: string | null,
   selectedDetailByKey: Record<DetailSelectionKey, string | null>,
 ): { panelStack: PanelStackItem[]; socialContext: SocialContextData | null } {
   const mainItems = SUBMENUS_BY_MAIN[selectedMain];
@@ -207,138 +187,6 @@ function buildPanels(
   }
 
   if (selectedMain === "market") {
-    if (selectedMainSub === "wallet") {
-      const selectedItem = findById(MARKET_WALLET_SUMMARY_LIST, selectedDetailByKey.marketWallet);
-
-      panelStack.push({
-        id: "market-wallet-summary",
-        kind: "list",
-        title: "Summary",
-        items: MARKET_WALLET_SUMMARY_LIST,
-        selectedId: selectedDetailByKey.marketWallet ?? undefined,
-        context: { main: "market", route: "market-wallet-summary" },
-      });
-
-      if (selectedItem) {
-        panelStack.push({
-          id: `market-wallet-detail-${selectedItem.id}`,
-          kind: "placeholder",
-          title: "Wallet Detail",
-          description: selectedItem.detailDescription,
-          rows: selectedItem.detailRows,
-        });
-      }
-
-      return { panelStack, socialContext: null };
-    }
-
-    if (selectedMainSub === "shop") {
-      const selectedShopSub =
-        MARKET_SHOP_SECTIONS.find((item) => item.id === selectedMarketShopSectionId)?.id ?? null;
-
-      panelStack.push({
-        id: "market-shop-menu",
-        kind: "menu",
-        title: "Shop",
-        items: MARKET_SHOP_SECTIONS,
-        selectedId: selectedShopSub ?? undefined,
-        context: { main: "market", route: "market-shop-menu" },
-      });
-
-      if (!selectedShopSub) {
-        return { panelStack, socialContext: null };
-      }
-
-      if (selectedShopSub === "catalog") {
-        const selectedItem = findById(MARKET_SHOP_CATALOG_LIST, selectedDetailByKey.marketCatalog);
-        panelStack.push({
-          id: "market-shop-catalog-list",
-          kind: "list",
-          title: "Listing",
-          items: MARKET_SHOP_CATALOG_LIST,
-          selectedId: selectedDetailByKey.marketCatalog ?? undefined,
-          context: { main: "market", route: "market-shop-catalog-list" },
-        });
-
-        if (selectedItem) {
-          panelStack.push({
-            id: `market-shop-catalog-detail-${selectedItem.id}`,
-            kind: "placeholder",
-            title: "Item Detail / Buy",
-            description: selectedItem.detailDescription,
-            rows: selectedItem.detailRows,
-            primaryActionLabel: "Buy",
-          });
-        }
-      } else {
-        const selectedItem = findById(MARKET_SHOP_MY_LISTINGS, selectedDetailByKey.marketMyListings);
-        panelStack.push({
-          id: "market-shop-my-listings",
-          kind: "list",
-          title: "My Selling List",
-          items: MARKET_SHOP_MY_LISTINGS,
-          selectedId: selectedDetailByKey.marketMyListings ?? undefined,
-          context: { main: "market", route: "market-shop-my-listings" },
-        });
-
-        if (selectedItem) {
-          panelStack.push({
-            id: `market-shop-my-listings-detail-${selectedItem.id}`,
-            kind: "placeholder",
-            title: "Listing Detail",
-            description: selectedItem.detailDescription,
-            rows: selectedItem.detailRows,
-          });
-        }
-      }
-
-      return { panelStack, socialContext: null };
-    }
-
-    const selectedTradeFriend = findById(MARKET_TRADE_FRIENDS, selectedDetailByKey.marketTradeFriend);
-    panelStack.push({
-      id: "market-trade-friends",
-      kind: "list",
-      title: "Friend List",
-      items: MARKET_TRADE_FRIENDS,
-      selectedId: selectedDetailByKey.marketTradeFriend ?? undefined,
-      context: { main: "market", route: "market-trade-friends" },
-    });
-
-    if (selectedTradeFriend) {
-      panelStack.push({
-        id: `market-trade-window-${selectedTradeFriend.id}`,
-        kind: "placeholder",
-        title: "Trade Window",
-        description: selectedTradeFriend.detailDescription,
-        rows: selectedTradeFriend.detailRows,
-      });
-
-      panelStack.push({
-        id: "market-trade-action-menu",
-        kind: "menu",
-        title: "Trade Action",
-        items: MARKET_TRADE_WINDOW_ACTIONS,
-        selectedId: selectedDetailByKey.marketTradeAction ?? undefined,
-        context: { main: "market", route: "market-trade-action-menu" },
-      });
-
-      if (selectedDetailByKey.marketTradeAction === "confirm") {
-        panelStack.push({
-          id: `market-trade-confirm-${selectedTradeFriend.id}`,
-          kind: "modal",
-          title: "Confirm Modal",
-          description: `Confirm trade with ${selectedTradeFriend.label}.`,
-          rows: [
-            "Validation: Slot limits checked",
-            "Validation: Partner online",
-            "Validation: Fee rule applied",
-          ],
-          confirmLabel: "Confirm Trade",
-        });
-      }
-    }
-
     return { panelStack, socialContext: null };
   }
 
@@ -396,7 +244,6 @@ export default function Home() {
   const [selectedSubByMain, setSelectedSubByMain] = useState<Record<MainNavId, string | null>>({
     ...DEFAULT_SUB_SELECTIONS,
   });
-  const [selectedMarketShopSectionId, setSelectedMarketShopSectionId] = useState<string | null>(null);
   const [selectedDetailByKey, setSelectedDetailByKey] = useState<
     Record<DetailSelectionKey, string | null>
   >(() => createDefaultDetailSelections());
@@ -425,15 +272,6 @@ export default function Home() {
     if (main === "lifelog") {
       updateDetailSelections({ lifelog: null });
     }
-    if (main === "market") {
-      updateDetailSelections({
-        marketWallet: null,
-        marketCatalog: null,
-        marketMyListings: null,
-        marketTradeFriend: null,
-        marketTradeAction: null,
-      });
-    }
   };
 
   const { panelStack: basePanelStack, socialContext } = useMemo(
@@ -441,14 +279,12 @@ export default function Home() {
       ? buildPanels(
         selectedMain,
         selectedSubByMain,
-        selectedMarketShopSectionId,
         selectedDetailByKey,
       )
       : { panelStack: [], socialContext: null },
     [
       selectedMain,
       selectedSubByMain,
-      selectedMarketShopSectionId,
       selectedDetailByKey,
     ],
   );
@@ -479,7 +315,6 @@ export default function Home() {
 
   const clearFeatureState = () => {
     setSelectedSubByMain({ ...DEFAULT_SUB_SELECTIONS });
-    setSelectedMarketShopSectionId(null);
     setSelectedDetailByKey(createDefaultDetailSelections());
     setActiveFormPanel(null);
     setEditingItemId(null);
@@ -521,26 +356,15 @@ export default function Home() {
         const next = tog(current);
         setSelectedSubByMain((prev) => ({ ...prev, [panel.context.main]: next }));
         clearDetailSelectionsForMain(panel.context.main);
-        if (panel.context.main === "market") setSelectedMarketShopSectionId(null);
         setActiveFormPanel(null);
         setEditingItemId(null);
         return;
-      }
-
-      if (panel.context.route === "market-shop-menu") {
-        setSelectedMarketShopSectionId(tog(selectedMarketShopSectionId));
-        updateDetailSelections({ marketCatalog: null, marketMyListings: null });
-        return;
-      }
-
-      if (panel.context.route === "market-trade-action-menu") {
-        updateDetailSelections({ marketTradeAction: tog(selectedDetailByKey.marketTradeAction) });
       }
       return;
     }
 
     if (panel.kind === "list") {
-      const { player, skills, social, marketWallet, marketCatalog, marketMyListings, marketTradeFriend } = selectedDetailByKey;
+      const { player, skills, social } = selectedDetailByKey;
 
       if (panel.context.route === "player-list") {
         setActiveFormPanel(null); setEditingItemId(null);
@@ -548,19 +372,10 @@ export default function Home() {
       }
       if (panel.context.route === "skills-list") updateDetailSelections({ skills: tog(skills) });
       if (panel.context.route === "social-list") updateDetailSelections({ social: tog(social) });
-      if (panel.context.route === "market-wallet-summary") updateDetailSelections({ marketWallet: tog(marketWallet) });
-      if (panel.context.route === "market-shop-catalog-list") updateDetailSelections({ marketCatalog: tog(marketCatalog) });
-      if (panel.context.route === "market-shop-my-listings") updateDetailSelections({ marketMyListings: tog(marketMyListings) });
-      if (panel.context.route === "market-trade-friends") {
-        updateDetailSelections({
-          marketTradeFriend: tog(marketTradeFriend),
-          marketTradeAction: null,
-        });
-      }
     }
   };
 
-  const closeFeatureSubmenu = (main: "player" | "inventory") => {
+  const closeFeatureSubmenu = (main: "player" | "inventory" | "market") => {
     setSelectedSubByMain((prev) => ({ ...prev, [main]: null }));
     clearDetailSelectionsForMain(main);
     setActiveFormPanel(null);
@@ -624,8 +439,6 @@ export default function Home() {
       openForm("party-create", "Create Party", PARTY_FORM_FIELDS, "파티 생성");
     } else if (route === "social-list" && sub === "guild") {
       openForm("guild-create", "Create Guild", GUILD_FORM_FIELDS, "길드 생성");
-    } else if (route === "market-shop-my-listings") {
-      openForm("listing-create", "New Listing", LISTING_FORM_FIELDS, "등록하기");
     }
   };
 
@@ -665,58 +478,7 @@ export default function Home() {
             }
           },
         });
-      } else if (selectedMain === "market") {
-        // Shop purchase: reserve → confirm flow
-        const shopItemId = Number(itemId);
-        const shopItem = MOCK_SHOP_ITEMS.find((s) => s.id === shopItemId);
-        const catalogItem = MARKET_SHOP_CATALOG_LIST.find((c) => c.id === itemId);
-        const itemName = catalogItem?.label ?? `Item #${shopItemId}`;
-        const price = shopItem?.price ?? 0;
-
-        setPendingAction({
-          title: "구매 예약",
-          message: `${itemName}\n${price.toLocaleString()} col — 5분간 예약합니다.`,
-          onConfirm: async () => {
-            try {
-              const { reservationToken, expiresAt } = await reserveShopItemApi(shopItemId);
-              const expiryStr = new Date(expiresAt).toLocaleTimeString("ko-KR", { hour: "2-digit", minute: "2-digit", second: "2-digit" });
-              setPendingAction({
-                title: "구매 확정",
-                message: `${itemName}\n${price.toLocaleString()} col\n예약 만료: ${expiryStr}`,
-                onConfirm: async () => {
-                  try {
-                    await confirmShopPurchaseApi(reservationToken);
-                    showToast({ variant: "success", title: "구매 완료", body: `${itemName} — ${price.toLocaleString()} col` });
-                  } catch {
-                    showToast({ variant: "error", title: "구매 실패", body: "다시 시도해주세요." });
-                  }
-                },
-              });
-            } catch {
-              showToast({ variant: "error", title: "예약 실패", body: "다시 시도해주세요." });
-            }
-          },
-        });
       }
-
-    } else if (actionType === "cancel") {
-      if (selectedMain === "market") {
-        const listingId = Number(itemId);
-        const listingItem = MARKET_SHOP_MY_LISTINGS.find((l) => l.id === itemId);
-        setPendingAction({
-          title: "리스팅 취소",
-          message: `${listingItem?.label ?? `리스팅 #${listingId}`} 판매를 취소하시겠습니까?`,
-          onConfirm: async () => {
-            try {
-              await cancelListingApi(listingId);
-              showToast({ variant: "info", title: "리스팅 취소됨", body: listingItem?.label ?? `#${listingId}` });
-            } catch {
-              showToast({ variant: "error", title: "취소 실패", body: "다시 시도해주세요." });
-            }
-          },
-        });
-      }
-
     } else if (actionType === "delete") {
       setPendingAction({
         title: "삭제",
@@ -727,25 +489,7 @@ export default function Home() {
   };
 
   // Called when form panel submit is confirmed
-  const handlePanelFormSubmit = (formKey: string, values: Record<string, string>) => {
-    if (formKey === "listing-create") {
-      const itemInstanceId = Number(values._itemInstanceId);
-      const itemId = Number(values._itemId);
-      const price = Number(values.price);
-      const itemName = values.itemName ?? `Item #${itemInstanceId}`;
-      if (!itemInstanceId || !price) {
-        showToast({ variant: "error", title: "입력 오류", body: "가격을 입력해주세요." });
-        return;
-      }
-      createListingApi({ itemInstanceId, itemId, price }).then(() => {
-        showToast({ variant: "success", title: "리스팅 등록됨", body: `${itemName} — ${price.toLocaleString()} col` });
-        setActiveFormPanel(null);
-      }).catch(() => {
-        showToast({ variant: "error", title: "등록 실패", body: "다시 시도해주세요." });
-      });
-      return;
-    }
-
+  const handlePanelFormSubmit = () => {
     const wasEditing = editingItemId !== null;
     setActiveFormPanel(null);
     setEditingItemId(null);
@@ -872,6 +616,19 @@ export default function Home() {
                 onPanelItemSelect={handlePanelItemSelect}
               />
               {inventorySurface}
+            </div>
+          ) : selectedMain === "market" ? (
+            <div className="lag-exchange-route flex w-fit items-center gap-3">
+              <RightPanels
+                selectedMain="market"
+                panelStack={panelStack.slice(0, 1)}
+                onPanelItemSelect={handlePanelItemSelect}
+              />
+              <ExchangeShell
+                surface={selectedSubByMain.market as MarketSubId | null}
+                playerId={playerId}
+                onBack={() => closeFeatureSubmenu("market")}
+              />
             </div>
           ) : selectedMain === "lifelog" && selectedSubByMain.lifelog === "journal" ? (
             <div className="flex w-fit items-center gap-3">

--- a/entities/nav/config.test.ts
+++ b/entities/nav/config.test.ts
@@ -32,4 +32,11 @@ describe("primary Orb navigation을 구성할 때", () => {
       expect(SUBMENUS_BY_MAIN.lifelog.map(({ id }) => id)).toEqual(["journal", "collection", "media", "exercise"]);
     });
   });
+
+  describe("Exchange IA를 노출하면", () => {
+    it("market internal key를 유지하고 Wallet/Shop/Trade만 표시한다", () => {
+      expect(MAIN_NAV_ITEMS.find(({ id }) => id === "market")).toEqual({ id: "market", label: "Exchange", slotLabel: "EX" });
+      expect(SUBMENUS_BY_MAIN.market.map(({ id }) => id)).toEqual(["wallet", "shop", "trade"]);
+    });
+  });
 });

--- a/entities/nav/config.ts
+++ b/entities/nav/config.ts
@@ -12,13 +12,13 @@ export const MAIN_NAV_ITEMS: Array<{ id: MainNavId; label: string; slotLabel: st
   { id: "quests",    label: "Journey",   slotLabel: "QU" },
   { id: "role",      label: "Role",      slotLabel: "RL" },
   { id: "lifelog",   label: "Lifelog",   slotLabel: "LI" },
-  { id: "market",    label: "Market",    slotLabel: "MK" },
+  { id: "market",    label: "Exchange",  slotLabel: "EX" },
   { id: "system",    label: "System",    slotLabel: "SY" },
 ];
 
 export const MAIN_PANEL_TITLES: Record<MainNavId, string> = {
   player: "Player", skills: "Skills", inventory: "Inventory", quests: "Journey",
-  role: "Role", social: "Social", lifelog: "Lifelog", market: "Market", system: "System",
+  role: "Role", social: "Social", lifelog: "Lifelog", market: "Exchange", system: "System",
 };
 
 export const SUBMENUS_BY_MAIN: Record<MainNavId, PanelMenuItem[]> = {
@@ -80,14 +80,4 @@ export const INVENTORY_GEAR_PARTS: PanelMenuItem[] = [
   { id: "armor",     label: "Armor",     slotLabel: "AR" },
   { id: "accessory", label: "Accessory", slotLabel: "AC" },
   { id: "boots",     label: "Boots",     slotLabel: "BT" },
-];
-
-export const MARKET_SHOP_SECTIONS: PanelMenuItem[] = [
-  { id: "catalog",    label: "Catalog",     slotLabel: "CA" },
-  { id: "myListings", label: "My Listings", slotLabel: "ML" },
-];
-
-export const MARKET_TRADE_WINDOW_ACTIONS: PanelMenuItem[] = [
-  { id: "review",  label: "Review Offer",  slotLabel: "RV" },
-  { id: "confirm", label: "Confirm Trade", slotLabel: "CF" },
 ];

--- a/features/market/ExchangeShell.test.tsx
+++ b/features/market/ExchangeShell.test.tsx
@@ -1,0 +1,185 @@
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { readFileSync } from "node:fs";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { InventoryEntry, ListingSummary, ShopItem, TradeSummary } from "@/shared/api/types";
+import ExchangeShell from "./ExchangeShell";
+
+const api = vi.hoisted(() => ({
+  getWalletApi: vi.fn(),
+  getShopItemsApi: vi.fn(),
+  getShopPurchasesApi: vi.fn(),
+  getOpenListingsApi: vi.fn(),
+  getMyListingsApi: vi.fn(),
+  getTradesApi: vi.fn(),
+  initiateShopPurchaseApi: vi.fn(),
+  confirmShopPurchaseApi: vi.fn(),
+  createListingApi: vi.fn(),
+  cancelListingApi: vi.fn(),
+  reserveListingApi: vi.fn(),
+  purchaseListingApi: vi.fn(),
+  getInventoryApi: vi.fn(),
+}));
+
+vi.mock("@/lib/api/endpoints/market.api", () => api);
+vi.mock("@/lib/api/endpoints/inventory.api", () => ({ getInventoryApi: api.getInventoryApi }));
+
+const shopItems: ShopItem[] = [
+  { id: 1, itemId: 1010, price: 45_000, currency: "GOLD", available: true, globalStockLimit: null, perPlayerLimit: 1, reservationTtlSec: 300 },
+  { id: 3, itemId: 5010, price: 4_200, currency: "GOLD", available: false, globalStockLimit: null, perPlayerLimit: null, reservationTtlSec: null },
+];
+const openListings: ListingSummary[] = [
+  { id: 101, itemId: 1003, sellerId: 7, price: 35_000, currency: "GOLD", status: "OPEN" },
+  { id: 201, itemId: 3011, sellerId: 24, price: 1_800, currency: "GEM", status: "OPEN" },
+];
+const inventory: InventoryEntry[] = [
+  { itemInstanceId: 4, slotIndex: 3, itemId: 2002, itemName: "Bound Boots", category: "ARMOR", type: "ETC", rarity: "RARE", stackable: false, maxStack: 1, quantity: 1, bound: true, durability: 72, instanceAttrs: {} },
+  { itemInstanceId: 5, slotIndex: 4, itemId: 3001, itemName: "Owned Potion Stack", category: "CONSUMABLE", type: "POTION", rarity: "COMMON", stackable: true, maxStack: 99, quantity: 42, bound: false, durability: null, instanceAttrs: {} },
+];
+const trades: TradeSummary[] = [
+  { id: 301, listingId: 88, buyerId: 7, sellerId: 24, price: 28_000, currency: "GOLD" },
+  { id: 302, listingId: 56, buyerId: 13, sellerId: 7, price: 45, currency: "GEM" },
+];
+
+describe("canonical Exchange surfaces", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+    vi.spyOn(globalThis.crypto, "randomUUID").mockReturnValue("00000000-0000-4000-8000-000000000068");
+    api.getWalletApi.mockResolvedValue({ amount: 284_500, currency: "GOLD" });
+    api.getShopItemsApi.mockResolvedValue(shopItems);
+    api.getShopPurchasesApi.mockResolvedValue([]);
+    api.getOpenListingsApi.mockResolvedValue(openListings);
+    api.getMyListingsApi.mockResolvedValue([openListings[0]]);
+    api.getTradesApi.mockResolvedValue(trades);
+    api.getInventoryApi.mockResolvedValue({ entries: inventory });
+    api.initiateShopPurchaseApi.mockResolvedValue({ id: 41 });
+    api.confirmShopPurchaseApi.mockResolvedValue({ reservationToken: "canonical-shop-token", expiresAt: "2026-08-23T01:00:00Z" });
+    api.createListingApi.mockResolvedValue({ id: 77 });
+    api.cancelListingApi.mockResolvedValue(undefined);
+    api.reserveListingApi.mockResolvedValue({ reservationToken: "listing-token", holdId: "hold-201", expiresAt: "2026-08-23T01:00:00Z" });
+    api.purchaseListingApi.mockResolvedValue({ id: 401, listingId: 201, buyerId: 7, sellerId: 24, price: 1_800, currency: "GEM" });
+  });
+
+  it("renders real Wallet loading/error/retry without generated history", async () => {
+    api.getWalletApi.mockRejectedValueOnce(new Error("Wallet unavailable")).mockResolvedValueOnce({ amount: 25, currency: "GEM" });
+    render(<ExchangeShell surface="wallet" playerId={7} onBack={vi.fn()} />);
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Wallet unavailable");
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    expect(await screen.findByText("25")).toBeInTheDocument();
+    expect(screen.getByText("GEM")).toBeInTheDocument();
+    expect(screen.queryByText(/transaction|monthly|available|reserved balance/i)).not.toBeInTheDocument();
+  });
+
+  it("loads canonical ShopItems, blocks unavailable purchase, and keeps one detail frame during replacement", async () => {
+    render(<ExchangeShell surface="shop" playerId={7} onBack={vi.fn()} />);
+
+    fireEvent.click(await screen.findByRole("button", { name: /Item #1010/ }));
+    const detail = document.querySelector('[data-stage-key="market-stage-2"]');
+    expect(detail).toBeInTheDocument();
+    expect(screen.getByText("Global stock limit").nextElementSibling).toHaveTextContent("None");
+
+    fireEvent.click(screen.getByRole("button", { name: /Item #5010/ }));
+    expect(document.querySelector('[data-stage-key="market-stage-2"]')).toBe(detail);
+    expect(screen.getByRole("button", { name: "Purchase" })).toBeDisabled();
+    expect(screen.getByText("This item is unavailable.")).toBeInTheDocument();
+  });
+
+  it("recovers a reserved purchase by returned id and explicitly confirms its canonical history token", async () => {
+    api.getShopPurchasesApi
+      .mockResolvedValueOnce([])
+      .mockResolvedValue([{ id: 41, shopItemId: 1, quantity: 1, status: "RESERVED", reservationToken: "canonical-shop-token", reservationExpiresAt: "2026-08-23T01:00:00Z" }]);
+    render(<ExchangeShell surface="shop" playerId={7} onBack={vi.fn()} />);
+
+    fireEvent.click(await screen.findByRole("button", { name: /Item #1010/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Reserve / Start purchase" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Confirm Purchase" }));
+
+    await waitFor(() => expect(api.confirmShopPurchaseApi).toHaveBeenCalledWith("canonical-shop-token", expect.any(String)));
+    expect(api.initiateShopPurchaseApi).toHaveBeenCalledWith(expect.objectContaining({ shopItemId: 1, quantity: 1, reserveOnly: true }));
+  });
+
+  it("guards self purchase and performs explicit Marketplace reserve/purchase", async () => {
+    render(<ExchangeShell surface="shop" playerId={7} onBack={vi.fn()} />);
+    fireEvent.click(await screen.findByRole("button", { name: "Marketplace" }));
+
+    fireEvent.click(screen.getByRole("button", { name: /Item #1003/ }));
+    expect(screen.getByRole("button", { name: "Your listing" })).toBeDisabled();
+    fireEvent.click(screen.getByRole("button", { name: /Item #3011/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Reserve" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Purchase reserved listing" }));
+
+    await waitFor(() => expect(api.purchaseListingApi).toHaveBeenCalledWith(201, "listing-token", expect.any(String)));
+    expect(api.reserveListingApi).toHaveBeenCalledWith(201, 300);
+  });
+
+  it("creates a PD-01 listing from a real whole InventoryEntry with only total price and GOLD/GEM", async () => {
+    render(<ExchangeShell surface="shop" playerId={7} onBack={vi.fn()} />);
+    fireEvent.click(await screen.findByRole("button", { name: "My Listings" }));
+    fireEvent.click(screen.getByRole("button", { name: "Create Listing" }));
+
+    expect(screen.getByRole("button", { name: /Bound Boots/ })).toBeDisabled();
+    const stack = screen.getByRole("button", { name: /Owned Potion Stack/ });
+    expect(stack).toHaveTextContent("Whole entry · x42");
+    expect(screen.queryByLabelText(/quantity|item id|inventory entry id|item name/i)).not.toBeInTheDocument();
+    expect(within(screen.getByLabelText("Currency")).getAllByRole("option").map(({ textContent }) => textContent)).toEqual(["GOLD", "GEM"]);
+
+    fireEvent.click(stack);
+    fireEvent.change(screen.getByLabelText("Total Price"), { target: { value: "12000" } });
+    fireEvent.change(screen.getByLabelText("Currency"), { target: { value: "GEM" } });
+    const form = screen.getByLabelText("Total Price").closest("form")!;
+    fireEvent.click(within(form).getByRole("button", { name: "Create Listing" }));
+
+    await waitFor(() => expect(api.createListingApi).toHaveBeenCalledWith({ inventoryEntryId: 5, price: 12_000, currency: "GEM" }));
+  });
+
+  it("keeps a rejected listing form open with an explicit error", async () => {
+    api.createListingApi.mockRejectedValue(new Error("Listing rejected"));
+    render(<ExchangeShell surface="shop" playerId={7} onBack={vi.fn()} />);
+    fireEvent.click(await screen.findByRole("button", { name: "My Listings" }));
+    fireEvent.click(screen.getByRole("button", { name: "Create Listing" }));
+    fireEvent.click(screen.getByRole("button", { name: /Owned Potion Stack/ }));
+    fireEvent.change(screen.getByLabelText("Total Price"), { target: { value: "1" } });
+    fireEvent.click(within(screen.getByLabelText("Total Price").closest("form")!).getByRole("button", { name: "Create Listing" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Listing rejected");
+    expect(screen.getByLabelText("Total Price")).toBeInTheDocument();
+  });
+
+  it("cancels My Listings only after confirmation and reloads authoritative lists", async () => {
+    render(<ExchangeShell surface="shop" playerId={7} onBack={vi.fn()} />);
+    fireEvent.click(await screen.findByRole("button", { name: "My Listings" }));
+    fireEvent.click(screen.getByRole("button", { name: /Item #1003/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Cancel Listing" }));
+
+    await waitFor(() => expect(api.cancelListingApi).toHaveBeenCalledWith(101));
+    expect(window.confirm).toHaveBeenCalledWith("Cancel listing #101?");
+    expect(api.getMyListingsApi).toHaveBeenCalledTimes(2);
+    expect(api.getOpenListingsApi).toHaveBeenCalledTimes(2);
+    expect(api.getInventoryApi).toHaveBeenCalledTimes(2);
+  });
+
+  it("replaces fake friend barter with canonical Bought/Sold Trade history", async () => {
+    render(<ExchangeShell surface="trade" playerId={7} onBack={vi.fn()} />);
+
+    expect(await screen.findByText("Bought")).toBeInTheDocument();
+    expect(screen.getByText("Sold")).toBeInTheDocument();
+    expect(screen.getByText("Player #24")).toBeInTheDocument();
+    expect(screen.getByText("Player #13")).toBeInTheDocument();
+    expect(screen.queryByText(/friend|barter|offered|received/i)).not.toBeInTheDocument();
+  });
+
+  it("keeps Exchange at two feature stages and translates the dual-theme hierarchy semantically", () => {
+    const source = readFileSync("features/market/ExchangeShell.tsx", "utf8");
+    const css = readFileSync("app/globals.css", "utf8");
+    const exchangeCss = css.slice(css.indexOf("/* Exchange uses"), css.indexOf("@media (min-width: 768px)"));
+
+    expect(new Set(source.match(/market-stage-[12]/g))).toEqual(new Set(["market-stage-1", "market-stage-2"]));
+    expect(source).not.toMatch(/MARKET_|friend|barter|Wishlist|Plan & Rhythm|Income|Asset Trace/);
+    expect(exchangeCss).toContain("var(--lag-control-bg)");
+    expect(exchangeCss).not.toMatch(/#[0-9a-f]{3,8}|rgba?\(/i);
+    expect(css).toMatch(/@media \(max-width: 767px\)[\s\S]*\.lag-exchange-tabs\s*{[^}]*grid-template-columns:\s*minmax\(0, 1fr\)/);
+  });
+});

--- a/features/market/ExchangeShell.test.tsx
+++ b/features/market/ExchangeShell.test.tsx
@@ -29,6 +29,7 @@ const shopItems: ShopItem[] = [
   { id: 3, itemId: 5010, price: 4_200, currency: "GOLD", available: false, globalStockLimit: null, perPlayerLimit: null, reservationTtlSec: null },
 ];
 const reservedPurchase: ShopPurchaseSummary = { id: 41, shopItemId: 1, quantity: 1, status: "RESERVED", reservationToken: "canonical-shop-token", reservationExpiresAt: "2026-08-23T01:00:00Z" };
+const requestedPurchase: ShopPurchaseSummary = { id: 40, shopItemId: 1, quantity: 1, status: "REQUESTED", reservationToken: null, reservationExpiresAt: null };
 const openListings: ListingSummary[] = [
   { id: 101, itemId: 1003, sellerId: 7, price: 35_000, currency: "GOLD", status: "OPEN" },
   { id: 201, itemId: 3011, sellerId: 24, price: 1_800, currency: "GEM", status: "OPEN" },
@@ -120,6 +121,22 @@ describe("canonical Exchange surfaces", () => {
     await waitFor(() => expect(api.confirmShopPurchaseApi).toHaveBeenCalledWith("canonical-shop-token", expect.any(String)));
   });
 
+  it("restores REQUESTED as pending and refreshes it into a confirmable reservation", async () => {
+    api.getShopPurchasesApi.mockResolvedValueOnce([requestedPurchase]).mockResolvedValue([reservedPurchase]);
+    render(<ExchangeShell surface="shop" playerId={7} onBack={vi.fn()} />);
+
+    fireEvent.click(await screen.findByRole("button", { name: /Item #1010/ }));
+
+    expect(await screen.findByRole("button", { name: "Refresh Purchase Status" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Reserve / Start purchase" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Confirm Purchase" })).not.toBeInTheDocument();
+    expect(api.initiateShopPurchaseApi).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Refresh Purchase Status" }));
+
+    expect(await screen.findByRole("button", { name: "Confirm Purchase" })).toBeInTheDocument();
+  });
+
   it("keeps a started reservation recoverable after Back and reopening the same item", async () => {
     api.getShopPurchasesApi.mockResolvedValueOnce([]).mockResolvedValue([reservedPurchase]);
     render(<ExchangeShell surface="shop" playerId={7} onBack={vi.fn()} />);
@@ -164,20 +181,18 @@ describe("canonical Exchange surfaces", () => {
     expect(screen.queryByRole("button", { name: "Confirm Purchase" })).not.toBeInTheDocument();
   });
 
-  it("deterministically restores the highest-id RESERVED purchase", async () => {
+  it("deterministically restores the highest-id nonterminal purchase", async () => {
     api.getShopPurchasesApi.mockResolvedValue([
       { ...reservedPurchase, id: 45, reservationToken: "latest-token" },
       { ...reservedPurchase, id: 43, reservationToken: "older-token" },
-      { ...reservedPurchase, id: 44, reservationToken: "middle-token" },
+      { ...requestedPurchase, id: 46 },
     ]);
     render(<ExchangeShell surface="shop" playerId={7} onBack={vi.fn()} />);
 
     fireEvent.click(await screen.findByRole("button", { name: /Item #1010/ }));
-    expect(await screen.findByRole("button", { name: "Confirm Purchase" })).toBeInTheDocument();
-    expect(screen.getByText("Purchase ID").nextElementSibling).toHaveTextContent("45");
-    fireEvent.click(screen.getByRole("button", { name: "Confirm Purchase" }));
-
-    await waitFor(() => expect(api.confirmShopPurchaseApi).toHaveBeenCalledWith("latest-token", expect.any(String)));
+    expect(await screen.findByRole("button", { name: "Refresh Purchase Status" })).toBeInTheDocument();
+    expect(screen.getByText("Purchase ID").nextElementSibling).toHaveTextContent("46");
+    expect(screen.queryByRole("button", { name: "Confirm Purchase" })).not.toBeInTheDocument();
   });
 
   it("guards self purchase and performs explicit Marketplace reserve/purchase", async () => {
@@ -206,9 +221,14 @@ describe("canonical Exchange surfaces", () => {
     expect(within(screen.getByLabelText("Currency")).getAllByRole("option").map(({ textContent }) => textContent)).toEqual(["GOLD", "GEM"]);
 
     fireEvent.click(stack);
+    expect(screen.getByLabelText("Total Price")).toHaveAttribute("step", "1");
+    fireEvent.change(screen.getByLabelText("Total Price"), { target: { value: "1.5" } });
+    const form = screen.getByLabelText("Total Price").closest("form")!;
+    expect(within(form).getByRole("button", { name: "Create Listing" })).toBeDisabled();
+    fireEvent.submit(form);
+    expect(api.createListingApi).not.toHaveBeenCalled();
     fireEvent.change(screen.getByLabelText("Total Price"), { target: { value: "12000" } });
     fireEvent.change(screen.getByLabelText("Currency"), { target: { value: "GEM" } });
-    const form = screen.getByLabelText("Total Price").closest("form")!;
     fireEvent.click(within(form).getByRole("button", { name: "Create Listing" }));
 
     await waitFor(() => expect(api.createListingApi).toHaveBeenCalledWith({ inventoryEntryId: 5, price: 12_000, currency: "GEM" }));
@@ -278,6 +298,8 @@ describe("canonical Exchange surfaces", () => {
     expect(new Set(source.match(/market-stage-[12]/g))).toEqual(new Set(["market-stage-1", "market-stage-2"]));
     expect(source).not.toMatch(/MARKET_|friend|barter|Wishlist|Plan & Rhythm|Income|Asset Trace/);
     expect(exchangeCss).toContain("var(--lag-control-bg)");
+    expect(exchangeCss).toContain(".lag-exchange-row:not(:disabled):hover");
+    expect(exchangeCss).toContain(".lag-exchange-entry:not(:disabled):hover");
     expect(exchangeCss).not.toMatch(/#[0-9a-f]{3,8}|rgba?\(/i);
     expect(css).toMatch(/@media \(max-width: 767px\)[\s\S]*\.lag-exchange-tabs\s*{[^}]*grid-template-columns:\s*minmax\(0, 1fr\)/);
   });

--- a/features/market/ExchangeShell.test.tsx
+++ b/features/market/ExchangeShell.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen, waitFor, within } from "@testing-library/rea
 import { readFileSync } from "node:fs";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { InventoryEntry, ListingSummary, ShopItem, TradeSummary } from "@/shared/api/types";
+import type { InventoryEntry, ListingSummary, ShopItem, ShopPurchaseSummary, TradeSummary } from "@/shared/api/types";
 import ExchangeShell from "./ExchangeShell";
 
 const api = vi.hoisted(() => ({
@@ -28,6 +28,7 @@ const shopItems: ShopItem[] = [
   { id: 1, itemId: 1010, price: 45_000, currency: "GOLD", available: true, globalStockLimit: null, perPlayerLimit: 1, reservationTtlSec: 300 },
   { id: 3, itemId: 5010, price: 4_200, currency: "GOLD", available: false, globalStockLimit: null, perPlayerLimit: null, reservationTtlSec: null },
 ];
+const reservedPurchase: ShopPurchaseSummary = { id: 41, shopItemId: 1, quantity: 1, status: "RESERVED", reservationToken: "canonical-shop-token", reservationExpiresAt: "2026-08-23T01:00:00Z" };
 const openListings: ListingSummary[] = [
   { id: 101, itemId: 1003, sellerId: 7, price: 35_000, currency: "GOLD", status: "OPEN" },
   { id: 201, itemId: 3011, sellerId: 24, price: 1_800, currency: "GEM", status: "OPEN" },
@@ -45,7 +46,10 @@ describe("canonical Exchange surfaces", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.spyOn(window, "confirm").mockReturnValue(true);
-    vi.spyOn(globalThis.crypto, "randomUUID").mockReturnValue("00000000-0000-4000-8000-000000000068");
+    vi.spyOn(globalThis.crypto, "randomUUID")
+      .mockReturnValueOnce("00000000-0000-4000-8000-000000000001")
+      .mockReturnValueOnce("00000000-0000-4000-8000-000000000002")
+      .mockReturnValue("00000000-0000-4000-8000-000000000003");
     api.getWalletApi.mockResolvedValue({ amount: 284_500, currency: "GOLD" });
     api.getShopItemsApi.mockResolvedValue(shopItems);
     api.getShopPurchasesApi.mockResolvedValue([]);
@@ -90,7 +94,7 @@ describe("canonical Exchange surfaces", () => {
   it("recovers a reserved purchase by returned id and explicitly confirms its canonical history token", async () => {
     api.getShopPurchasesApi
       .mockResolvedValueOnce([])
-      .mockResolvedValue([{ id: 41, shopItemId: 1, quantity: 1, status: "RESERVED", reservationToken: "canonical-shop-token", reservationExpiresAt: "2026-08-23T01:00:00Z" }]);
+      .mockResolvedValue([reservedPurchase]);
     render(<ExchangeShell surface="shop" playerId={7} onBack={vi.fn()} />);
 
     fireEvent.click(await screen.findByRole("button", { name: /Item #1010/ }));
@@ -99,6 +103,81 @@ describe("canonical Exchange surfaces", () => {
 
     await waitFor(() => expect(api.confirmShopPurchaseApi).toHaveBeenCalledWith("canonical-shop-token", expect.any(String)));
     expect(api.initiateShopPurchaseApi).toHaveBeenCalledWith(expect.objectContaining({ shopItemId: 1, quantity: 1, reserveOnly: true }));
+  });
+
+  it("restores an existing RESERVED purchase when its matching System Shop item opens", async () => {
+    api.getShopPurchasesApi.mockResolvedValue([reservedPurchase]);
+    render(<ExchangeShell surface="shop" playerId={7} onBack={vi.fn()} />);
+
+    fireEvent.click(await screen.findByRole("button", { name: /Item #1010/ }));
+
+    expect(await screen.findByRole("button", { name: "Confirm Purchase" })).toBeInTheDocument();
+    expect(screen.getByText("Purchase ID").nextElementSibling).toHaveTextContent("41");
+    expect(screen.getByText("Reservation expiry").nextElementSibling).not.toHaveTextContent("Not reserved");
+    expect(api.initiateShopPurchaseApi).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Confirm Purchase" }));
+    await waitFor(() => expect(api.confirmShopPurchaseApi).toHaveBeenCalledWith("canonical-shop-token", expect.any(String)));
+  });
+
+  it("keeps a started reservation recoverable after Back and reopening the same item", async () => {
+    api.getShopPurchasesApi.mockResolvedValueOnce([]).mockResolvedValue([reservedPurchase]);
+    render(<ExchangeShell surface="shop" playerId={7} onBack={vi.fn()} />);
+
+    fireEvent.click(await screen.findByRole("button", { name: /Item #1010/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Reserve / Start purchase" }));
+    expect(await screen.findByRole("button", { name: "Confirm Purchase" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Back to System Shop" }));
+    fireEvent.click(screen.getByRole("button", { name: /Item #1010/ }));
+
+    expect(await screen.findByRole("button", { name: "Confirm Purchase" })).toBeInTheDocument();
+    expect(api.initiateShopPurchaseApi).toHaveBeenCalledTimes(1);
+  });
+
+  it("reloads purchase history and restores the reservation after Shop surface re-entry", async () => {
+    api.getShopPurchasesApi.mockResolvedValue([reservedPurchase]);
+    const view = render(<ExchangeShell surface="shop" playerId={7} onBack={vi.fn()} />);
+    fireEvent.click(await screen.findByRole("button", { name: /Item #1010/ }));
+    expect(await screen.findByRole("button", { name: "Confirm Purchase" })).toBeInTheDocument();
+
+    view.rerender(<ExchangeShell surface="wallet" playerId={7} onBack={vi.fn()} />);
+    expect(await screen.findByText("284,500")).toBeInTheDocument();
+    view.rerender(<ExchangeShell surface="shop" playerId={7} onBack={vi.fn()} />);
+    await waitFor(() => expect(api.getShopPurchasesApi).toHaveBeenCalledTimes(2));
+    fireEvent.click(await screen.findByRole("button", { name: /Item #1010/ }));
+
+    expect(await screen.findByRole("button", { name: "Confirm Purchase" })).toBeInTheDocument();
+    expect(api.initiateShopPurchaseApi).not.toHaveBeenCalled();
+  });
+
+  it("does not restore COMPLETED, CANCELED, or EXPIRED purchases as pending", async () => {
+    api.getShopPurchasesApi.mockResolvedValue([
+      { ...reservedPurchase, id: 51, status: "COMPLETED" },
+      { ...reservedPurchase, id: 52, status: "CANCELED" },
+      { ...reservedPurchase, id: 53, status: "EXPIRED" },
+    ]);
+    render(<ExchangeShell surface="shop" playerId={7} onBack={vi.fn()} />);
+
+    fireEvent.click(await screen.findByRole("button", { name: /Item #1010/ }));
+
+    expect(await screen.findByRole("button", { name: "Reserve / Start purchase" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Confirm Purchase" })).not.toBeInTheDocument();
+  });
+
+  it("deterministically restores the highest-id RESERVED purchase", async () => {
+    api.getShopPurchasesApi.mockResolvedValue([
+      { ...reservedPurchase, id: 45, reservationToken: "latest-token" },
+      { ...reservedPurchase, id: 43, reservationToken: "older-token" },
+      { ...reservedPurchase, id: 44, reservationToken: "middle-token" },
+    ]);
+    render(<ExchangeShell surface="shop" playerId={7} onBack={vi.fn()} />);
+
+    fireEvent.click(await screen.findByRole("button", { name: /Item #1010/ }));
+    expect(await screen.findByRole("button", { name: "Confirm Purchase" })).toBeInTheDocument();
+    expect(screen.getByText("Purchase ID").nextElementSibling).toHaveTextContent("45");
+    fireEvent.click(screen.getByRole("button", { name: "Confirm Purchase" }));
+
+    await waitFor(() => expect(api.confirmShopPurchaseApi).toHaveBeenCalledWith("latest-token", expect.any(String)));
   });
 
   it("guards self purchase and performs explicit Marketplace reserve/purchase", async () => {
@@ -115,14 +194,14 @@ describe("canonical Exchange surfaces", () => {
     expect(api.reserveListingApi).toHaveBeenCalledWith(201, 300);
   });
 
-  it("creates a PD-01 listing from a real whole InventoryEntry with only total price and GOLD/GEM", async () => {
+  it("creates a whole-entry listing from a real InventoryEntry with only total price and GOLD/GEM", async () => {
     render(<ExchangeShell surface="shop" playerId={7} onBack={vi.fn()} />);
     fireEvent.click(await screen.findByRole("button", { name: "My Listings" }));
     fireEvent.click(screen.getByRole("button", { name: "Create Listing" }));
 
     expect(screen.getByRole("button", { name: /Bound Boots/ })).toBeDisabled();
     const stack = screen.getByRole("button", { name: /Owned Potion Stack/ });
-    expect(stack).toHaveTextContent("Whole entry · x42");
+    expect(stack).toHaveTextContent("Complete item or stack · x42");
     expect(screen.queryByLabelText(/quantity|item id|inventory entry id|item name/i)).not.toBeInTheDocument();
     expect(within(screen.getByLabelText("Currency")).getAllByRole("option").map(({ textContent }) => textContent)).toEqual(["GOLD", "GEM"]);
 
@@ -169,6 +248,26 @@ describe("canonical Exchange surfaces", () => {
     expect(screen.getByText("Player #24")).toBeInTheDocument();
     expect(screen.getByText("Player #13")).toBeInTheDocument();
     expect(screen.queryByText(/friend|barter|offered|received/i)).not.toBeInTheDocument();
+  });
+
+  it("keeps internal implementation jargon out of rendered Exchange copy", async () => {
+    const renderedCopy: string[] = [];
+    const view = render(<ExchangeShell surface="wallet" playerId={7} onBack={vi.fn()} />);
+    await screen.findByText("284,500");
+    renderedCopy.push(document.body.textContent ?? "");
+
+    view.rerender(<ExchangeShell surface="shop" playerId={7} onBack={vi.fn()} />);
+    await screen.findByRole("button", { name: "My Listings" });
+    fireEvent.click(screen.getByRole("button", { name: "My Listings" }));
+    fireEvent.click(screen.getByRole("button", { name: "Create Listing" }));
+    await screen.findByText("Sell Item");
+    renderedCopy.push(document.body.textContent ?? "");
+
+    view.rerender(<ExchangeShell surface="trade" playerId={7} onBack={vi.fn()} />);
+    await screen.findByText("Bought");
+    renderedCopy.push(document.body.textContent ?? "");
+
+    expect(renderedCopy.join(" ")).not.toMatch(/Canonical|backend-owned|PD-01/i);
   });
 
   it("keeps Exchange at two feature stages and translates the dual-theme hierarchy semantically", () => {

--- a/features/market/ExchangeShell.tsx
+++ b/features/market/ExchangeShell.tsx
@@ -22,6 +22,7 @@ import {
   type ExchangeShopSurface,
   formatCurrency,
   itemIdentity,
+  recoverLatestReservedShopPurchase,
   tradePresentation,
 } from "./model";
 import { useExchangeMutations } from "./useExchangeMutations";
@@ -85,7 +86,7 @@ function WalletPanel({ query, onBack }: { query: ExchangeQuery<WalletBalance | n
     <PanelStage stageKey="market-stage-1">
       <PanelFrame title="Wallet" depth={0} backButton={<BackButton label="Back to Exchange" onClick={onBack} />}>
         <section className="lag-exchange-surface">
-          <SurfaceHeader eyebrow="Canonical balance" title="Wallet" description="Current backend-owned balance. No generated ledger or split balance." accent="cyan" />
+          <SurfaceHeader eyebrow="Balance" title="Wallet" description="Your current Exchange balance." accent="cyan" />
           {query.loading && !wallet ? <Feedback state="info" role="status">Loading Wallet...</Feedback> : null}
           {query.error ? <div className="lag-exchange-state"><Feedback>{query.error}</Feedback><button type="button" className="lag-exchange-button" onClick={() => void query.reload()}>Retry</button></div> : null}
           {wallet ? (
@@ -115,7 +116,7 @@ function ShopItemDetail({ item, purchase, purchaseId, pending, onBack, onStart, 
   return (
     <article className="lag-exchange-detail">
       <SurfaceHeader eyebrow="System Shop item" title={itemIdentity(item.itemId)} description={`Shop item #${item.id}`} accent="amber" />
-      <DetailSection title="Canonical terms">
+      <DetailSection title="Purchase Details">
         <DataRow label="Price">{formatCurrency(item.price, item.currency)}</DataRow>
         <DataRow label="Available">{item.available ? "Available" : "Unavailable"}</DataRow>
         <DataRow label="Global stock limit">{item.globalStockLimit ?? "None"}</DataRow>
@@ -123,7 +124,7 @@ function ShopItemDetail({ item, purchase, purchaseId, pending, onBack, onStart, 
         <DataRow label="Reservation TTL">{item.reservationTtlSec ? `${item.reservationTtlSec} seconds` : "Direct purchase"}</DataRow>
       </DetailSection>
       {purchase ? (
-        <DetailSection title="Purchase history state">
+        <DetailSection title="Purchase Status">
           <DataRow label="Purchase ID">{purchase.id}</DataRow>
           <DataRow label="Status">{purchase.status}</DataRow>
           <DataRow label="Reservation expiry">{purchase.reservationExpiresAt ? new Date(purchase.reservationExpiresAt).toLocaleString() : "Not reserved"}</DataRow>
@@ -133,7 +134,7 @@ function ShopItemDetail({ item, purchase, purchaseId, pending, onBack, onStart, 
         {purchaseId === null ? <button type="button" className="lag-exchange-action" disabled={pending || !item.available} onClick={onStart}>{pending ? "Working..." : item.reservationTtlSec ? "Reserve / Start purchase" : "Purchase"}</button> : null}
         {purchaseId !== null && !purchase ? <button type="button" className="lag-exchange-action" disabled={pending} onClick={onRefresh}>{pending ? "Working..." : "Refresh Purchase Status"}</button> : null}
         {reserved ? <button type="button" className="lag-exchange-action" disabled={pending} onClick={onConfirm}>{pending ? "Working..." : "Confirm Purchase"}</button> : null}
-        {purchase?.status === "COMPLETED" ? <Feedback state="info" role="status">Purchase completed in canonical history.</Feedback> : null}
+        {purchase?.status === "COMPLETED" ? <Feedback state="info" role="status">Purchase completed.</Feedback> : null}
         {!item.available ? <Feedback state="info" role="status">This item is unavailable.</Feedback> : null}
         <button type="button" className="lag-exchange-button" onClick={onBack}>Back to System Shop</button>
       </div>
@@ -179,7 +180,7 @@ function ListingDetail({ listing, playerId, reservation, pending, onBack, onRese
 function MyListingDetail({ listing, pending, onBack, onCancel }: { listing: ListingSummary; pending: boolean; onBack: () => void; onCancel: () => void }) {
   return (
     <article className="lag-exchange-detail">
-      <SurfaceHeader eyebrow={`My listing #${listing.id}`} title={itemIdentity(listing.itemId)} description="Canonical whole-entry listing summary" accent="violet" />
+      <SurfaceHeader eyebrow={`My listing #${listing.id}`} title={itemIdentity(listing.itemId)} description="Listing details for the complete item or stack." accent="violet" />
       <DetailSection title="Listing state">
         <DataRow label="Total price">{formatCurrency(listing.price, listing.currency)}</DataRow>
         <DataRow label="Status">{listing.status}</DataRow>
@@ -208,9 +209,9 @@ function CreateListingForm({ entries, pending, onBack, onSubmit }: {
       event.preventDefault();
       if (selectedEntry && Number(price) >= 1) onSubmit(selectedEntry, Number(price), currency);
     }}>
-      <SurfaceHeader eyebrow="PD-01 · whole entry" title="Create Listing" description="Select one owned InventoryEntry. The complete entry or stack is listed." accent="amber" />
+      <SurfaceHeader eyebrow="Sell Item" title="Create Listing" description="Select an inventory item. The complete item or stack will be listed." accent="amber" />
       <fieldset className="lag-exchange-entry-picker">
-        <legend>Owned InventoryEntry</legend>
+        <legend>Inventory Item</legend>
         {entries.length === 0 ? <Feedback state="info" role="status">No owned entries available.</Feedback> : null}
         {entries.map((entry) => (
           <button
@@ -224,13 +225,13 @@ function CreateListingForm({ entries, pending, onBack, onSubmit }: {
           >
             <strong>{entry.itemName}</strong>
             <span>{entry.rarity} · {entry.category}</span>
-            <small>Whole entry · x{entry.quantity}{entry.bound ? " · Bound · unavailable" : ""}</small>
+            <small>Complete item or stack · x{entry.quantity}{entry.bound ? " · Bound · unavailable" : ""}</small>
           </button>
         ))}
       </fieldset>
       <label className="lag-exchange-field">Total Price<input aria-label="Total Price" type="number" min={1} required value={price} onChange={(event) => setPrice(event.target.value)} /></label>
       <label className="lag-exchange-field">Currency<select aria-label="Currency" value={currency} onChange={(event) => setCurrency(event.target.value as EconomyCurrency)}>{EXCHANGE_CURRENCIES.map((value) => <option key={value}>{value}</option>)}</select></label>
-      {selectedEntry ? <Feedback state="info" role="status">Selected: {selectedEntry.itemName} · whole stack x{selectedEntry.quantity}</Feedback> : null}
+      {selectedEntry ? <Feedback state="info" role="status">Selected: {selectedEntry.itemName} · complete stack x{selectedEntry.quantity}</Feedback> : null}
       <div className="lag-exchange-actions">
         <button type="submit" className="lag-exchange-action" disabled={pending || !selectedEntry || Number(price) < 1}>{pending ? "Working..." : "Create Listing"}</button>
         <button type="button" className="lag-exchange-button" onClick={onBack}>Cancel</button>
@@ -244,7 +245,7 @@ function TradePanel({ query, playerId, onBack }: { query: ExchangeQuery<TradeSum
     <PanelStage stageKey="market-stage-1">
       <PanelFrame title="Trade History" depth={0} backButton={<BackButton label="Back to Exchange" onClick={onBack} />}>
         <section className="lag-exchange-surface">
-          <SurfaceHeader eyebrow="Canonical settlements" title="Trade History" description="Completed marketplace trades for the current player." accent="violet" />
+          <SurfaceHeader eyebrow="Trade History" title="Trade History" description="Your completed Marketplace purchases and sales." accent="violet" />
           <QueryState query={query} empty="No Trade history.">
             <div className="lag-exchange-list">
               {query.data.map((trade) => {
@@ -284,13 +285,19 @@ export default function ExchangeShell({ surface, playerId, onBack }: { surface: 
   if (surface === "trade") return <div className="lag-panel-rail lag-exchange-shell"><TradePanel query={queries.trades} playerId={playerId} onBack={onBack} /></div>;
 
   const selectedShopItem = queries.shopItems.data.find((item) => item.id === selectedShopItemId) ?? null;
-  const activePurchase = activePurchaseId === null ? null : queries.shopPurchases.data.find((purchase) => purchase.id === activePurchaseId) ?? null;
+  const recoveredPurchase = selectedShopItemId === null
+    ? null
+    : recoverLatestReservedShopPurchase(queries.shopPurchases.data, selectedShopItemId);
+  const activePurchase = activePurchaseId === null
+    ? recoveredPurchase
+    : queries.shopPurchases.data.find((purchase) => purchase.id === activePurchaseId) ?? null;
+  const effectivePurchaseId = activePurchaseId ?? recoveredPurchase?.id ?? null;
   const listingSource = shopSurface === "marketplace" ? queries.openListings.data : queries.myListings.data;
   const selectedListing = listingSource.find((listing) => listing.id === selectedListingId) ?? null;
   const detailIdentity = creatingListing
     ? "create-listing"
     : selectedShopItem
-      ? `shop-${selectedShopItem.id}-${activePurchase?.status ?? (activePurchaseId === null ? "new" : `pending-${activePurchaseId}`)}`
+      ? `shop-${selectedShopItem.id}-${activePurchase?.status ?? (effectivePurchaseId === null ? "new" : `pending-${effectivePurchaseId}`)}`
       : selectedListing
         ? `${shopSurface}-${selectedListing.id}-${listingReservation?.reservationToken ?? "new"}`
         : null;
@@ -309,7 +316,7 @@ export default function ExchangeShell({ surface, playerId, onBack }: { surface: 
       <PanelStage stageKey="market-stage-1">
         <PanelFrame title="Shop" depth={detailIdentity ? 1 : 0} backButton={<BackButton label="Back to Exchange" onClick={onBack} />}>
           <section className="lag-exchange-surface">
-            <SurfaceHeader eyebrow="Canonical exchange" title="Shop" description="System inventory, player listings, and whole-entry selling." accent="cyan" />
+            <SurfaceHeader eyebrow="Exchange Shop" title="Shop" description="Browse System Shop items and player listings, or sell an inventory item." accent="cyan" />
             <div className="lag-exchange-tabs" aria-label="Shop surfaces">
               {([
                 ["system-shop", "System Shop"],
@@ -352,7 +359,7 @@ export default function ExchangeShell({ surface, playerId, onBack }: { surface: 
           <PanelStage key="market-stage-2" stageKey="market-stage-2" index={1}>
             <PanelFrame title={creatingListing ? "New Listing" : "Exchange Detail"} depth={0} contentKey={detailIdentity} backButton={<BackButton label="Back to Shop" onClick={closeDetail} />}>
               {mutations.error ? <div className="lag-exchange-state"><Feedback>{mutations.error}</Feedback></div> : null}
-              {selectedShopItem ? <ShopItemDetail item={selectedShopItem} purchase={activePurchase} purchaseId={activePurchaseId} pending={mutations.pendingKey !== null} onBack={closeDetail} onStart={() => void mutations.startShopPurchase(selectedShopItem).then((result) => setActivePurchaseId(result?.purchaseId ?? null))} onRefresh={() => { if (activePurchaseId !== null) void mutations.refreshShopPurchase(activePurchaseId); }} onConfirm={() => { if (activePurchase) void mutations.confirmShopPurchase(activePurchase); }} /> : null}
+              {selectedShopItem ? <ShopItemDetail item={selectedShopItem} purchase={activePurchase} purchaseId={effectivePurchaseId} pending={mutations.pendingKey !== null} onBack={closeDetail} onStart={() => void mutations.startShopPurchase(selectedShopItem).then((result) => setActivePurchaseId(result?.purchaseId ?? null))} onRefresh={() => { if (effectivePurchaseId !== null) void mutations.refreshShopPurchase(effectivePurchaseId); }} onConfirm={() => { if (activePurchase) void mutations.confirmShopPurchase(activePurchase).then((completed) => { if (completed) closeDetail(); }); }} /> : null}
               {shopSurface === "marketplace" && selectedListing ? <ListingDetail listing={selectedListing} playerId={playerId} reservation={listingReservation} pending={mutations.pendingKey !== null} onBack={closeDetail} onReserve={() => void mutations.reserveListing(selectedListing).then((reservation) => setListingReservation(reservation ?? null))} onPurchase={() => { if (listingReservation) void mutations.purchaseListing(selectedListing, listingReservation.reservationToken).then((trade) => { if (trade) closeDetail(); }); }} /> : null}
               {shopSurface === "my-listings" && selectedListing ? <MyListingDetail listing={selectedListing} pending={mutations.pendingKey !== null} onBack={closeDetail} onCancel={() => { if (window.confirm(`Cancel listing #${selectedListing.id}?`)) void mutations.cancelListing(selectedListing).then((done) => { if (done) closeDetail(); }); }} /> : null}
               {shopSurface === "my-listings" && creatingListing ? <CreateListingForm entries={queries.inventory.data} pending={mutations.pendingKey !== null} onBack={closeDetail} onSubmit={(entry, price, currency) => void mutations.createListing(entry, price, currency).then((listing) => { if (listing) closeDetail(); })} /> : null}

--- a/features/market/ExchangeShell.tsx
+++ b/features/market/ExchangeShell.tsx
@@ -1,0 +1,365 @@
+"use client";
+
+import { AnimatePresence } from "framer-motion";
+import { useEffect, useState } from "react";
+
+import type { MarketSubId } from "@/entities/nav";
+import type {
+  EconomyCurrency,
+  InventoryEntry,
+  ListingReservation,
+  ListingSummary,
+  ShopItem,
+  ShopPurchaseSummary,
+  TradeSummary,
+  WalletBalance,
+} from "@/shared/api/types";
+import { requestStageFocus } from "@/shared/hooks/useStageCamera";
+import PanelStage from "@/shared/ui/PanelStage";
+import { BackButton, PanelFrame } from "@/widgets/right-panels/ui/PanelFrame";
+import {
+  EXCHANGE_CURRENCIES,
+  type ExchangeShopSurface,
+  formatCurrency,
+  itemIdentity,
+  tradePresentation,
+} from "./model";
+import { useExchangeMutations } from "./useExchangeMutations";
+import { type ExchangeQuery, useExchangeQueries } from "./useExchangeQueries";
+
+function Feedback({ children, state = "error", role = "alert" }: { children: React.ReactNode; state?: "error" | "info"; role?: "alert" | "status" }) {
+  return <p className="lag-exchange-feedback" data-state={state} role={role}>{children}</p>;
+}
+
+function QueryState<T>({ query, empty, children }: { query: ExchangeQuery<T[]>; empty: string; children: React.ReactNode }) {
+  return (
+    <>
+      {query.loading && query.data.length === 0 ? <Feedback state="info" role="status">Loading...</Feedback> : null}
+      {query.error ? <div className="lag-exchange-state"><Feedback>{query.error}</Feedback><button type="button" className="lag-exchange-button" onClick={() => void query.reload()}>Retry</button></div> : null}
+      {!query.loading && !query.error && query.data.length === 0 ? <Feedback state="info" role="status">{empty}</Feedback> : null}
+      {query.data.length > 0 ? children : null}
+    </>
+  );
+}
+
+function SurfaceHeader({ eyebrow, title, description, accent }: { eyebrow: string; title: string; description: string; accent: "cyan" | "amber" | "violet" }) {
+  return (
+    <header className="lag-exchange-header" data-accent={accent}>
+      <span>{eyebrow}</span>
+      <h4>{title}</h4>
+      <p>{description}</p>
+    </header>
+  );
+}
+
+function DataRow({ label, children }: { label: string; children: React.ReactNode }) {
+  return <div className="lag-exchange-data-row"><dt>{label}</dt><dd>{children}</dd></div>;
+}
+
+function DetailSection({ title, children }: { title: string; children: React.ReactNode }) {
+  return <section className="lag-exchange-section"><h5>{title}</h5><dl>{children}</dl></section>;
+}
+
+function ExchangeRow({ selected, title, meta, value, disabled, status, onClick }: {
+  selected: boolean;
+  title: string;
+  meta: string;
+  value: string;
+  disabled?: boolean;
+  status?: string;
+  onClick: () => void;
+}) {
+  return (
+    <button type="button" className="lag-exchange-row" data-selected={selected} aria-pressed={selected} disabled={disabled} onClick={onClick}>
+      <span className="lag-exchange-row-mark" aria-hidden>◇</span>
+      <span className="lag-exchange-row-copy"><strong>{title}</strong><small>{meta}</small>{status ? <em>{status}</em> : null}</span>
+      <span className="lag-exchange-value">{value}</span>
+      <span aria-hidden>→</span>
+    </button>
+  );
+}
+
+function WalletPanel({ query, onBack }: { query: ExchangeQuery<WalletBalance | null>; onBack: () => void }) {
+  const wallet = query.data;
+  return (
+    <PanelStage stageKey="market-stage-1">
+      <PanelFrame title="Wallet" depth={0} backButton={<BackButton label="Back to Exchange" onClick={onBack} />}>
+        <section className="lag-exchange-surface">
+          <SurfaceHeader eyebrow="Canonical balance" title="Wallet" description="Current backend-owned balance. No generated ledger or split balance." accent="cyan" />
+          {query.loading && !wallet ? <Feedback state="info" role="status">Loading Wallet...</Feedback> : null}
+          {query.error ? <div className="lag-exchange-state"><Feedback>{query.error}</Feedback><button type="button" className="lag-exchange-button" onClick={() => void query.reload()}>Retry</button></div> : null}
+          {wallet ? (
+            <article className="lag-exchange-balance">
+              <span>Current amount</span>
+              <strong>{wallet.amount.toLocaleString()}</strong>
+              <em>{wallet.currency}</em>
+            </article>
+          ) : null}
+        </section>
+      </PanelFrame>
+    </PanelStage>
+  );
+}
+
+function ShopItemDetail({ item, purchase, purchaseId, pending, onBack, onStart, onRefresh, onConfirm }: {
+  item: ShopItem;
+  purchase: ShopPurchaseSummary | null;
+  purchaseId: number | null;
+  pending: boolean;
+  onBack: () => void;
+  onStart: () => void;
+  onRefresh: () => void;
+  onConfirm: () => void;
+}) {
+  const reserved = purchase?.status === "RESERVED" && Boolean(purchase.reservationToken);
+  return (
+    <article className="lag-exchange-detail">
+      <SurfaceHeader eyebrow="System Shop item" title={itemIdentity(item.itemId)} description={`Shop item #${item.id}`} accent="amber" />
+      <DetailSection title="Canonical terms">
+        <DataRow label="Price">{formatCurrency(item.price, item.currency)}</DataRow>
+        <DataRow label="Available">{item.available ? "Available" : "Unavailable"}</DataRow>
+        <DataRow label="Global stock limit">{item.globalStockLimit ?? "None"}</DataRow>
+        <DataRow label="Per-player limit">{item.perPlayerLimit ?? "None"}</DataRow>
+        <DataRow label="Reservation TTL">{item.reservationTtlSec ? `${item.reservationTtlSec} seconds` : "Direct purchase"}</DataRow>
+      </DetailSection>
+      {purchase ? (
+        <DetailSection title="Purchase history state">
+          <DataRow label="Purchase ID">{purchase.id}</DataRow>
+          <DataRow label="Status">{purchase.status}</DataRow>
+          <DataRow label="Reservation expiry">{purchase.reservationExpiresAt ? new Date(purchase.reservationExpiresAt).toLocaleString() : "Not reserved"}</DataRow>
+        </DetailSection>
+      ) : null}
+      <div className="lag-exchange-actions">
+        {purchaseId === null ? <button type="button" className="lag-exchange-action" disabled={pending || !item.available} onClick={onStart}>{pending ? "Working..." : item.reservationTtlSec ? "Reserve / Start purchase" : "Purchase"}</button> : null}
+        {purchaseId !== null && !purchase ? <button type="button" className="lag-exchange-action" disabled={pending} onClick={onRefresh}>{pending ? "Working..." : "Refresh Purchase Status"}</button> : null}
+        {reserved ? <button type="button" className="lag-exchange-action" disabled={pending} onClick={onConfirm}>{pending ? "Working..." : "Confirm Purchase"}</button> : null}
+        {purchase?.status === "COMPLETED" ? <Feedback state="info" role="status">Purchase completed in canonical history.</Feedback> : null}
+        {!item.available ? <Feedback state="info" role="status">This item is unavailable.</Feedback> : null}
+        <button type="button" className="lag-exchange-button" onClick={onBack}>Back to System Shop</button>
+      </div>
+    </article>
+  );
+}
+
+function ListingDetail({ listing, playerId, reservation, pending, onBack, onReserve, onPurchase }: {
+  listing: ListingSummary;
+  playerId: number;
+  reservation: ListingReservation | null;
+  pending: boolean;
+  onBack: () => void;
+  onReserve: () => void;
+  onPurchase: () => void;
+}) {
+  const own = listing.sellerId === playerId;
+  const open = listing.status === "OPEN";
+  return (
+    <article className="lag-exchange-detail">
+      <SurfaceHeader eyebrow={`Listing #${listing.id}`} title={itemIdentity(listing.itemId)} description={own ? "Your listing" : `Seller · Player #${listing.sellerId}`} accent="violet" />
+      <DetailSection title="Listing terms">
+        <DataRow label="Total price">{formatCurrency(listing.price, listing.currency)}</DataRow>
+        <DataRow label="Status">{listing.status}</DataRow>
+        <DataRow label="Seller">{own ? "You · purchase unavailable" : `Player #${listing.sellerId}`}</DataRow>
+      </DetailSection>
+      {reservation ? (
+        <DetailSection title="Reservation">
+          <DataRow label="Hold ID">{reservation.holdId}</DataRow>
+          <DataRow label="Expires">{new Date(reservation.expiresAt).toLocaleString()}</DataRow>
+        </DetailSection>
+      ) : null}
+      <div className="lag-exchange-actions">
+        {!reservation ? <button type="button" className="lag-exchange-action" disabled={pending || own || !open} onClick={onReserve}>{pending ? "Working..." : own ? "Your listing" : "Reserve"}</button> : null}
+        {reservation ? <button type="button" className="lag-exchange-action" disabled={pending} onClick={onPurchase}>{pending ? "Working..." : "Purchase reserved listing"}</button> : null}
+        {!open ? <Feedback state="info" role="status">This listing is not open.</Feedback> : null}
+        <button type="button" className="lag-exchange-button" onClick={onBack}>Back to Marketplace</button>
+      </div>
+    </article>
+  );
+}
+
+function MyListingDetail({ listing, pending, onBack, onCancel }: { listing: ListingSummary; pending: boolean; onBack: () => void; onCancel: () => void }) {
+  return (
+    <article className="lag-exchange-detail">
+      <SurfaceHeader eyebrow={`My listing #${listing.id}`} title={itemIdentity(listing.itemId)} description="Canonical whole-entry listing summary" accent="violet" />
+      <DetailSection title="Listing state">
+        <DataRow label="Total price">{formatCurrency(listing.price, listing.currency)}</DataRow>
+        <DataRow label="Status">{listing.status}</DataRow>
+      </DetailSection>
+      <div className="lag-exchange-actions">
+        {listing.status === "OPEN" ? <button type="button" className="lag-exchange-button" data-variant="destructive" disabled={pending} onClick={onCancel}>{pending ? "Working..." : "Cancel Listing"}</button> : null}
+        <button type="button" className="lag-exchange-button" onClick={onBack}>Back to My Listings</button>
+      </div>
+    </article>
+  );
+}
+
+function CreateListingForm({ entries, pending, onBack, onSubmit }: {
+  entries: InventoryEntry[];
+  pending: boolean;
+  onBack: () => void;
+  onSubmit: (entry: InventoryEntry, price: number, currency: EconomyCurrency) => void;
+}) {
+  const [selectedEntryId, setSelectedEntryId] = useState<number | null>(null);
+  const [price, setPrice] = useState("");
+  const [currency, setCurrency] = useState<EconomyCurrency>("GOLD");
+  const selectedEntry = entries.find((entry) => entry.itemInstanceId === selectedEntryId) ?? null;
+
+  return (
+    <form className="lag-exchange-detail" onSubmit={(event) => {
+      event.preventDefault();
+      if (selectedEntry && Number(price) >= 1) onSubmit(selectedEntry, Number(price), currency);
+    }}>
+      <SurfaceHeader eyebrow="PD-01 · whole entry" title="Create Listing" description="Select one owned InventoryEntry. The complete entry or stack is listed." accent="amber" />
+      <fieldset className="lag-exchange-entry-picker">
+        <legend>Owned InventoryEntry</legend>
+        {entries.length === 0 ? <Feedback state="info" role="status">No owned entries available.</Feedback> : null}
+        {entries.map((entry) => (
+          <button
+            key={entry.itemInstanceId}
+            type="button"
+            className="lag-exchange-entry"
+            data-selected={selectedEntryId === entry.itemInstanceId}
+            aria-pressed={selectedEntryId === entry.itemInstanceId}
+            disabled={entry.bound || pending}
+            onClick={() => setSelectedEntryId(entry.itemInstanceId)}
+          >
+            <strong>{entry.itemName}</strong>
+            <span>{entry.rarity} · {entry.category}</span>
+            <small>Whole entry · x{entry.quantity}{entry.bound ? " · Bound · unavailable" : ""}</small>
+          </button>
+        ))}
+      </fieldset>
+      <label className="lag-exchange-field">Total Price<input aria-label="Total Price" type="number" min={1} required value={price} onChange={(event) => setPrice(event.target.value)} /></label>
+      <label className="lag-exchange-field">Currency<select aria-label="Currency" value={currency} onChange={(event) => setCurrency(event.target.value as EconomyCurrency)}>{EXCHANGE_CURRENCIES.map((value) => <option key={value}>{value}</option>)}</select></label>
+      {selectedEntry ? <Feedback state="info" role="status">Selected: {selectedEntry.itemName} · whole stack x{selectedEntry.quantity}</Feedback> : null}
+      <div className="lag-exchange-actions">
+        <button type="submit" className="lag-exchange-action" disabled={pending || !selectedEntry || Number(price) < 1}>{pending ? "Working..." : "Create Listing"}</button>
+        <button type="button" className="lag-exchange-button" onClick={onBack}>Cancel</button>
+      </div>
+    </form>
+  );
+}
+
+function TradePanel({ query, playerId, onBack }: { query: ExchangeQuery<TradeSummary[]>; playerId: number; onBack: () => void }) {
+  return (
+    <PanelStage stageKey="market-stage-1">
+      <PanelFrame title="Trade History" depth={0} backButton={<BackButton label="Back to Exchange" onClick={onBack} />}>
+        <section className="lag-exchange-surface">
+          <SurfaceHeader eyebrow="Canonical settlements" title="Trade History" description="Completed marketplace trades for the current player." accent="violet" />
+          <QueryState query={query} empty="No Trade history.">
+            <div className="lag-exchange-list">
+              {query.data.map((trade) => {
+                const presentation = tradePresentation(trade, playerId);
+                return <article key={trade.id} className="lag-exchange-trade"><span>{presentation.direction}</span><strong>{presentation.counterparty}</strong><small>Listing #{trade.listingId}</small><em>{formatCurrency(trade.price, trade.currency)}</em></article>;
+              })}
+            </div>
+          </QueryState>
+        </section>
+      </PanelFrame>
+    </PanelStage>
+  );
+}
+
+export default function ExchangeShell({ surface, playerId, onBack }: { surface: MarketSubId | null; playerId: number; onBack: () => void }) {
+  const queries = useExchangeQueries(surface);
+  const mutations = useExchangeMutations(queries);
+  const [shopSurface, setShopSurface] = useState<ExchangeShopSurface>("system-shop");
+  const [selectedShopItemId, setSelectedShopItemId] = useState<number | null>(null);
+  const [activePurchaseId, setActivePurchaseId] = useState<number | null>(null);
+  const [selectedListingId, setSelectedListingId] = useState<number | null>(null);
+  const [listingReservation, setListingReservation] = useState<ListingReservation | null>(null);
+  const [creatingListing, setCreatingListing] = useState(false);
+
+  useEffect(() => {
+    setShopSurface("system-shop");
+    setSelectedShopItemId(null);
+    setActivePurchaseId(null);
+    setSelectedListingId(null);
+    setListingReservation(null);
+    setCreatingListing(false);
+    mutations.clearError();
+  }, [surface]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  if (!surface) return null;
+  if (surface === "wallet") return <div className="lag-panel-rail lag-exchange-shell"><WalletPanel query={queries.wallet} onBack={onBack} /></div>;
+  if (surface === "trade") return <div className="lag-panel-rail lag-exchange-shell"><TradePanel query={queries.trades} playerId={playerId} onBack={onBack} /></div>;
+
+  const selectedShopItem = queries.shopItems.data.find((item) => item.id === selectedShopItemId) ?? null;
+  const activePurchase = activePurchaseId === null ? null : queries.shopPurchases.data.find((purchase) => purchase.id === activePurchaseId) ?? null;
+  const listingSource = shopSurface === "marketplace" ? queries.openListings.data : queries.myListings.data;
+  const selectedListing = listingSource.find((listing) => listing.id === selectedListingId) ?? null;
+  const detailIdentity = creatingListing
+    ? "create-listing"
+    : selectedShopItem
+      ? `shop-${selectedShopItem.id}-${activePurchase?.status ?? (activePurchaseId === null ? "new" : `pending-${activePurchaseId}`)}`
+      : selectedListing
+        ? `${shopSurface}-${selectedListing.id}-${listingReservation?.reservationToken ?? "new"}`
+        : null;
+  const closeDetail = () => {
+    setSelectedShopItemId(null);
+    setActivePurchaseId(null);
+    setSelectedListingId(null);
+    setListingReservation(null);
+    setCreatingListing(false);
+    mutations.clearError();
+    requestStageFocus("market-stage-1", "center");
+  };
+
+  return (
+    <div className="lag-panel-rail lag-exchange-shell" data-testid="exchange-shell">
+      <PanelStage stageKey="market-stage-1">
+        <PanelFrame title="Shop" depth={detailIdentity ? 1 : 0} backButton={<BackButton label="Back to Exchange" onClick={onBack} />}>
+          <section className="lag-exchange-surface">
+            <SurfaceHeader eyebrow="Canonical exchange" title="Shop" description="System inventory, player listings, and whole-entry selling." accent="cyan" />
+            <div className="lag-exchange-tabs" aria-label="Shop surfaces">
+              {([
+                ["system-shop", "System Shop"],
+                ["marketplace", "Marketplace"],
+                ["my-listings", "My Listings"],
+              ] as const).map(([id, label]) => <button key={id} type="button" data-selected={shopSurface === id} aria-pressed={shopSurface === id} onClick={() => { setShopSurface(id); closeDetail(); }}>{label}</button>)}
+            </div>
+            {shopSurface === "system-shop" ? (
+              <QueryState query={queries.shopItems} empty="No System Shop items.">
+                <div className="lag-exchange-list">
+                  {queries.shopItems.data.map((item) => <ExchangeRow key={item.id} selected={selectedShopItemId === item.id} title={itemIdentity(item.itemId)} meta={`Shop item #${item.id} · ${item.available ? "Available" : "Unavailable"}`} value={formatCurrency(item.price, item.currency)} status={item.reservationTtlSec ? `Reservation · ${item.reservationTtlSec}s` : "Direct purchase"} onClick={() => { setSelectedShopItemId(item.id); setActivePurchaseId(null); setSelectedListingId(null); }} />)}
+                </div>
+              </QueryState>
+            ) : null}
+
+            {shopSurface === "marketplace" ? (
+              <QueryState query={queries.openListings} empty="No open Marketplace listings.">
+                <div className="lag-exchange-list">
+                  {queries.openListings.data.map((listing) => <ExchangeRow key={listing.id} selected={selectedListingId === listing.id} title={itemIdentity(listing.itemId)} meta={listing.sellerId === playerId ? "Your listing" : `Seller · Player #${listing.sellerId}`} value={formatCurrency(listing.price, listing.currency)} status={listing.status} onClick={() => { setSelectedListingId(listing.id); setListingReservation(null); setSelectedShopItemId(null); }} />)}
+                </div>
+              </QueryState>
+            ) : null}
+
+            {shopSurface === "my-listings" ? (
+              <>
+                <button type="button" className="lag-exchange-action" disabled={mutations.pendingKey !== null} onClick={() => { setCreatingListing(true); setSelectedListingId(null); }}>Create Listing</button>
+                <QueryState query={queries.myListings} empty="No My Listings.">
+                  <div className="lag-exchange-list">
+                    {queries.myListings.data.map((listing) => <ExchangeRow key={listing.id} selected={selectedListingId === listing.id} title={itemIdentity(listing.itemId)} meta={`Listing #${listing.id}`} value={formatCurrency(listing.price, listing.currency)} status={listing.status} onClick={() => { setSelectedListingId(listing.id); setCreatingListing(false); setListingReservation(null); }} />)}
+                  </div>
+                </QueryState>
+              </>
+            ) : null}
+          </section>
+        </PanelFrame>
+      </PanelStage>
+
+      <AnimatePresence initial={false}>
+        {detailIdentity ? (
+          <PanelStage key="market-stage-2" stageKey="market-stage-2" index={1}>
+            <PanelFrame title={creatingListing ? "New Listing" : "Exchange Detail"} depth={0} contentKey={detailIdentity} backButton={<BackButton label="Back to Shop" onClick={closeDetail} />}>
+              {mutations.error ? <div className="lag-exchange-state"><Feedback>{mutations.error}</Feedback></div> : null}
+              {selectedShopItem ? <ShopItemDetail item={selectedShopItem} purchase={activePurchase} purchaseId={activePurchaseId} pending={mutations.pendingKey !== null} onBack={closeDetail} onStart={() => void mutations.startShopPurchase(selectedShopItem).then((result) => setActivePurchaseId(result?.purchaseId ?? null))} onRefresh={() => { if (activePurchaseId !== null) void mutations.refreshShopPurchase(activePurchaseId); }} onConfirm={() => { if (activePurchase) void mutations.confirmShopPurchase(activePurchase); }} /> : null}
+              {shopSurface === "marketplace" && selectedListing ? <ListingDetail listing={selectedListing} playerId={playerId} reservation={listingReservation} pending={mutations.pendingKey !== null} onBack={closeDetail} onReserve={() => void mutations.reserveListing(selectedListing).then((reservation) => setListingReservation(reservation ?? null))} onPurchase={() => { if (listingReservation) void mutations.purchaseListing(selectedListing, listingReservation.reservationToken).then((trade) => { if (trade) closeDetail(); }); }} /> : null}
+              {shopSurface === "my-listings" && selectedListing ? <MyListingDetail listing={selectedListing} pending={mutations.pendingKey !== null} onBack={closeDetail} onCancel={() => { if (window.confirm(`Cancel listing #${selectedListing.id}?`)) void mutations.cancelListing(selectedListing).then((done) => { if (done) closeDetail(); }); }} /> : null}
+              {shopSurface === "my-listings" && creatingListing ? <CreateListingForm entries={queries.inventory.data} pending={mutations.pendingKey !== null} onBack={closeDetail} onSubmit={(entry, price, currency) => void mutations.createListing(entry, price, currency).then((listing) => { if (listing) closeDetail(); })} /> : null}
+            </PanelFrame>
+          </PanelStage>
+        ) : null}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/features/market/ExchangeShell.tsx
+++ b/features/market/ExchangeShell.tsx
@@ -22,7 +22,7 @@ import {
   type ExchangeShopSurface,
   formatCurrency,
   itemIdentity,
-  recoverLatestReservedShopPurchase,
+  recoverLatestPendingShopPurchase,
   tradePresentation,
 } from "./model";
 import { useExchangeMutations } from "./useExchangeMutations";
@@ -112,7 +112,8 @@ function ShopItemDetail({ item, purchase, purchaseId, pending, onBack, onStart, 
   onRefresh: () => void;
   onConfirm: () => void;
 }) {
-  const reserved = purchase?.status === "RESERVED" && Boolean(purchase.reservationToken);
+  const confirmable = purchase?.status === "RESERVED" && Boolean(purchase.reservationToken);
+  const refreshable = purchaseId !== null && (!purchase || purchase.status === "REQUESTED" || (purchase.status === "RESERVED" && !purchase.reservationToken));
   return (
     <article className="lag-exchange-detail">
       <SurfaceHeader eyebrow="System Shop item" title={itemIdentity(item.itemId)} description={`Shop item #${item.id}`} accent="amber" />
@@ -132,8 +133,8 @@ function ShopItemDetail({ item, purchase, purchaseId, pending, onBack, onStart, 
       ) : null}
       <div className="lag-exchange-actions">
         {purchaseId === null ? <button type="button" className="lag-exchange-action" disabled={pending || !item.available} onClick={onStart}>{pending ? "Working..." : item.reservationTtlSec ? "Reserve / Start purchase" : "Purchase"}</button> : null}
-        {purchaseId !== null && !purchase ? <button type="button" className="lag-exchange-action" disabled={pending} onClick={onRefresh}>{pending ? "Working..." : "Refresh Purchase Status"}</button> : null}
-        {reserved ? <button type="button" className="lag-exchange-action" disabled={pending} onClick={onConfirm}>{pending ? "Working..." : "Confirm Purchase"}</button> : null}
+        {refreshable ? <button type="button" className="lag-exchange-action" disabled={pending} onClick={onRefresh}>{pending ? "Working..." : "Refresh Purchase Status"}</button> : null}
+        {confirmable ? <button type="button" className="lag-exchange-action" disabled={pending} onClick={onConfirm}>{pending ? "Working..." : "Confirm Purchase"}</button> : null}
         {purchase?.status === "COMPLETED" ? <Feedback state="info" role="status">Purchase completed.</Feedback> : null}
         {!item.available ? <Feedback state="info" role="status">This item is unavailable.</Feedback> : null}
         <button type="button" className="lag-exchange-button" onClick={onBack}>Back to System Shop</button>
@@ -203,11 +204,13 @@ function CreateListingForm({ entries, pending, onBack, onSubmit }: {
   const [price, setPrice] = useState("");
   const [currency, setCurrency] = useState<EconomyCurrency>("GOLD");
   const selectedEntry = entries.find((entry) => entry.itemInstanceId === selectedEntryId) ?? null;
+  const priceValue = Number(price);
+  const priceValid = Number.isInteger(priceValue) && priceValue >= 1;
 
   return (
     <form className="lag-exchange-detail" onSubmit={(event) => {
       event.preventDefault();
-      if (selectedEntry && Number(price) >= 1) onSubmit(selectedEntry, Number(price), currency);
+      if (selectedEntry && priceValid) onSubmit(selectedEntry, priceValue, currency);
     }}>
       <SurfaceHeader eyebrow="Sell Item" title="Create Listing" description="Select an inventory item. The complete item or stack will be listed." accent="amber" />
       <fieldset className="lag-exchange-entry-picker">
@@ -229,11 +232,11 @@ function CreateListingForm({ entries, pending, onBack, onSubmit }: {
           </button>
         ))}
       </fieldset>
-      <label className="lag-exchange-field">Total Price<input aria-label="Total Price" type="number" min={1} required value={price} onChange={(event) => setPrice(event.target.value)} /></label>
+      <label className="lag-exchange-field">Total Price<input aria-label="Total Price" type="number" min={1} step={1} required value={price} onChange={(event) => setPrice(event.target.value)} /></label>
       <label className="lag-exchange-field">Currency<select aria-label="Currency" value={currency} onChange={(event) => setCurrency(event.target.value as EconomyCurrency)}>{EXCHANGE_CURRENCIES.map((value) => <option key={value}>{value}</option>)}</select></label>
       {selectedEntry ? <Feedback state="info" role="status">Selected: {selectedEntry.itemName} · complete stack x{selectedEntry.quantity}</Feedback> : null}
       <div className="lag-exchange-actions">
-        <button type="submit" className="lag-exchange-action" disabled={pending || !selectedEntry || Number(price) < 1}>{pending ? "Working..." : "Create Listing"}</button>
+        <button type="submit" className="lag-exchange-action" disabled={pending || !selectedEntry || !priceValid}>{pending ? "Working..." : "Create Listing"}</button>
         <button type="button" className="lag-exchange-button" onClick={onBack}>Cancel</button>
       </div>
     </form>
@@ -287,7 +290,7 @@ export default function ExchangeShell({ surface, playerId, onBack }: { surface: 
   const selectedShopItem = queries.shopItems.data.find((item) => item.id === selectedShopItemId) ?? null;
   const recoveredPurchase = selectedShopItemId === null
     ? null
-    : recoverLatestReservedShopPurchase(queries.shopPurchases.data, selectedShopItemId);
+    : recoverLatestPendingShopPurchase(queries.shopPurchases.data, selectedShopItemId);
   const activePurchase = activePurchaseId === null
     ? recoveredPurchase
     : queries.shopPurchases.data.find((purchase) => purchase.id === activePurchaseId) ?? null;

--- a/features/market/model.test.ts
+++ b/features/market/model.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { EXCHANGE_CURRENCIES, recoverShopPurchase, tradePresentation } from "./model";
+
+describe("Exchange presentation helpers", () => {
+  it("only offers canonical currencies and recovers reservation state by purchase id", () => {
+    expect(EXCHANGE_CURRENCIES).toEqual(["GOLD", "GEM"]);
+    expect(recoverShopPurchase([
+      { id: 42, shopItemId: 3, quantity: 1, status: "RESERVED", reservationToken: "canonical-token", reservationExpiresAt: "2026-08-23T01:00:00Z" },
+    ], 42)?.reservationToken).toBe("canonical-token");
+  });
+
+  it("derives Bought/Sold and neutral counterparty identity from current player", () => {
+    const bought = tradePresentation({ id: 1, listingId: 2, buyerId: 7, sellerId: 9, price: 30, currency: "GOLD" }, 7);
+    const sold = tradePresentation({ id: 2, listingId: 3, buyerId: 11, sellerId: 7, price: 4, currency: "GEM" }, 7);
+
+    expect(bought).toEqual({ direction: "Bought", counterparty: "Player #9" });
+    expect(sold).toEqual({ direction: "Sold", counterparty: "Player #11" });
+  });
+});

--- a/features/market/model.test.ts
+++ b/features/market/model.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { EXCHANGE_CURRENCIES, recoverShopPurchase, tradePresentation } from "./model";
+import { EXCHANGE_CURRENCIES, recoverLatestReservedShopPurchase, recoverShopPurchase, tradePresentation } from "./model";
 
 describe("Exchange presentation helpers", () => {
   it("only offers canonical currencies and recovers reservation state by purchase id", () => {
@@ -16,5 +16,18 @@ describe("Exchange presentation helpers", () => {
 
     expect(bought).toEqual({ direction: "Bought", counterparty: "Player #9" });
     expect(sold).toEqual({ direction: "Sold", counterparty: "Player #11" });
+  });
+
+  it("recovers only the highest-id confirmable reservation for a Shop item", () => {
+    const purchases = [
+      { id: 44, shopItemId: 3, quantity: 1, status: "RESERVED", reservationToken: "older", reservationExpiresAt: "2026-08-23T01:00:00Z" },
+      { id: 47, shopItemId: 3, quantity: 1, status: "COMPLETED", reservationToken: "completed", reservationExpiresAt: null },
+      { id: 48, shopItemId: 3, quantity: 1, status: "RESERVED", reservationToken: null, reservationExpiresAt: "2026-08-23T02:00:00Z" },
+      { id: 46, shopItemId: 4, quantity: 1, status: "RESERVED", reservationToken: "other-item", reservationExpiresAt: "2026-08-23T02:00:00Z" },
+      { id: 45, shopItemId: 3, quantity: 1, status: "RESERVED", reservationToken: "latest-confirmable", reservationExpiresAt: "2026-08-23T03:00:00Z" },
+    ];
+
+    expect(recoverLatestReservedShopPurchase(purchases, 3)?.id).toBe(45);
+    expect(recoverLatestReservedShopPurchase(purchases, 99)).toBeNull();
   });
 });

--- a/features/market/model.test.ts
+++ b/features/market/model.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { EXCHANGE_CURRENCIES, recoverLatestReservedShopPurchase, recoverShopPurchase, tradePresentation } from "./model";
+import { EXCHANGE_CURRENCIES, recoverLatestPendingShopPurchase, recoverShopPurchase, tradePresentation } from "./model";
 
 describe("Exchange presentation helpers", () => {
   it("only offers canonical currencies and recovers reservation state by purchase id", () => {
@@ -18,16 +18,17 @@ describe("Exchange presentation helpers", () => {
     expect(sold).toEqual({ direction: "Sold", counterparty: "Player #11" });
   });
 
-  it("recovers only the highest-id confirmable reservation for a Shop item", () => {
+  it("recovers the highest-id REQUESTED or RESERVED purchase for a Shop item", () => {
     const purchases = [
       { id: 44, shopItemId: 3, quantity: 1, status: "RESERVED", reservationToken: "older", reservationExpiresAt: "2026-08-23T01:00:00Z" },
       { id: 47, shopItemId: 3, quantity: 1, status: "COMPLETED", reservationToken: "completed", reservationExpiresAt: null },
-      { id: 48, shopItemId: 3, quantity: 1, status: "RESERVED", reservationToken: null, reservationExpiresAt: "2026-08-23T02:00:00Z" },
+      { id: 48, shopItemId: 3, quantity: 1, status: "REQUESTED", reservationToken: null, reservationExpiresAt: null },
       { id: 46, shopItemId: 4, quantity: 1, status: "RESERVED", reservationToken: "other-item", reservationExpiresAt: "2026-08-23T02:00:00Z" },
       { id: 45, shopItemId: 3, quantity: 1, status: "RESERVED", reservationToken: "latest-confirmable", reservationExpiresAt: "2026-08-23T03:00:00Z" },
+      { id: 49, shopItemId: 3, quantity: 1, status: "EXPIRED", reservationToken: null, reservationExpiresAt: null },
     ];
 
-    expect(recoverLatestReservedShopPurchase(purchases, 3)?.id).toBe(45);
-    expect(recoverLatestReservedShopPurchase(purchases, 99)).toBeNull();
+    expect(recoverLatestPendingShopPurchase(purchases, 3)?.id).toBe(48);
+    expect(recoverLatestPendingShopPurchase(purchases, 99)).toBeNull();
   });
 });

--- a/features/market/model.ts
+++ b/features/market/model.ts
@@ -15,6 +15,17 @@ export function recoverShopPurchase(purchases: ShopPurchaseSummary[], purchaseId
   return purchases.find((purchase) => purchase.id === purchaseId) ?? null;
 }
 
+export function recoverLatestReservedShopPurchase(purchases: ShopPurchaseSummary[], shopItemId: number) {
+  return purchases.reduce<ShopPurchaseSummary | null>((latest, purchase) => (
+    purchase.shopItemId === shopItemId
+    && purchase.status === "RESERVED"
+    && purchase.reservationToken
+    && (!latest || purchase.id > latest.id)
+      ? purchase
+      : latest
+  ), null);
+}
+
 export function tradePresentation(trade: TradeSummary, playerId: number) {
   const bought = trade.buyerId === playerId;
   const counterpartyId = bought ? trade.sellerId : trade.buyerId;

--- a/features/market/model.ts
+++ b/features/market/model.ts
@@ -1,93 +1,22 @@
-import type { PanelDataItem, FormFieldSpec } from "@/entities/nav";
-import { makeList, pad, dateAt } from "@/entities/nav";
-import { MOCK_SHOP_ITEMS, MOCK_MY_LISTINGS, SHOP_ITEM_NAMES } from "@/lib/api/mock/market.mock";
+import type { EconomyCurrency, ShopPurchaseSummary, TradeSummary } from "@/shared/api/types";
 
-export const LISTING_FORM_FIELDS: FormFieldSpec[] = [
-  { key: "itemName", label: "Item Name", type: "text", placeholder: "e.g. Elucidator", required: true },
-  { key: "price", label: "Price (col)", type: "number", placeholder: "10000", required: true },
-  { key: "quantity", label: "Quantity", type: "number", placeholder: "1", required: true },
-];
+export const EXCHANGE_CURRENCIES: EconomyCurrency[] = ["GOLD", "GEM"];
+export type ExchangeShopSurface = "system-shop" | "marketplace" | "my-listings";
 
-export const MARKET_WALLET_SUMMARY_LIST = makeList({
-  count: 36,
-  idPrefix: "market-wallet",
-  slotPrefix: "WL",
-  label: (index) => `Wallet Summary ${pad(index + 1, 3)}`,
-  subtitle: (index) => `Balance ${(index % 90000) + 20000} col | ${dateAt(index)}`,
-  detailTitle: "Wallet Detail",
-  detailDescription: (index) => `Wallet transaction detail ${pad(index + 1, 3)}.`,
-  detailRows: (index) => [
-    `Available: ${(index % 70000) + 12000} col`,
-    `Pending: ${(index % 9000) + 800} col`,
-    `Settlement: ${dateAt(index + 2)}`,
-    `Risk: ${(index % 5) === 0 ? "Review" : "Clear"}`,
-  ],
-});
+export function formatCurrency(amount: number, currency: EconomyCurrency) {
+  return `${amount.toLocaleString()} ${currency}`;
+}
 
-export const MARKET_SHOP_CATALOG_LIST: PanelDataItem[] = MOCK_SHOP_ITEMS.map((item) => {
-  const info = SHOP_ITEM_NAMES[item.itemId] ?? { name: `Item #${item.itemId}`, category: "Misc", rarity: "Common" };
-  return {
-    id: String(item.id),
-    label: info.name,
-    slotLabel: info.rarity.slice(0, 2).toUpperCase(),
-    subtitle: `${info.rarity} | ${item.price.toLocaleString()} col${item.available ? "" : " | 품절"}`,
-    detailTitle: info.name,
-    detailDescription: `${info.category} — ${info.rarity}`,
-    detailRows: [
-      `카테고리: ${info.category}`,
-      `희귀도: ${info.rarity}`,
-      `가격: ${item.price.toLocaleString()} col`,
-      ...(item.globalStockLimit ? [`재고 한도: ${item.globalStockLimit}`] : []),
-      ...(item.perPlayerLimit ? [`인당 구매 한도: ${item.perPlayerLimit}`] : []),
-      `상태: ${item.available ? "구매 가능" : "품절"}`,
-    ],
-    actions: item.available ? [{ type: "start" as const, label: "구매" }] : [],
-  };
-});
+export function itemIdentity(itemId: number) {
+  return `Item #${itemId}`;
+}
 
-const LISTING_ITEM_NAMES: Record<number, string> = {
-  1003: "Pale Edge",
-  5002: "Mithril Ingot",
-  3001: "HP Potion (M)",
-  7001: "Lucky Charm",
-  5003: "Dragon Scale",
-};
+export function recoverShopPurchase(purchases: ShopPurchaseSummary[], purchaseId: number) {
+  return purchases.find((purchase) => purchase.id === purchaseId) ?? null;
+}
 
-export const MARKET_SHOP_MY_LISTINGS: PanelDataItem[] = MOCK_MY_LISTINGS.map((listing) => {
-  const itemName = LISTING_ITEM_NAMES[listing.itemId] ?? `Item #${listing.itemId}`;
-  const statusLabel = listing.status === "ACTIVE" ? "판매 중" : listing.status === "RESERVED" ? "예약됨" : listing.status;
-  return {
-    id: String(listing.id),
-    label: itemName,
-    slotLabel: statusLabel.slice(0, 2),
-    subtitle: `${listing.price.toLocaleString()} col | ${statusLabel}`,
-    detailTitle: itemName,
-    detailDescription: `마켓 리스팅 #${listing.id}`,
-    detailRows: [
-      `가격: ${listing.price.toLocaleString()} col`,
-      `상태: ${statusLabel}`,
-      `화폐: ${listing.currency}`,
-    ],
-    actions: listing.status === "ACTIVE"
-      ? [{ type: "cancel" as const, label: "취소" }]
-      : [],
-  };
-});
-
-export const MARKET_TRADE_FRIENDS = makeList({
-  count: 48,
-  idPrefix: "market-trade-friend",
-  slotPrefix: "TR",
-  label: (index) => `Trade Partner ${pad(index + 1, 3)}`,
-  subtitle: (index) =>
-    `Lv.${(index % 68) + 8} | Trust ${(index % 100) + 1} | ${(index % 2) === 0 ? "Online" : "Away"}`,
-  detailTitle: "Trade Window",
-  detailDescription: (index) => `Trade session detail ${pad(index + 1, 3)}.`,
-  detailRows: (index) => [
-    `Allowed Slots: ${(index % 6) + 4}`,
-    `Recent Trades: ${(index % 22) + 1}`,
-    `Last Trade: ${dateAt(index + 1)}`,
-    `Partner Fee: ${(index % 4) + 1}%`,
-  ],
-});
-
+export function tradePresentation(trade: TradeSummary, playerId: number) {
+  const bought = trade.buyerId === playerId;
+  const counterpartyId = bought ? trade.sellerId : trade.buyerId;
+  return { direction: bought ? "Bought" : "Sold", counterparty: `Player #${counterpartyId}` };
+}

--- a/features/market/model.ts
+++ b/features/market/model.ts
@@ -15,11 +15,10 @@ export function recoverShopPurchase(purchases: ShopPurchaseSummary[], purchaseId
   return purchases.find((purchase) => purchase.id === purchaseId) ?? null;
 }
 
-export function recoverLatestReservedShopPurchase(purchases: ShopPurchaseSummary[], shopItemId: number) {
+export function recoverLatestPendingShopPurchase(purchases: ShopPurchaseSummary[], shopItemId: number) {
   return purchases.reduce<ShopPurchaseSummary | null>((latest, purchase) => (
     purchase.shopItemId === shopItemId
-    && purchase.status === "RESERVED"
-    && purchase.reservationToken
+    && (purchase.status === "REQUESTED" || purchase.status === "RESERVED")
     && (!latest || purchase.id > latest.id)
       ? purchase
       : latest

--- a/features/market/useExchangeMutations.test.tsx
+++ b/features/market/useExchangeMutations.test.tsx
@@ -1,0 +1,106 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ShopPurchaseSummary } from "@/shared/api/types";
+import type { ExchangeQueries } from "./useExchangeQueries";
+import { useExchangeMutations } from "./useExchangeMutations";
+
+const api = vi.hoisted(() => ({
+  initiateShopPurchaseApi: vi.fn(),
+  confirmShopPurchaseApi: vi.fn(),
+  createListingApi: vi.fn(),
+  cancelListingApi: vi.fn(),
+  reserveListingApi: vi.fn(),
+  purchaseListingApi: vi.fn(),
+}));
+
+vi.mock("@/lib/api/endpoints/market.api", () => api);
+
+const query = <T,>(data: T, reloadValue = data) => ({ data, loading: false, error: null, reload: vi.fn().mockResolvedValue(reloadValue) });
+
+function queries(): ExchangeQueries {
+  return {
+    wallet: query({ amount: 100, currency: "GOLD" as const }),
+    shopItems: query([]),
+    shopPurchases: query([], [{ id: 41, shopItemId: 2, quantity: 1, status: "RESERVED", reservationToken: "canonical-shop-token", reservationExpiresAt: "2026-08-23T01:00:00Z" }]),
+    openListings: query([]),
+    myListings: query([]),
+    inventory: query([]),
+    trades: query([]),
+  };
+}
+
+describe("Exchange command ownership", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(globalThis.crypto, "randomUUID").mockReturnValue("00000000-0000-4000-8000-000000000068");
+  });
+
+  it("recovers a shop reservation from canonical purchase history and confirms its token", async () => {
+    api.initiateShopPurchaseApi.mockResolvedValue({ id: 41 });
+    api.confirmShopPurchaseApi.mockResolvedValue({ reservationToken: "canonical-shop-token", expiresAt: "2026-08-23T01:00:00Z" });
+    const state = queries();
+    const hook = renderHook(() => useExchangeMutations(state));
+    let attempt: { purchaseId: number; purchase: ShopPurchaseSummary | null } | undefined;
+
+    await act(async () => { attempt = await hook.result.current.startShopPurchase({ id: 2, itemId: 9, price: 30, currency: "GEM", available: true, globalStockLimit: null, perPlayerLimit: 2, reservationTtlSec: 60 }); });
+    await act(async () => { await hook.result.current.confirmShopPurchase(attempt!.purchase!); });
+
+    expect(api.initiateShopPurchaseApi).toHaveBeenCalledWith(expect.objectContaining({ shopItemId: 2, quantity: 1, reserveOnly: true }));
+    expect(api.confirmShopPurchaseApi).toHaveBeenCalledWith("canonical-shop-token", expect.any(String));
+    expect(state.shopPurchases.reload).toHaveBeenCalledTimes(2);
+    expect(state.wallet.reload).toHaveBeenCalledTimes(2);
+    expect(state.inventory.reload).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not fabricate completion when canonical purchase history has not caught up", async () => {
+    api.initiateShopPurchaseApi.mockResolvedValue({ id: 99 });
+    const state = queries();
+    vi.mocked(state.shopPurchases.reload).mockResolvedValue([]);
+    const { result } = renderHook(() => useExchangeMutations(state));
+
+    let attempt: { purchaseId: number; purchase: ShopPurchaseSummary | null } | undefined;
+    await act(async () => { attempt = await result.current.startShopPurchase({ id: 2, itemId: 9, price: 30, currency: "GEM", available: true, globalStockLimit: null, perPlayerLimit: 2, reservationTtlSec: 60 }); });
+
+    expect(attempt).toEqual({ purchaseId: 99, purchase: null });
+    expect(result.current.error).toContain("canonical purchase history is not available");
+    expect(api.confirmShopPurchaseApi).not.toHaveBeenCalled();
+
+    vi.mocked(state.shopPurchases.reload).mockResolvedValue([{ id: 99, shopItemId: 2, quantity: 1, status: "RESERVED", reservationToken: "late-token", reservationExpiresAt: "2026-08-23T01:00:00Z" }]);
+    await act(async () => { await result.current.refreshShopPurchase(99); });
+    expect(api.initiateShopPurchaseApi).toHaveBeenCalledTimes(1);
+  });
+
+  it("maps the selected owned entry to the exact whole-entry listing command", async () => {
+    api.createListingApi.mockResolvedValue({ id: 77 });
+    const state = queries();
+    const { result } = renderHook(() => useExchangeMutations(state));
+
+    await act(async () => {
+      await result.current.createListing({ itemInstanceId: 501, slotIndex: 3, itemId: 90, itemName: "Owned Stack", category: "MATERIAL", type: "ORE", rarity: "RARE", stackable: true, maxStack: 99, quantity: 12, bound: false, durability: null, instanceAttrs: {} }, 12_000, "GEM");
+    });
+
+    expect(api.createListingApi).toHaveBeenCalledWith({ inventoryEntryId: 501, price: 12_000, currency: "GEM" });
+    expect(state.myListings.reload).toHaveBeenCalledTimes(1);
+    expect(state.openListings.reload).toHaveBeenCalledTimes(1);
+    expect(state.inventory.reload).toHaveBeenCalledTimes(1);
+  });
+
+  it("reloads canonical surfaces after a reserved Marketplace purchase", async () => {
+    api.reserveListingApi.mockResolvedValue({ reservationToken: "listing-token", holdId: "hold-8", expiresAt: "2026-08-23T01:00:00Z" });
+    api.purchaseListingApi.mockResolvedValue({ id: 9, listingId: 8, buyerId: 7, sellerId: 4, price: 70, currency: "GOLD" });
+    const state = queries();
+    const { result } = renderHook(() => useExchangeMutations(state));
+    const listing = { id: 8, itemId: 90, sellerId: 4, price: 70, currency: "GOLD" as const, status: "OPEN" };
+
+    await act(async () => { await result.current.reserveListing(listing); });
+    await act(async () => { await result.current.purchaseListing(listing, "listing-token"); });
+
+    expect(api.reserveListingApi).toHaveBeenCalledWith(8, 300);
+    expect(api.purchaseListingApi).toHaveBeenCalledWith(8, "listing-token", expect.any(String));
+    expect(state.openListings.reload).toHaveBeenCalledTimes(1);
+    expect(state.trades.reload).toHaveBeenCalledTimes(1);
+    expect(state.wallet.reload).toHaveBeenCalledTimes(2);
+    expect(state.inventory.reload).toHaveBeenCalledTimes(1);
+  });
+});

--- a/features/market/useExchangeMutations.test.tsx
+++ b/features/market/useExchangeMutations.test.tsx
@@ -1,7 +1,6 @@
 import { act, renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { ShopPurchaseSummary } from "@/shared/api/types";
 import type { ExchangeQueries } from "./useExchangeQueries";
 import { useExchangeMutations } from "./useExchangeMutations";
 
@@ -16,13 +15,18 @@ const api = vi.hoisted(() => ({
 
 vi.mock("@/lib/api/endpoints/market.api", () => api);
 
+const UUIDS = [
+  "00000000-0000-4000-8000-000000000001",
+  "00000000-0000-4000-8000-000000000002",
+  "00000000-0000-4000-8000-000000000003",
+] as const;
 const query = <T,>(data: T, reloadValue = data) => ({ data, loading: false, error: null, reload: vi.fn().mockResolvedValue(reloadValue) });
 
 function queries(): ExchangeQueries {
   return {
     wallet: query({ amount: 100, currency: "GOLD" as const }),
     shopItems: query([]),
-    shopPurchases: query([], [{ id: 41, shopItemId: 2, quantity: 1, status: "RESERVED", reservationToken: "canonical-shop-token", reservationExpiresAt: "2026-08-23T01:00:00Z" }]),
+    shopPurchases: query([]),
     openListings: query([]),
     myListings: query([]),
     inventory: query([]),
@@ -32,46 +36,91 @@ function queries(): ExchangeQueries {
 
 describe("Exchange command ownership", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
-    vi.spyOn(globalThis.crypto, "randomUUID").mockReturnValue("00000000-0000-4000-8000-000000000068");
+    vi.resetAllMocks();
+    let index = 0;
+    vi.spyOn(globalThis.crypto, "randomUUID").mockImplementation(() => UUIDS[index++] ?? UUIDS[2]);
   });
 
-  it("recovers a shop reservation from canonical purchase history and confirms its token", async () => {
-    api.initiateShopPurchaseApi.mockResolvedValue({ id: 41 });
-    api.confirmShopPurchaseApi.mockResolvedValue({ reservationToken: "canonical-shop-token", expiresAt: "2026-08-23T01:00:00Z" });
+  it("reuses one Shop start key while unresolved and creates a new key after success", async () => {
+    api.initiateShopPurchaseApi
+      .mockRejectedValueOnce(new Error("response lost"))
+      .mockResolvedValueOnce({ id: 41 })
+      .mockResolvedValueOnce({ id: 42 });
     const state = queries();
-    const hook = renderHook(() => useExchangeMutations(state));
-    let attempt: { purchaseId: number; purchase: ShopPurchaseSummary | null } | undefined;
+    vi.mocked(state.shopPurchases.reload).mockResolvedValue([
+      { id: 41, shopItemId: 2, quantity: 1, status: "RESERVED", reservationToken: "token-41", reservationExpiresAt: "2026-08-23T01:00:00Z" },
+      { id: 42, shopItemId: 2, quantity: 1, status: "RESERVED", reservationToken: "token-42", reservationExpiresAt: "2026-08-23T02:00:00Z" },
+    ]);
+    const { result } = renderHook(() => useExchangeMutations(state));
+    const item = { id: 2, itemId: 9, price: 30, currency: "GEM" as const, available: true, globalStockLimit: null, perPlayerLimit: 2, reservationTtlSec: 60 };
 
-    await act(async () => { attempt = await hook.result.current.startShopPurchase({ id: 2, itemId: 9, price: 30, currency: "GEM", available: true, globalStockLimit: null, perPlayerLimit: 2, reservationTtlSec: 60 }); });
-    await act(async () => { await hook.result.current.confirmShopPurchase(attempt!.purchase!); });
+    await act(async () => { await result.current.startShopPurchase(item); });
+    await act(async () => { await result.current.startShopPurchase(item); });
+    await act(async () => { await result.current.startShopPurchase(item); });
 
-    expect(api.initiateShopPurchaseApi).toHaveBeenCalledWith(expect.objectContaining({ shopItemId: 2, quantity: 1, reserveOnly: true }));
-    expect(api.confirmShopPurchaseApi).toHaveBeenCalledWith("canonical-shop-token", expect.any(String));
-    expect(state.shopPurchases.reload).toHaveBeenCalledTimes(2);
+    const keys = api.initiateShopPurchaseApi.mock.calls.map(([request]) => request.idempotencyKey);
+    expect(keys).toEqual([UUIDS[0], UUIDS[0], UUIDS[1]]);
+    expect(globalThis.crypto.randomUUID).toHaveBeenCalledTimes(2);
+  });
+
+  it("reuses one Shop confirm key while unresolved and clears it after completed history", async () => {
+    api.confirmShopPurchaseApi
+      .mockRejectedValueOnce(new Error("response lost"))
+      .mockResolvedValueOnce({ reservationToken: "shop-token", expiresAt: "2026-08-23T01:00:00Z" })
+      .mockResolvedValueOnce({ reservationToken: "shop-token", expiresAt: "2026-08-23T01:00:00Z" });
+    const state = queries();
+    vi.mocked(state.shopPurchases.reload).mockResolvedValue([
+      { id: 41, shopItemId: 2, quantity: 1, status: "COMPLETED", reservationToken: "shop-token", reservationExpiresAt: "2026-08-23T01:00:00Z" },
+    ]);
+    const { result } = renderHook(() => useExchangeMutations(state));
+    const purchase = { id: 41, shopItemId: 2, quantity: 1, status: "RESERVED", reservationToken: "shop-token", reservationExpiresAt: "2026-08-23T01:00:00Z" };
+
+    await act(async () => { await result.current.confirmShopPurchase(purchase); });
+    await act(async () => { await result.current.confirmShopPurchase(purchase); });
+    await act(async () => { await result.current.confirmShopPurchase(purchase); });
+
+    const keys = api.confirmShopPurchaseApi.mock.calls.map(([, key]) => key);
+    expect(keys).toEqual([UUIDS[0], UUIDS[0], UUIDS[1]]);
+    expect(globalThis.crypto.randomUUID).toHaveBeenCalledTimes(2);
+  });
+
+  it("reuses one Marketplace purchase key while unresolved and creates a new key after trade success", async () => {
+    api.purchaseListingApi
+      .mockRejectedValueOnce(new Error("response lost"))
+      .mockResolvedValueOnce({ id: 9, listingId: 8, buyerId: 7, sellerId: 4, price: 70, currency: "GOLD" })
+      .mockResolvedValueOnce({ id: 10, listingId: 8, buyerId: 7, sellerId: 4, price: 70, currency: "GOLD" });
+    const state = queries();
+    const { result } = renderHook(() => useExchangeMutations(state));
+    const listing = { id: 8, itemId: 90, sellerId: 4, price: 70, currency: "GOLD" as const, status: "OPEN" };
+
+    await act(async () => { await result.current.purchaseListing(listing, "listing-token"); });
+    await act(async () => { await result.current.purchaseListing(listing, "listing-token"); });
+    await act(async () => { await result.current.purchaseListing(listing, "listing-token"); });
+
+    const keys = api.purchaseListingApi.mock.calls.map(([, , key]) => key);
+    expect(keys).toEqual([UUIDS[0], UUIDS[0], UUIDS[1]]);
+    expect(globalThis.crypto.randomUUID).toHaveBeenCalledTimes(2);
+    expect(state.openListings.reload).toHaveBeenCalledTimes(2);
+    expect(state.trades.reload).toHaveBeenCalledTimes(2);
     expect(state.wallet.reload).toHaveBeenCalledTimes(2);
     expect(state.inventory.reload).toHaveBeenCalledTimes(2);
   });
 
-  it("does not fabricate completion when canonical purchase history has not caught up", async () => {
+  it("keeps an accepted purchase id when history has not caught up instead of starting again", async () => {
     api.initiateShopPurchaseApi.mockResolvedValue({ id: 99 });
     const state = queries();
-    vi.mocked(state.shopPurchases.reload).mockResolvedValue([]);
     const { result } = renderHook(() => useExchangeMutations(state));
+    const item = { id: 2, itemId: 9, price: 30, currency: "GEM" as const, available: true, globalStockLimit: null, perPlayerLimit: 2, reservationTtlSec: 60 };
 
-    let attempt: { purchaseId: number; purchase: ShopPurchaseSummary | null } | undefined;
-    await act(async () => { attempt = await result.current.startShopPurchase({ id: 2, itemId: 9, price: 30, currency: "GEM", available: true, globalStockLimit: null, perPlayerLimit: 2, reservationTtlSec: 60 }); });
+    let attempt;
+    await act(async () => { attempt = await result.current.startShopPurchase(item); });
 
     expect(attempt).toEqual({ purchaseId: 99, purchase: null });
-    expect(result.current.error).toContain("canonical purchase history is not available");
-    expect(api.confirmShopPurchaseApi).not.toHaveBeenCalled();
-
-    vi.mocked(state.shopPurchases.reload).mockResolvedValue([{ id: 99, shopItemId: 2, quantity: 1, status: "RESERVED", reservationToken: "late-token", reservationExpiresAt: "2026-08-23T01:00:00Z" }]);
-    await act(async () => { await result.current.refreshShopPurchase(99); });
+    expect(result.current.error).toContain("purchase history is not available");
     expect(api.initiateShopPurchaseApi).toHaveBeenCalledTimes(1);
   });
 
-  it("maps the selected owned entry to the exact whole-entry listing command", async () => {
+  it("keeps whole-entry listing mapping and authoritative reloads unchanged", async () => {
     api.createListingApi.mockResolvedValue({ id: 77 });
     const state = queries();
     const { result } = renderHook(() => useExchangeMutations(state));
@@ -83,24 +132,6 @@ describe("Exchange command ownership", () => {
     expect(api.createListingApi).toHaveBeenCalledWith({ inventoryEntryId: 501, price: 12_000, currency: "GEM" });
     expect(state.myListings.reload).toHaveBeenCalledTimes(1);
     expect(state.openListings.reload).toHaveBeenCalledTimes(1);
-    expect(state.inventory.reload).toHaveBeenCalledTimes(1);
-  });
-
-  it("reloads canonical surfaces after a reserved Marketplace purchase", async () => {
-    api.reserveListingApi.mockResolvedValue({ reservationToken: "listing-token", holdId: "hold-8", expiresAt: "2026-08-23T01:00:00Z" });
-    api.purchaseListingApi.mockResolvedValue({ id: 9, listingId: 8, buyerId: 7, sellerId: 4, price: 70, currency: "GOLD" });
-    const state = queries();
-    const { result } = renderHook(() => useExchangeMutations(state));
-    const listing = { id: 8, itemId: 90, sellerId: 4, price: 70, currency: "GOLD" as const, status: "OPEN" };
-
-    await act(async () => { await result.current.reserveListing(listing); });
-    await act(async () => { await result.current.purchaseListing(listing, "listing-token"); });
-
-    expect(api.reserveListingApi).toHaveBeenCalledWith(8, 300);
-    expect(api.purchaseListingApi).toHaveBeenCalledWith(8, "listing-token", expect.any(String));
-    expect(state.openListings.reload).toHaveBeenCalledTimes(1);
-    expect(state.trades.reload).toHaveBeenCalledTimes(1);
-    expect(state.wallet.reload).toHaveBeenCalledTimes(2);
     expect(state.inventory.reload).toHaveBeenCalledTimes(1);
   });
 });

--- a/features/market/useExchangeMutations.test.tsx
+++ b/features/market/useExchangeMutations.test.tsx
@@ -41,16 +41,20 @@ describe("Exchange command ownership", () => {
     vi.spyOn(globalThis.crypto, "randomUUID").mockImplementation(() => UUIDS[index++] ?? UUIDS[2]);
   });
 
-  it("reuses one Shop start key while unresolved and creates a new key after success", async () => {
+  it("keeps the Shop start key when the command succeeds but purchase history reload rejects", async () => {
     api.initiateShopPurchaseApi
-      .mockRejectedValueOnce(new Error("response lost"))
+      .mockResolvedValueOnce({ id: 41 })
       .mockResolvedValueOnce({ id: 41 })
       .mockResolvedValueOnce({ id: 42 });
     const state = queries();
-    vi.mocked(state.shopPurchases.reload).mockResolvedValue([
-      { id: 41, shopItemId: 2, quantity: 1, status: "RESERVED", reservationToken: "token-41", reservationExpiresAt: "2026-08-23T01:00:00Z" },
-      { id: 42, shopItemId: 2, quantity: 1, status: "RESERVED", reservationToken: "token-42", reservationExpiresAt: "2026-08-23T02:00:00Z" },
-    ]);
+    vi.mocked(state.shopPurchases.reload)
+      .mockRejectedValueOnce(new Error("history unavailable"))
+      .mockResolvedValueOnce([
+        { id: 41, shopItemId: 2, quantity: 1, status: "RESERVED", reservationToken: "token-41", reservationExpiresAt: "2026-08-23T01:00:00Z" },
+      ])
+      .mockResolvedValueOnce([
+        { id: 42, shopItemId: 2, quantity: 1, status: "RESERVED", reservationToken: "token-42", reservationExpiresAt: "2026-08-23T02:00:00Z" },
+      ]);
     const { result } = renderHook(() => useExchangeMutations(state));
     const item = { id: 2, itemId: 9, price: 30, currency: "GEM" as const, available: true, globalStockLimit: null, perPlayerLimit: 2, reservationTtlSec: 60 };
 
@@ -61,6 +65,7 @@ describe("Exchange command ownership", () => {
     const keys = api.initiateShopPurchaseApi.mock.calls.map(([request]) => request.idempotencyKey);
     expect(keys).toEqual([UUIDS[0], UUIDS[0], UUIDS[1]]);
     expect(globalThis.crypto.randomUUID).toHaveBeenCalledTimes(2);
+    expect(state.shopPurchases.reload).toHaveBeenCalledTimes(3);
   });
 
   it("reuses one Shop confirm key while unresolved and clears it after completed history", async () => {
@@ -84,12 +89,13 @@ describe("Exchange command ownership", () => {
     expect(globalThis.crypto.randomUUID).toHaveBeenCalledTimes(2);
   });
 
-  it("reuses one Marketplace purchase key while unresolved and creates a new key after trade success", async () => {
+  it("keeps the Marketplace purchase key when the command succeeds but an authoritative reload rejects", async () => {
     api.purchaseListingApi
-      .mockRejectedValueOnce(new Error("response lost"))
+      .mockResolvedValueOnce({ id: 9, listingId: 8, buyerId: 7, sellerId: 4, price: 70, currency: "GOLD" })
       .mockResolvedValueOnce({ id: 9, listingId: 8, buyerId: 7, sellerId: 4, price: 70, currency: "GOLD" })
       .mockResolvedValueOnce({ id: 10, listingId: 8, buyerId: 7, sellerId: 4, price: 70, currency: "GOLD" });
     const state = queries();
+    vi.mocked(state.openListings.reload).mockRejectedValueOnce(new Error("listings unavailable")).mockResolvedValue([]);
     const { result } = renderHook(() => useExchangeMutations(state));
     const listing = { id: 8, itemId: 90, sellerId: 4, price: 70, currency: "GOLD" as const, status: "OPEN" };
 
@@ -100,10 +106,10 @@ describe("Exchange command ownership", () => {
     const keys = api.purchaseListingApi.mock.calls.map(([, , key]) => key);
     expect(keys).toEqual([UUIDS[0], UUIDS[0], UUIDS[1]]);
     expect(globalThis.crypto.randomUUID).toHaveBeenCalledTimes(2);
-    expect(state.openListings.reload).toHaveBeenCalledTimes(2);
-    expect(state.trades.reload).toHaveBeenCalledTimes(2);
-    expect(state.wallet.reload).toHaveBeenCalledTimes(2);
-    expect(state.inventory.reload).toHaveBeenCalledTimes(2);
+    expect(state.openListings.reload).toHaveBeenCalledTimes(3);
+    expect(state.trades.reload).toHaveBeenCalledTimes(3);
+    expect(state.wallet.reload).toHaveBeenCalledTimes(3);
+    expect(state.inventory.reload).toHaveBeenCalledTimes(3);
   });
 
   it("keeps an accepted purchase id when history has not caught up instead of starting again", async () => {

--- a/features/market/useExchangeMutations.ts
+++ b/features/market/useExchangeMutations.ts
@@ -1,0 +1,121 @@
+"use client";
+
+import { useRef, useState } from "react";
+
+import type { EconomyCurrency, InventoryEntry, ListingSummary, ShopItem, ShopPurchaseSummary } from "@/shared/api/types";
+import {
+  cancelListingApi,
+  confirmShopPurchaseApi,
+  createListingApi,
+  initiateShopPurchaseApi,
+  purchaseListingApi,
+  reserveListingApi,
+} from "@/lib/api/endpoints/market.api";
+import { recoverShopPurchase } from "./model";
+import type { ExchangeQueries } from "./useExchangeQueries";
+
+const message = (caught: unknown) => caught instanceof Error ? caught.message : "Request failed.";
+const intentKey = () => globalThis.crypto.randomUUID();
+
+export function useExchangeMutations(queries: ExchangeQueries) {
+  // ponytail: one Exchange command at a time; split by action only if concurrent commands become a product requirement.
+  const locked = useRef(false);
+  const [pendingKey, setPendingKey] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const run = async <T,>(key: string, action: () => Promise<T>): Promise<T | undefined> => {
+    if (locked.current) return undefined;
+    locked.current = true;
+    setPendingKey(key);
+    setError(null);
+    try {
+      return await action();
+    } catch (caught) {
+      setError(message(caught));
+      return undefined;
+    } finally {
+      locked.current = false;
+      setPendingKey(null);
+    }
+  };
+
+  const startShopPurchase = (item: ShopItem) => run(`shop-start-${item.id}`, async () => {
+    const initiated = await initiateShopPurchaseApi({
+      shopItemId: item.id,
+      quantity: 1,
+      reserveOnly: (item.reservationTtlSec ?? 0) > 0,
+      idempotencyKey: intentKey(),
+    });
+    const [history] = await Promise.all([
+      queries.shopPurchases.reload(),
+      queries.shopItems.reload(),
+      queries.wallet.reload(),
+      queries.inventory.reload(),
+    ]);
+    const purchase = history && recoverShopPurchase(history, initiated.id);
+    if (!purchase) setError(`Purchase #${initiated.id} was accepted, but canonical purchase history is not available yet.`);
+    return { purchaseId: initiated.id, purchase: purchase ?? null };
+  });
+
+  const refreshShopPurchase = (purchaseId: number) => run(`shop-refresh-${purchaseId}`, async () => {
+    const history = await queries.shopPurchases.reload();
+    const purchase = history && recoverShopPurchase(history, purchaseId);
+    if (!purchase) throw new Error(`Purchase #${purchaseId} is not available in canonical purchase history yet.`);
+    return purchase;
+  });
+
+  const confirmShopPurchase = (purchase: ShopPurchaseSummary) => run(`shop-confirm-${purchase.id}`, async () => {
+    if (!purchase.reservationToken) throw new Error("Canonical reservation token is unavailable.");
+    await confirmShopPurchaseApi(purchase.reservationToken, intentKey());
+    await Promise.all([
+      queries.shopPurchases.reload(),
+      queries.shopItems.reload(),
+      queries.wallet.reload(),
+      queries.inventory.reload(),
+    ]);
+    return true;
+  });
+
+  const reserveListing = (listing: ListingSummary) => run(`listing-reserve-${listing.id}`, async () => {
+    const reservation = await reserveListingApi(listing.id, 300);
+    await queries.wallet.reload();
+    return reservation;
+  });
+
+  const purchaseListing = (listing: ListingSummary, reservationToken: string) => run(`listing-purchase-${listing.id}`, async () => {
+    const trade = await purchaseListingApi(listing.id, reservationToken, intentKey());
+    await Promise.all([
+      queries.openListings.reload(),
+      queries.myListings.reload(),
+      queries.trades.reload(),
+      queries.wallet.reload(),
+      queries.inventory.reload(),
+    ]);
+    return trade;
+  });
+
+  const createListing = (entry: InventoryEntry, price: number, currency: EconomyCurrency) => run(`listing-create-${entry.itemInstanceId}`, async () => {
+    const listing = await createListingApi({ inventoryEntryId: entry.itemInstanceId, price, currency });
+    await Promise.all([queries.myListings.reload(), queries.openListings.reload(), queries.inventory.reload()]);
+    return listing;
+  });
+
+  const cancelListing = (listing: ListingSummary) => run(`listing-cancel-${listing.id}`, async () => {
+    await cancelListingApi(listing.id);
+    await Promise.all([queries.myListings.reload(), queries.openListings.reload(), queries.inventory.reload()]);
+    return true;
+  });
+
+  return {
+    pendingKey,
+    error,
+    clearError: () => setError(null),
+    startShopPurchase,
+    refreshShopPurchase,
+    confirmShopPurchase,
+    reserveListing,
+    purchaseListing,
+    createListing,
+    cancelListing,
+  };
+}

--- a/features/market/useExchangeMutations.ts
+++ b/features/market/useExchangeMutations.ts
@@ -20,8 +20,17 @@ const intentKey = () => globalThis.crypto.randomUUID();
 export function useExchangeMutations(queries: ExchangeQueries) {
   // ponytail: one Exchange command at a time; split by action only if concurrent commands become a product requirement.
   const locked = useRef(false);
+  const intentKeys = useRef(new Map<string, string>());
   const [pendingKey, setPendingKey] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+
+  const keyFor = (intent: string) => {
+    const current = intentKeys.current.get(intent);
+    if (current) return current;
+    const created = intentKey();
+    intentKeys.current.set(intent, created);
+    return created;
+  };
 
   const run = async <T,>(key: string, action: () => Promise<T>): Promise<T | undefined> => {
     if (locked.current) return undefined;
@@ -40,12 +49,14 @@ export function useExchangeMutations(queries: ExchangeQueries) {
   };
 
   const startShopPurchase = (item: ShopItem) => run(`shop-start-${item.id}`, async () => {
+    const intent = `shop-start:${item.id}`;
     const initiated = await initiateShopPurchaseApi({
       shopItemId: item.id,
       quantity: 1,
       reserveOnly: (item.reservationTtlSec ?? 0) > 0,
-      idempotencyKey: intentKey(),
+      idempotencyKey: keyFor(intent),
     });
+    intentKeys.current.delete(intent);
     const [history] = await Promise.all([
       queries.shopPurchases.reload(),
       queries.shopItems.reload(),
@@ -53,27 +64,34 @@ export function useExchangeMutations(queries: ExchangeQueries) {
       queries.inventory.reload(),
     ]);
     const purchase = history && recoverShopPurchase(history, initiated.id);
-    if (!purchase) setError(`Purchase #${initiated.id} was accepted, but canonical purchase history is not available yet.`);
+    if (!purchase) setError(`Purchase #${initiated.id} was accepted, but purchase history is not available yet.`);
     return { purchaseId: initiated.id, purchase: purchase ?? null };
   });
 
   const refreshShopPurchase = (purchaseId: number) => run(`shop-refresh-${purchaseId}`, async () => {
     const history = await queries.shopPurchases.reload();
     const purchase = history && recoverShopPurchase(history, purchaseId);
-    if (!purchase) throw new Error(`Purchase #${purchaseId} is not available in canonical purchase history yet.`);
+    if (!purchase) throw new Error(`Purchase #${purchaseId} is not available in purchase history yet.`);
     return purchase;
   });
 
   const confirmShopPurchase = (purchase: ShopPurchaseSummary) => run(`shop-confirm-${purchase.id}`, async () => {
-    if (!purchase.reservationToken) throw new Error("Canonical reservation token is unavailable.");
-    await confirmShopPurchaseApi(purchase.reservationToken, intentKey());
-    await Promise.all([
+    if (!purchase.reservationToken) throw new Error("Reservation token is unavailable.");
+    const intent = `shop-confirm:${purchase.id}:${purchase.reservationToken}`;
+    await confirmShopPurchaseApi(purchase.reservationToken, keyFor(intent));
+    const [history] = await Promise.all([
       queries.shopPurchases.reload(),
       queries.shopItems.reload(),
       queries.wallet.reload(),
       queries.inventory.reload(),
     ]);
-    return true;
+    const current = history && recoverShopPurchase(history, purchase.id);
+    if (current && current.status !== "REQUESTED" && current.status !== "RESERVED") intentKeys.current.delete(intent);
+    if (current?.status === "COMPLETED") return true;
+    setError(current?.status === "CANCELED" || current?.status === "EXPIRED"
+      ? "This reservation can no longer be confirmed."
+      : "Confirmation is still processing. Retry to check its status.");
+    return false;
   });
 
   const reserveListing = (listing: ListingSummary) => run(`listing-reserve-${listing.id}`, async () => {
@@ -83,7 +101,9 @@ export function useExchangeMutations(queries: ExchangeQueries) {
   });
 
   const purchaseListing = (listing: ListingSummary, reservationToken: string) => run(`listing-purchase-${listing.id}`, async () => {
-    const trade = await purchaseListingApi(listing.id, reservationToken, intentKey());
+    const intent = `listing-purchase:${listing.id}:${reservationToken}`;
+    const trade = await purchaseListingApi(listing.id, reservationToken, keyFor(intent));
+    intentKeys.current.delete(intent);
     await Promise.all([
       queries.openListings.reload(),
       queries.myListings.reload(),

--- a/features/market/useExchangeMutations.ts
+++ b/features/market/useExchangeMutations.ts
@@ -16,6 +16,7 @@ import type { ExchangeQueries } from "./useExchangeQueries";
 
 const message = (caught: unknown) => caught instanceof Error ? caught.message : "Request failed.";
 const intentKey = () => globalThis.crypto.randomUUID();
+const fullyReloaded = (results: PromiseSettledResult<unknown>[]) => results.every((result) => result.status === "fulfilled" && result.value !== undefined);
 
 export function useExchangeMutations(queries: ExchangeQueries) {
   // ponytail: one Exchange command at a time; split by action only if concurrent commands become a product requirement.
@@ -56,15 +57,17 @@ export function useExchangeMutations(queries: ExchangeQueries) {
       reserveOnly: (item.reservationTtlSec ?? 0) > 0,
       idempotencyKey: keyFor(intent),
     });
-    intentKeys.current.delete(intent);
-    const [history] = await Promise.all([
+    const refreshes = await Promise.allSettled([
       queries.shopPurchases.reload(),
       queries.shopItems.reload(),
       queries.wallet.reload(),
       queries.inventory.reload(),
     ]);
+    const history = refreshes[0].status === "fulfilled" ? refreshes[0].value : undefined;
     const purchase = history && recoverShopPurchase(history, initiated.id);
+    if (purchase) intentKeys.current.delete(intent);
     if (!purchase) setError(`Purchase #${initiated.id} was accepted, but purchase history is not available yet.`);
+    else if (!fullyReloaded(refreshes)) setError("Purchase accepted, but some Exchange data could not be refreshed.");
     return { purchaseId: initiated.id, purchase: purchase ?? null };
   });
 
@@ -72,6 +75,7 @@ export function useExchangeMutations(queries: ExchangeQueries) {
     const history = await queries.shopPurchases.reload();
     const purchase = history && recoverShopPurchase(history, purchaseId);
     if (!purchase) throw new Error(`Purchase #${purchaseId} is not available in purchase history yet.`);
+    intentKeys.current.delete(`shop-start:${purchase.shopItemId}`);
     return purchase;
   });
 
@@ -86,7 +90,10 @@ export function useExchangeMutations(queries: ExchangeQueries) {
       queries.inventory.reload(),
     ]);
     const current = history && recoverShopPurchase(history, purchase.id);
-    if (current && current.status !== "REQUESTED" && current.status !== "RESERVED") intentKeys.current.delete(intent);
+    if (current && current.status !== "REQUESTED" && current.status !== "RESERVED") {
+      intentKeys.current.delete(intent);
+      intentKeys.current.delete(`shop-start:${purchase.shopItemId}`);
+    }
     if (current?.status === "COMPLETED") return true;
     setError(current?.status === "CANCELED" || current?.status === "EXPIRED"
       ? "This reservation can no longer be confirmed."
@@ -103,14 +110,15 @@ export function useExchangeMutations(queries: ExchangeQueries) {
   const purchaseListing = (listing: ListingSummary, reservationToken: string) => run(`listing-purchase-${listing.id}`, async () => {
     const intent = `listing-purchase:${listing.id}:${reservationToken}`;
     const trade = await purchaseListingApi(listing.id, reservationToken, keyFor(intent));
-    intentKeys.current.delete(intent);
-    await Promise.all([
+    const refreshes = await Promise.allSettled([
       queries.openListings.reload(),
       queries.myListings.reload(),
       queries.trades.reload(),
       queries.wallet.reload(),
       queries.inventory.reload(),
     ]);
+    if (fullyReloaded(refreshes)) intentKeys.current.delete(intent);
+    else setError("Purchase completed, but some Exchange data could not be refreshed.");
     return trade;
   });
 

--- a/features/market/useExchangeQueries.test.tsx
+++ b/features/market/useExchangeQueries.test.tsx
@@ -1,0 +1,59 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useExchangeQueries } from "./useExchangeQueries";
+
+const api = vi.hoisted(() => ({
+  getWalletApi: vi.fn(),
+  getShopItemsApi: vi.fn(),
+  getShopPurchasesApi: vi.fn(),
+  getOpenListingsApi: vi.fn(),
+  getMyListingsApi: vi.fn(),
+  getTradesApi: vi.fn(),
+  getInventoryApi: vi.fn(),
+}));
+
+vi.mock("@/lib/api/endpoints/market.api", () => api);
+vi.mock("@/lib/api/endpoints/inventory.api", () => ({ getInventoryApi: api.getInventoryApi }));
+
+describe("Exchange read ownership", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api.getWalletApi.mockResolvedValue({ amount: 900, currency: "GOLD" });
+    api.getShopItemsApi.mockResolvedValue([]);
+    api.getShopPurchasesApi.mockResolvedValue([]);
+    api.getOpenListingsApi.mockResolvedValue([]);
+    api.getMyListingsApi.mockResolvedValue([]);
+    api.getTradesApi.mockResolvedValue([]);
+    api.getInventoryApi.mockResolvedValue({ entries: [] });
+  });
+
+  it("loads only the selected canonical surface and switches Shop data on together", async () => {
+    const view = renderHook(({ surface }) => useExchangeQueries(surface), { initialProps: { surface: "wallet" as "wallet" | "shop" | "trade" | null } });
+
+    await waitFor(() => expect(view.result.current.wallet.data).toEqual({ amount: 900, currency: "GOLD" }));
+    expect(api.getShopItemsApi).not.toHaveBeenCalled();
+    expect(api.getTradesApi).not.toHaveBeenCalled();
+
+    view.rerender({ surface: "shop" });
+    await waitFor(() => expect(api.getInventoryApi).toHaveBeenCalledTimes(1));
+    expect(api.getShopItemsApi).toHaveBeenCalledTimes(1);
+    expect(api.getShopPurchasesApi).toHaveBeenCalledTimes(1);
+    expect(api.getOpenListingsApi).toHaveBeenCalledTimes(1);
+    expect(api.getMyListingsApi).toHaveBeenCalledTimes(1);
+
+    view.rerender({ surface: "trade" });
+    await waitFor(() => expect(api.getTradesApi).toHaveBeenCalledTimes(1));
+  });
+
+  it("keeps the current value on failure and exposes a working retry", async () => {
+    api.getWalletApi.mockRejectedValueOnce(new Error("Wallet offline")).mockResolvedValueOnce({ amount: 25, currency: "GEM" });
+    const { result } = renderHook(() => useExchangeQueries("wallet"));
+
+    await waitFor(() => expect(result.current.wallet.error).toBe("Wallet offline"));
+    await act(async () => { await result.current.wallet.reload(); });
+
+    expect(result.current.wallet.data).toEqual({ amount: 25, currency: "GEM" });
+    expect(result.current.wallet.error).toBeNull();
+  });
+});

--- a/features/market/useExchangeQueries.ts
+++ b/features/market/useExchangeQueries.ts
@@ -1,0 +1,70 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import type { MarketSubId } from "@/entities/nav";
+import type { InventoryEntry, ListingSummary, ShopItem, ShopPurchaseSummary, TradeSummary, WalletBalance } from "@/shared/api/types";
+import { getInventoryApi } from "@/lib/api/endpoints/inventory.api";
+import {
+  getMyListingsApi,
+  getOpenListingsApi,
+  getShopItemsApi,
+  getShopPurchasesApi,
+  getTradesApi,
+  getWalletApi,
+} from "@/lib/api/endpoints/market.api";
+
+export type ExchangeQuery<T> = {
+  data: T;
+  loading: boolean;
+  error: string | null;
+  reload: () => Promise<T | undefined>;
+};
+
+const message = (caught: unknown, fallback: string) => caught instanceof Error ? caught.message : fallback;
+
+function useExchangeQuery<T>(initial: T, load: () => Promise<T>, fallback: string, enabled: boolean): ExchangeQuery<T> {
+  const [data, setData] = useState(initial);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const requestId = useRef(0);
+
+  const reload = useCallback(async () => {
+    const id = ++requestId.current;
+    setLoading(true);
+    setError(null);
+    try {
+      const next = await load();
+      if (id === requestId.current) setData(next);
+      return next;
+    } catch (caught) {
+      if (id === requestId.current) setError(message(caught, fallback));
+      return undefined;
+    } finally {
+      if (id === requestId.current) setLoading(false);
+    }
+  }, [fallback, load]);
+
+  useEffect(() => {
+    if (enabled) void reload();
+  }, [enabled, reload]);
+
+  return { data, loading, error, reload };
+}
+
+const loadInventory = async () => (await getInventoryApi()).entries;
+
+export function useExchangeQueries(surface: MarketSubId | null) {
+  const shop = surface === "shop";
+  const wallet = useExchangeQuery<WalletBalance | null>(null, getWalletApi, "Unable to load Wallet.", surface === "wallet" || shop);
+  const shopItems = useExchangeQuery<ShopItem[]>([], getShopItemsApi, "Unable to load System Shop.", shop);
+  const shopPurchases = useExchangeQuery<ShopPurchaseSummary[]>([], getShopPurchasesApi, "Unable to load purchase history.", shop);
+  const openListings = useExchangeQuery<ListingSummary[]>([], getOpenListingsApi, "Unable to load Marketplace.", shop);
+  const myListings = useExchangeQuery<ListingSummary[]>([], getMyListingsApi, "Unable to load My Listings.", shop);
+  const inventory = useExchangeQuery<InventoryEntry[]>([], loadInventory, "Unable to load owned InventoryEntry data.", shop);
+  const trades = useExchangeQuery<TradeSummary[]>([], getTradesApi, "Unable to load Trade history.", surface === "trade");
+
+  return { wallet, shopItems, shopPurchases, openListings, myListings, inventory, trades };
+}
+
+export type ExchangeQueries = ReturnType<typeof useExchangeQueries>;

--- a/lib/api/endpoints/admin.api.ts
+++ b/lib/api/endpoints/admin.api.ts
@@ -146,9 +146,9 @@ export async function adminDeleteUserApi(userId: number): Promise<void> {
 export async function adminGetListingsApi() {
   if (USE_MOCK) {
     return [
-      { id: 201, itemId: 1001, sellerId: 6, price: 35000, currency: "col", status: "ACTIVE" },
-      { id: 202, itemId: 2001, sellerId: 12, price: 62000, currency: "col", status: "ACTIVE" },
-      { id: 203, itemId: 3001, sellerId: 24, price: 1200, currency: "col", status: "RESERVED" },
+      { id: 201, itemId: 1001, sellerId: 6, price: 35000, currency: "GOLD", status: "ACTIVE" },
+      { id: 202, itemId: 2001, sellerId: 12, price: 62000, currency: "GOLD", status: "ACTIVE" },
+      { id: 203, itemId: 3001, sellerId: 24, price: 1200, currency: "GEM", status: "RESERVED" },
     ];
   }
   return apiGet("/api/v1/admin/economy/listings");
@@ -634,9 +634,9 @@ export async function adminChangeQuestStatusApi(
 
 // ===== Admin Economy Shop =====
 const MOCK_SHOP_ITEMS = [
-  { id: 1, itemId: 101, itemName: "Elucidator",    price: 15000, currency: "col", available: true,  globalStockLimit: null, perPlayerLimit: 3,  reservationTtlSec: 300 },
-  { id: 2, itemId: 201, itemName: "Healing Potion",price: 500,   currency: "col", available: true,  globalStockLimit: 100, perPlayerLimit: 10, reservationTtlSec: 60  },
-  { id: 3, itemId: 301, itemName: "Wind Fleuret",   price: 8000,  currency: "col", available: false, globalStockLimit: 5,   perPlayerLimit: 1,  reservationTtlSec: 600 },
+  { id: 1, itemId: 101, itemName: "Elucidator",    price: 15000, currency: "GOLD", available: true,  globalStockLimit: null, perPlayerLimit: 3,  reservationTtlSec: 300 },
+  { id: 2, itemId: 201, itemName: "Healing Potion",price: 500,   currency: "GOLD", available: true,  globalStockLimit: 100, perPlayerLimit: 10, reservationTtlSec: 60  },
+  { id: 3, itemId: 301, itemName: "Wind Fleuret",   price: 8000,  currency: "GEM", available: false, globalStockLimit: 5,   perPlayerLimit: 1,  reservationTtlSec: 600 },
 ];
 
 export async function adminGetShopItemsApi(): Promise<typeof MOCK_SHOP_ITEMS> {

--- a/lib/api/endpoints/market.api.test.ts
+++ b/lib/api/endpoints/market.api.test.ts
@@ -1,0 +1,95 @@
+import { readFileSync } from "node:fs";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { marketMock } from "../mock/market.mock";
+import {
+  confirmShopPurchaseApi,
+  createListingApi,
+  getOpenListingsApi,
+  getShopItemsApi,
+  getShopPurchasesApi,
+  getTradesApi,
+  getWalletApi,
+  initiateShopPurchaseApi,
+  purchaseListingApi,
+  reserveListingApi,
+} from "./market.api";
+
+const client = vi.hoisted(() => ({ apiDelete: vi.fn(), apiGet: vi.fn(), apiPost: vi.fn() }));
+vi.mock("@/shared/api/client", () => ({ USE_MOCK: false, ...client }));
+
+describe("canonical Economy API adapters", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    marketMock.reset();
+  });
+
+  it("uses amount/currency wallet and canonical ShopItem wrappers without enrichment", async () => {
+    client.apiGet
+      .mockResolvedValueOnce({ amount: 900, currency: "GOLD" })
+      .mockResolvedValueOnce({ items: [{ id: 1, itemId: 9, price: 30, currency: "GEM", available: false, globalStockLimit: null, perPlayerLimit: 2, reservationTtlSec: 60 }] });
+
+    await expect(getWalletApi()).resolves.toEqual({ amount: 900, currency: "GOLD" });
+    await expect(getShopItemsApi()).resolves.toEqual([
+      { id: 1, itemId: 9, price: 30, currency: "GEM", available: false, globalStockLimit: null, perPlayerLimit: 2, reservationTtlSec: 60 },
+    ]);
+  });
+
+  it("treats shop initiation as {id}, unwraps purchase history, and confirms its canonical token", async () => {
+    client.apiPost.mockResolvedValueOnce({ id: 42 }).mockResolvedValueOnce({ reservationToken: "token-42", expiresAt: "2026-08-23T01:00:00Z" });
+    client.apiGet.mockResolvedValue({ purchases: [{ id: 42, shopItemId: 3, quantity: 1, status: "RESERVED", reservationToken: "token-42", reservationExpiresAt: "2026-08-23T01:00:00Z" }] });
+    const intent = { shopItemId: 3, quantity: 1, reserveOnly: true, idempotencyKey: "intent-shop-42" };
+
+    await expect(initiateShopPurchaseApi(intent)).resolves.toEqual({ id: 42 });
+    await expect(getShopPurchasesApi()).resolves.toEqual([expect.objectContaining({ id: 42, reservationToken: "token-42" })]);
+    await expect(confirmShopPurchaseApi("token-42", "intent-confirm-42")).resolves.toEqual({ reservationToken: "token-42", expiresAt: "2026-08-23T01:00:00Z" });
+
+    expect(client.apiPost).toHaveBeenNthCalledWith(1, "/api/v1/economy/shop/purchase", intent);
+    expect(client.apiPost).toHaveBeenNthCalledWith(2, "/api/v1/economy/shop/reservations/confirm", { reservationToken: "token-42", idempotencyKey: "intent-confirm-42" });
+  });
+
+  it("opens a whole-entry listing with exactly inventoryEntryId/price/currency", async () => {
+    client.apiPost.mockResolvedValue({ id: 77 });
+
+    await createListingApi({ inventoryEntryId: 501, price: 12_000, currency: "GOLD" });
+
+    const body = client.apiPost.mock.calls[0][1];
+    expect(client.apiPost).toHaveBeenCalledWith("/api/v1/economy/listings", { inventoryEntryId: 501, price: 12_000, currency: "GOLD" });
+    expect(Object.keys(body)).toEqual(["inventoryEntryId", "price", "currency"]);
+    expect(body).not.toHaveProperty("itemInstanceId");
+    expect(body).not.toHaveProperty("itemId");
+  });
+
+  it("uses canonical listing reserve/purchase bodies and listing summary fields", async () => {
+    client.apiGet.mockResolvedValue({ listings: [{ id: 8, itemId: 90, sellerId: 4, price: 70, currency: "GEM", status: "OPEN" }] });
+    client.apiPost
+      .mockResolvedValueOnce({ reservationToken: "listing-token", holdId: "hold-8", expiresAt: "2026-08-23T01:00:00Z" })
+      .mockResolvedValueOnce({ id: 9, listingId: 8, buyerId: 7, sellerId: 4, price: 70, currency: "GEM" });
+
+    await expect(getOpenListingsApi()).resolves.toEqual([{ id: 8, itemId: 90, sellerId: 4, price: 70, currency: "GEM", status: "OPEN" }]);
+    await reserveListingApi(8, 300);
+    await purchaseListingApi(8, "listing-token", "intent-listing-8");
+
+    expect(client.apiPost).toHaveBeenNthCalledWith(1, "/api/v1/economy/listings/8/reserve", { ttlSeconds: 300 });
+    expect(client.apiPost).toHaveBeenNthCalledWith(2, "/api/v1/economy/listings/8/purchase", { reservationToken: "listing-token", idempotencyKey: "intent-listing-8" });
+  });
+
+  it("unwraps the canonical {trades} response without partner or barter enrichment", async () => {
+    const trade = { id: 1, listingId: 2, buyerId: 7, sellerId: 8, price: 40, currency: "GOLD" };
+    client.apiGet.mockResolvedValue({ trades: [trade] });
+
+    await expect(getTradesApi()).resolves.toEqual([trade]);
+  });
+
+  it("keeps mock fixtures canonical and removes the legacy currency fallback", () => {
+    const source = ["shared/api/types/economy.ts", "lib/api/endpoints/market.api.ts", "lib/api/mock/market.mock.ts"]
+      .map((file) => readFileSync(file, "utf8"))
+      .join("\n");
+    const fixtures = marketMock.shopItems().items;
+
+    expect(new Set(fixtures.map(({ currency }) => currency))).toEqual(new Set(["GOLD", "GEM"]));
+    expect(Object.keys(fixtures[0])).toEqual(["id", "itemId", "price", "currency", "available", "globalStockLimit", "perPlayerLimit", "reservationTtlSec"]);
+    expect(source).not.toMatch(/["']col["']/i);
+    expect(source).not.toContain("itemName");
+  });
+});

--- a/lib/api/endpoints/market.api.ts
+++ b/lib/api/endpoints/market.api.ts
@@ -1,153 +1,91 @@
-import { USE_MOCK, apiGet, apiPost, apiDelete } from "../client";
-import {
-  MOCK_MY_LISTINGS,
-  MOCK_SHOP_ITEMS,
-  MOCK_TRADES,
-  MOCK_WALLET,
-  SHOP_ITEM_NAMES,
-  TRADE_PARTNER_NAMES,
-} from "../mock/market.mock";
-import type { ListingSummary, ShopItem, TradeSummary, WalletBalance } from "../types";
+import { USE_MOCK, apiDelete, apiGet, apiPost } from "@/shared/api/client";
+import type {
+  ListingReservation,
+  ListingSummary,
+  ListingsResponse,
+  OpenListingRequest,
+  ShopItem,
+  ShopPurchaseId,
+  ShopPurchaseRequest,
+  ShopPurchasesResponse,
+  ShopPurchaseSummary,
+  ShopReservation,
+  TradeSummary,
+  TradesResponse,
+  WalletBalance,
+} from "@/shared/api/types";
+import { marketMock } from "../mock/market.mock";
 
-export async function getWalletApi(): Promise<WalletBalance> {
-  if (USE_MOCK) return MOCK_WALLET;
-  return apiGet<WalletBalance>("/api/v1/economy/wallet");
+export function getWalletApi(): Promise<WalletBalance> {
+  return USE_MOCK ? Promise.resolve(marketMock.wallet()) : apiGet<WalletBalance>("/api/v1/economy/wallet");
 }
 
-export async function getShopItemsApi(): Promise<
-  Array<ShopItem & { itemName: string; itemCategory: string; itemRarity: string }>
-> {
-  if (USE_MOCK) {
-    return MOCK_SHOP_ITEMS.map((item) => {
-      const info = SHOP_ITEM_NAMES[item.itemId] ?? {
-        name: `Item #${item.itemId}`,
-        category: "Misc",
-        rarity: "Common",
-      };
-      return { ...item, itemName: info.name, itemCategory: info.category, itemRarity: info.rarity };
-    });
-  }
-  const res = await apiGet<{ items: Array<ShopItem & { itemName: string; itemCategory: string; itemRarity: string }> }>("/api/v1/economy/shop/items");
-  return res.items;
+export async function getShopItemsApi(): Promise<ShopItem[]> {
+  const response = USE_MOCK
+    ? marketMock.shopItems()
+    : await apiGet<{ items: ShopItem[] }>("/api/v1/economy/shop/items");
+  return response.items;
 }
 
-// Reserve → returns token + expiresAt
-export async function reserveShopItemApi(shopItemId: number): Promise<{
-  reservationToken: string;
-  expiresAt: string;
-}> {
-  if (USE_MOCK) {
-    return {
-      reservationToken: `mock-token-${shopItemId}-${Date.now()}`,
-      expiresAt: new Date(Date.now() + 5 * 60 * 1000).toISOString(),
-    };
-  }
-  const res = await apiPost<{ reservationToken: string; expiresAt: string }>(
-    "/api/v1/economy/shop/purchase",
-    { shopItemId, quantity: 1, reserveOnly: true, idempotencyKey: `reserve-${shopItemId}-${Date.now()}` },
-  );
-  return res;
+export async function getShopPurchasesApi(): Promise<ShopPurchaseSummary[]> {
+  const response: ShopPurchasesResponse = USE_MOCK
+    ? marketMock.shopPurchases()
+    : await apiGet<ShopPurchasesResponse>("/api/v1/economy/shop/purchases");
+  return response.purchases;
 }
 
-// Confirm purchase with reservation token
-export async function confirmShopPurchaseApi(reservationToken: string): Promise<{ purchaseId: number }> {
-  if (USE_MOCK) {
-    return { purchaseId: Date.now() };
-  }
-  const res = await apiPost<{ id: number }>("/api/v1/economy/shop/reservations/confirm", {
-    reservationToken,
-    idempotencyKey: `confirm-${Date.now()}`,
-  });
-  return { purchaseId: res.id };
+export function initiateShopPurchaseApi(request: ShopPurchaseRequest): Promise<ShopPurchaseId> {
+  return USE_MOCK
+    ? Promise.resolve(marketMock.initiateShopPurchase(request))
+    : apiPost<ShopPurchaseId>("/api/v1/economy/shop/purchase", request);
 }
 
-// Direct purchase (no reservation flow) — for items without stock limits
-export async function purchaseShopItemApi(shopItemId: number): Promise<{ purchaseId: number }> {
-  if (USE_MOCK) return { purchaseId: Date.now() };
-  const res = await apiPost<{ id: number }>("/api/v1/economy/shop/purchase", {
-    shopItemId,
-    quantity: 1,
-    reserveOnly: false,
-    idempotencyKey: `buy-${shopItemId}-${Date.now()}`,
-  });
-  return { purchaseId: res.id };
+export function confirmShopPurchaseApi(reservationToken: string, idempotencyKey: string): Promise<ShopReservation> {
+  return USE_MOCK
+    ? Promise.resolve(marketMock.confirmShopPurchase(reservationToken))
+    : apiPost<ShopReservation>("/api/v1/economy/shop/reservations/confirm", { reservationToken, idempotencyKey });
 }
 
 export async function getMyListingsApi(): Promise<ListingSummary[]> {
-  if (USE_MOCK) return MOCK_MY_LISTINGS;
-  const res = await apiGet<{ listings: ListingSummary[] }>("/api/v1/economy/listings/me");
-  return res.listings;
+  const response: ListingsResponse = USE_MOCK
+    ? marketMock.myListings()
+    : await apiGet<ListingsResponse>("/api/v1/economy/listings/me");
+  return response.listings;
 }
 
 export async function getOpenListingsApi(): Promise<ListingSummary[]> {
-  if (USE_MOCK) return MOCK_MY_LISTINGS;
-  const res = await apiGet<{ listings: ListingSummary[] }>("/api/v1/economy/listings");
-  return res.listings;
+  const response: ListingsResponse = USE_MOCK
+    ? marketMock.openListings()
+    : await apiGet<ListingsResponse>("/api/v1/economy/listings");
+  return response.listings;
 }
 
-export async function createListingApi(data: {
-  itemInstanceId: number;
-  itemId: number;
-  price: number;
-  currency?: string;
-}): Promise<{ listingId: number }> {
-  if (USE_MOCK) {
-    return { listingId: Date.now() };
-  }
-  const res = await apiPost<{ id: number }>("/api/v1/economy/listings", {
-    itemInstanceId: data.itemInstanceId,
-    itemId: data.itemId,
-    price: data.price,
-    currency: data.currency ?? "col",
-  });
-  return { listingId: res.id };
+export function createListingApi(request: OpenListingRequest): Promise<{ id: number }> {
+  return USE_MOCK
+    ? Promise.resolve(marketMock.createListing(request))
+    : apiPost<{ id: number }>("/api/v1/economy/listings", request);
 }
 
 export async function cancelListingApi(listingId: number): Promise<void> {
-  if (USE_MOCK) return;
-  await apiDelete(`/api/v1/economy/listings/${listingId}`);
+  if (USE_MOCK) return marketMock.cancelListing(listingId);
+  await apiDelete<void>(`/api/v1/economy/listings/${listingId}`);
 }
 
-// Reserve a marketplace listing before purchase
-export async function reserveListingApi(listingId: number): Promise<{
-  reservationToken: string;
-  holdId: string;
-  expiresAt: string;
-}> {
-  if (USE_MOCK) {
-    return {
-      reservationToken: `mock-listing-token-${listingId}-${Date.now()}`,
-      holdId: `hold-${Date.now()}`,
-      expiresAt: new Date(Date.now() + 5 * 60 * 1000).toISOString(),
-    };
-  }
-  return apiPost(`/api/v1/economy/listings/${listingId}/reserve`, { ttlSeconds: 300 });
+export function reserveListingApi(listingId: number, ttlSeconds: number): Promise<ListingReservation> {
+  return USE_MOCK
+    ? Promise.resolve(marketMock.reserveListing(listingId))
+    : apiPost<ListingReservation>(`/api/v1/economy/listings/${listingId}/reserve`, { ttlSeconds });
 }
 
-// Purchase a reserved listing
-export async function purchaseListingApi(listingId: number, reservationToken: string): Promise<{ tradeId: number }> {
-  if (USE_MOCK) {
-    return { tradeId: Date.now() };
-  }
-  const res = await apiPost<{ id: number }>(`/api/v1/economy/listings/${listingId}/purchase`, {
-    reservationToken,
-    idempotencyKey: `trade-${listingId}-${Date.now()}`,
-  });
-  return { tradeId: res.id };
+export function purchaseListingApi(listingId: number, reservationToken: string, idempotencyKey: string): Promise<TradeSummary> {
+  return USE_MOCK
+    ? Promise.resolve(marketMock.purchaseListing(listingId, reservationToken))
+    : apiPost<TradeSummary>(`/api/v1/economy/listings/${listingId}/purchase`, { reservationToken, idempotencyKey });
 }
 
-export async function getTradesApi(): Promise<
-  Array<TradeSummary & { partnerName: string; direction: "buy" | "sell" }>
-> {
-  if (USE_MOCK) {
-    return MOCK_TRADES.map((t) => ({
-      ...t,
-      direction: t.buyerId === 6 ? "buy" : "sell",
-      partnerName:
-        t.buyerId === 6
-          ? (TRADE_PARTNER_NAMES[t.sellerId] ?? `Player ${t.sellerId}`)
-          : (TRADE_PARTNER_NAMES[t.buyerId] ?? `Player ${t.buyerId}`),
-    }));
-  }
-  return apiGet("/api/v1/economy/trades");
+export async function getTradesApi(): Promise<TradeSummary[]> {
+  const response: TradesResponse = USE_MOCK
+    ? marketMock.trades()
+    : await apiGet<TradesResponse>("/api/v1/economy/trades");
+  return response.trades;
 }

--- a/lib/api/mock/market.mock.ts
+++ b/lib/api/mock/market.mock.ts
@@ -1,66 +1,120 @@
-import type { ListingSummary, ShopItem, TradeSummary, WalletBalance } from "../types";
+import type {
+  ListingReservation,
+  ListingSummary,
+  OpenListingRequest,
+  ShopItem,
+  ShopPurchaseId,
+  ShopPurchaseRequest,
+  ShopPurchaseSummary,
+  ShopReservation,
+  TradeSummary,
+  WalletBalance,
+} from "@/shared/api/types";
+import { inventoryMock } from "./inventory.mock";
 
-export const MOCK_WALLET: WalletBalance = {
-  amount: 284500,
-  currency: "col",
-};
-
-export const MOCK_SHOP_ITEMS: ShopItem[] = [
-  { id: 1, itemId: 1010, price: 45000, currency: "col", available: true, globalStockLimit: null, perPlayerLimit: 1, reservationTtlSec: 300 },
-  { id: 2, itemId: 1011, price: 28000, currency: "col", available: true, globalStockLimit: null, perPlayerLimit: 1, reservationTtlSec: 300 },
-  { id: 3, itemId: 2010, price: 62000, currency: "col", available: true, globalStockLimit: null, perPlayerLimit: 1, reservationTtlSec: 300 },
-  { id: 4, itemId: 3010, price: 2500, currency: "col", available: true, globalStockLimit: 1000, perPlayerLimit: 10, reservationTtlSec: 60 },
-  { id: 5, itemId: 3011, price: 1800, currency: "col", available: true, globalStockLimit: 2000, perPlayerLimit: 20, reservationTtlSec: 60 },
-  { id: 6, itemId: 4010, price: 8000, currency: "col", available: true, globalStockLimit: 200, perPlayerLimit: 3, reservationTtlSec: 120 },
-  { id: 7, itemId: 5010, price: 4200, currency: "col", available: false, globalStockLimit: null, perPlayerLimit: null, reservationTtlSec: null },
-  { id: 8, itemId: 5011, price: 18000, currency: "col", available: true, globalStockLimit: 50, perPlayerLimit: 5, reservationTtlSec: 180 },
-  { id: 9, itemId: 6010, price: 6500, currency: "col", available: true, globalStockLimit: null, perPlayerLimit: 3, reservationTtlSec: 120 },
-  { id: 10, itemId: 7010, price: 32000, currency: "col", available: true, globalStockLimit: null, perPlayerLimit: 1, reservationTtlSec: 300 },
-  { id: 11, itemId: 1012, price: 15000, currency: "col", available: true, globalStockLimit: null, perPlayerLimit: 2, reservationTtlSec: 300 },
-  { id: 12, itemId: 3012, price: 3200, currency: "col", available: true, globalStockLimit: 500, perPlayerLimit: 10, reservationTtlSec: 60 },
+const INITIAL_WALLET: WalletBalance = { amount: 284_500, currency: "GOLD" };
+const INITIAL_SHOP_ITEMS: ShopItem[] = [
+  { id: 1, itemId: 1010, price: 45_000, currency: "GOLD", available: true, globalStockLimit: null, perPlayerLimit: 1, reservationTtlSec: 300 },
+  { id: 2, itemId: 3010, price: 25, currency: "GEM", available: true, globalStockLimit: 1_000, perPlayerLimit: 10, reservationTtlSec: 60 },
+  { id: 3, itemId: 5010, price: 4_200, currency: "GOLD", available: false, globalStockLimit: null, perPlayerLimit: null, reservationTtlSec: null },
+];
+const INITIAL_MY_LISTINGS: ListingSummary[] = [
+  { id: 101, itemId: 1003, sellerId: 7, price: 35_000, currency: "GOLD", status: "OPEN" },
+  { id: 102, itemId: 5002, sellerId: 7, price: 85, currency: "GEM", status: "OPEN" },
+];
+const INITIAL_OPEN_LISTINGS: ListingSummary[] = [
+  ...INITIAL_MY_LISTINGS,
+  { id: 201, itemId: 3011, sellerId: 24, price: 1_800, currency: "GOLD", status: "OPEN" },
+  { id: 202, itemId: 7010, sellerId: 37, price: 32, currency: "GEM", status: "OPEN" },
+];
+const INITIAL_TRADES: TradeSummary[] = [
+  { id: 301, listingId: 88, buyerId: 7, sellerId: 24, price: 28_000, currency: "GOLD" },
+  { id: 302, listingId: 56, buyerId: 13, sellerId: 7, price: 45, currency: "GEM" },
 ];
 
-// Item name mapping for shop display
-export const SHOP_ITEM_NAMES: Record<number, { name: string; category: string; rarity: string }> = {
-  1010: { name: "Liberator Sword", category: "Weapon", rarity: "Epic" },
-  1011: { name: "Night Sky Blade", category: "Weapon", rarity: "Rare" },
-  2010: { name: "Crystalline Breastplate", category: "Armor", rarity: "Epic" },
-  3010: { name: "HP Potion (L)", category: "Consumable", rarity: "Uncommon" },
-  3011: { name: "MP Potion (M)", category: "Consumable", rarity: "Common" },
-  4010: { name: "Floor Teleport Crystal", category: "Consumable", rarity: "Uncommon" },
-  5010: { name: "Orichalcum Ore", category: "Material", rarity: "Legendary" },
-  5011: { name: "Mithril Plate", category: "Material", rarity: "Rare" },
-  6010: { name: "Enchantment Scroll (ATK)", category: "Scroll", rarity: "Uncommon" },
-  7010: { name: "Shadow Cloak", category: "Armor", rarity: "Epic" },
-  1012: { name: "Steel Broadsword", category: "Weapon", rarity: "Uncommon" },
-  3012: { name: "Stamina Boost Potion", category: "Consumable", rarity: "Common" },
-};
+let wallet = INITIAL_WALLET;
+let shopItems = structuredClone(INITIAL_SHOP_ITEMS);
+let myListings = structuredClone(INITIAL_MY_LISTINGS);
+let openListings = structuredClone(INITIAL_OPEN_LISTINGS);
+let purchases: ShopPurchaseSummary[] = [];
+let trades = structuredClone(INITIAL_TRADES);
+let nextId = 1_000;
 
-export const MOCK_MY_LISTINGS: ListingSummary[] = [
-  { id: 101, itemId: 1003, sellerId: 6, price: 35000, currency: "col", status: "ACTIVE" },
-  { id: 102, itemId: 5002, sellerId: 6, price: 8500, currency: "col", status: "ACTIVE" },
-  { id: 103, itemId: 3001, sellerId: 6, price: 1200, currency: "col", status: "ACTIVE" },
-  { id: 104, itemId: 7001, sellerId: 6, price: 12000, currency: "col", status: "RESERVED" },
-  { id: 105, itemId: 5003, sellerId: 6, price: 55000, currency: "col", status: "ACTIVE" },
-];
+const copy = <T,>(value: T): T => structuredClone(value);
 
-export const MOCK_TRADES: TradeSummary[] = [
-  { id: 201, listingId: 88, buyerId: 6, sellerId: 24, price: 28000, currency: "col" },
-  { id: 202, listingId: 56, buyerId: 6, sellerId: 37, price: 4500, currency: "col" },
-  { id: 203, listingId: 91, buyerId: 13, sellerId: 6, price: 9000, currency: "col" },
-  { id: 204, listingId: 72, buyerId: 6, sellerId: 51, price: 62000, currency: "col" },
-  { id: 205, listingId: 103, buyerId: 7, sellerId: 6, price: 35000, currency: "col" },
-  { id: 206, listingId: 44, buyerId: 6, sellerId: 18, price: 1800, currency: "col" },
-  { id: 207, listingId: 118, buyerId: 6, sellerId: 63, price: 14500, currency: "col" },
-];
-
-// Partner name mapping for trades
-export const TRADE_PARTNER_NAMES: Record<number, string> = {
-  24: "Agil",
-  37: "Argo",
-  51: "Lisbeth",
-  63: "Sachi",
-  18: "Thinker",
-  7: "Asuna",
-  13: "Klein",
+export const marketMock = {
+  reset() {
+    wallet = INITIAL_WALLET;
+    shopItems = copy(INITIAL_SHOP_ITEMS);
+    myListings = copy(INITIAL_MY_LISTINGS);
+    openListings = copy(INITIAL_OPEN_LISTINGS);
+    purchases = [];
+    trades = copy(INITIAL_TRADES);
+    nextId = 1_000;
+  },
+  wallet: () => copy(wallet),
+  shopItems: () => ({ items: copy(shopItems) }),
+  shopPurchases: () => ({ purchases: copy(purchases) }),
+  myListings: () => ({ listings: copy(myListings) }),
+  openListings: () => ({ listings: copy(openListings) }),
+  trades: () => ({ trades: copy(trades) }),
+  initiateShopPurchase(request: ShopPurchaseRequest): ShopPurchaseId {
+    const shopItem = shopItems.find((item) => item.id === request.shopItemId);
+    if (!shopItem?.available) throw new Error("Shop item is unavailable.");
+    const id = nextId++;
+    const ttl = shopItem.reservationTtlSec;
+    purchases.unshift({
+      id,
+      shopItemId: request.shopItemId,
+      quantity: request.quantity,
+      status: request.reserveOnly ? "RESERVED" : "COMPLETED",
+      reservationToken: request.reserveOnly ? `shop-reservation-${id}` : null,
+      reservationExpiresAt: request.reserveOnly
+        ? new Date(Date.now() + (ttl ?? 300) * 1_000).toISOString()
+        : null,
+    });
+    return { id };
+  },
+  confirmShopPurchase(reservationToken: string): ShopReservation {
+    const purchase = purchases.find((candidate) => candidate.reservationToken === reservationToken);
+    if (!purchase) throw new Error("Reservation not found.");
+    purchase.status = "COMPLETED";
+    return { reservationToken, expiresAt: purchase.reservationExpiresAt ?? new Date().toISOString() };
+  },
+  createListing(request: OpenListingRequest) {
+    const inventoryEntry = inventoryMock.inventory().entries.find((entry) => entry.itemInstanceId === request.inventoryEntryId);
+    if (!inventoryEntry || inventoryEntry.bound) throw new Error("Inventory entry is unavailable for listing.");
+    const listing: ListingSummary = {
+      id: nextId++,
+      itemId: inventoryEntry.itemId,
+      sellerId: 7,
+      price: request.price,
+      currency: request.currency,
+      status: "OPEN",
+    };
+    myListings.unshift(listing);
+    openListings.unshift(listing);
+    return { id: listing.id };
+  },
+  cancelListing(listingId: number) {
+    myListings = myListings.map((listing) => listing.id === listingId ? { ...listing, status: "CANCELED" } : listing);
+    openListings = openListings.filter((listing) => listing.id !== listingId);
+  },
+  reserveListing(listingId: number): ListingReservation {
+    if (!openListings.some((listing) => listing.id === listingId)) throw new Error("Listing not found.");
+    return {
+      reservationToken: `listing-reservation-${listingId}`,
+      holdId: `hold-${listingId}`,
+      expiresAt: new Date(Date.now() + 300_000).toISOString(),
+    };
+  },
+  purchaseListing(listingId: number, reservationToken: string): TradeSummary {
+    if (reservationToken !== `listing-reservation-${listingId}`) throw new Error("Reservation not found.");
+    const listing = openListings.find((candidate) => candidate.id === listingId);
+    if (!listing) throw new Error("Listing not found.");
+    const trade: TradeSummary = { id: nextId++, listingId, buyerId: 7, sellerId: listing.sellerId, price: listing.price, currency: listing.currency };
+    trades.unshift(trade);
+    openListings = openListings.filter((candidate) => candidate.id !== listingId);
+    return copy(trade);
+  },
 };

--- a/shared/api/types/economy.ts
+++ b/shared/api/types/economy.ts
@@ -1,6 +1,14 @@
+export type EconomyCurrency = "GOLD" | "GEM";
+
 export interface WalletBalance {
   amount: number;
-  currency: string;
+  currency: EconomyCurrency;
+}
+
+export interface OpenListingRequest {
+  inventoryEntryId: number;
+  price: number;
+  currency: EconomyCurrency;
 }
 
 export interface ListingSummary {
@@ -8,7 +16,7 @@ export interface ListingSummary {
   itemId: number;
   sellerId: number;
   price: number;
-  currency: string;
+  currency: EconomyCurrency;
   status: string;
 }
 
@@ -16,7 +24,7 @@ export interface ShopItem {
   id: number;
   itemId: number;
   price: number;
-  currency: string;
+  currency: EconomyCurrency;
   available: boolean;
   globalStockLimit: number | null;
   perPlayerLimit: number | null;
@@ -29,5 +37,48 @@ export interface TradeSummary {
   buyerId: number;
   sellerId: number;
   price: number;
-  currency: string;
+  currency: EconomyCurrency;
+}
+
+export interface ListingsResponse {
+  listings: ListingSummary[];
+}
+
+export interface TradesResponse {
+  trades: TradeSummary[];
+}
+
+export interface ShopPurchaseRequest {
+  shopItemId: number;
+  quantity: number;
+  reserveOnly: boolean;
+  idempotencyKey: string;
+}
+
+export interface ShopPurchaseId {
+  id: number;
+}
+
+export interface ShopPurchaseSummary {
+  id: number;
+  shopItemId: number;
+  quantity: number;
+  status: string;
+  reservationToken: string | null;
+  reservationExpiresAt: string | null;
+}
+
+export interface ShopPurchasesResponse {
+  purchases: ShopPurchaseSummary[];
+}
+
+export interface ShopReservation {
+  reservationToken: string;
+  expiresAt: string;
+}
+
+export interface ListingReservation {
+  reservationToken: string;
+  holdId: string;
+  expiresAt: string;
 }


### PR DESCRIPTION
## Purpose

Replace the remaining mock-driven Market panels with feature-owned Exchange surfaces backed by the current Economy and Inventory contracts.

Closes #68

## Delivered

- canonical frontend Economy DTO/API alignment
- GOLD/GEM currency alignment
- feature-owned Exchange shell/query state
- real Wallet surface
- real System Shop surface
- canonical shop purchase/reservation handling
- real Marketplace open listings
- real My Listings
- PD-01 whole-entry listing creation
- canonical listing reserve/purchase flow
- real Trade history
- removal of fake friend-trade runtime UI
- removal of generated Market presentation dependencies
- desktop/mobile dual-theme Exchange hierarchy

## Product Placement

The internal navigation key remains `market` to avoid an unrelated routing migration.

The user-facing navigation label is aligned to:

```text
Exchange
```

Global OrbNav geometry and stage-camera behavior are unchanged.

## Contract Alignment

Frontend Economy contracts now follow the current backend API.

Currency:

```text
GOLD
GEM
```

Wallet:

```text
amount
currency
```

Open Listing request:

```text
inventoryEntryId
price
currency
```

Listing summary:

```text
id
itemId
sellerId
price
currency
status
```

Trade history uses the canonical `{ trades }` wrapper.

Legacy request fields and currency fallbacks are not used.

## Wallet

Wallet renders the real balance returned by the Economy API.

No synthetic transaction history, monthly totals, or unsupported balance splits are introduced.

## System Shop

Shop items come from the canonical Economy endpoint.

The UI does not rely on static mock item-name/category/rarity enrichment.

Purchase initiation handles the backend purchase-id response correctly.

Reserved purchases recover their canonical reservation state/token through real purchase history before explicit confirmation.

## Marketplace

Open listings come from the real Economy endpoint.

Purchase remains an explicit two-step reservation/purchase flow using the canonical reservation token.

Self-purchase is not offered in the UI, while the backend remains final correctness authority.

## My Listings

Listing creation starts from a real InventoryEntry.

PD-01 remains enforced in the UI:

- whole InventoryEntry
- whole stack
- total entry price
- no quantity input
- no unit price
- no partial listing

The selected Inventory entry id is mapped into the backend `inventoryEntryId` request field.

## Trade

The previous fake friend/barter trade presentation is removed.

Trade uses canonical Economy trade history.

Bought/Sold direction is derived from authenticated player participation without inventing friend names or unsupported item metadata.

## Feature Ownership

Economy query/mutation orchestration is moved out of `app/page.tsx` and into `features/market` ownership.

The app page retains composition/navigation responsibility.

## Design Translation

Approved dual-theme Economy references are used for material hierarchy, spacing, density, and staged depth only.

Illustrative personal-finance concepts from the design boards are not implemented because they are not part of the current Exchange backend domain.

## Responsive / Accessibility

Desktop respects the maximum three visible panel depths.

Mobile preserves one-screen-one-purpose navigation and the fixed bottom OrbNav.

Existing global camera tuning is not reopened.

## Scope Boundaries

This PR does not add:

- backend endpoints
- wallet transaction history
- direct friend trade
- partial-stack marketplace listing
- personal-finance/LifePlan features
- Settings/System polish
- global camera changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Exchange screens for wallet balances, system-shop purchases, marketplace listings, and trade history.
  * Added listing creation, cancellation, reservations, purchases, and recovery states.
  * Added loading, retry, empty, unavailable, and error feedback states.
* **UI Updates**
  * Renamed Market to Exchange.
  * Added responsive desktop and mobile layouts.
  * Standardized currency displays to GOLD and GEM.
* **Bug Fixes**
  * Improved data refresh, purchase confirmation, and recovery after Exchange operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->