### PR TITLE
[UI] Polish Home and Settings surfaces

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -137,6 +137,8 @@ body {
 .lag-home-surface,
 .lag-home-card,
 .lag-settings-control,
+.lag-settings-theme,
+.lag-settings-group,
 .lag-button-primary,
 .lag-button-secondary,
 .lag-panel-card,
@@ -243,7 +245,10 @@ body {
 }
 
 .lag-home {
+  display: grid;
+  width: min(1180px, calc(100vw - 48px));
   min-width: 0;
+  gap: var(--lag-space-4);
 }
 
 .lag-home-surface {
@@ -254,7 +259,105 @@ body {
 }
 
 .lag-home-hero {
+  display: flex;
+  min-height: 148px;
+  align-items: end;
+  justify-content: space-between;
+  gap: var(--lag-space-6);
+  padding: var(--lag-space-6);
+  background:
+    linear-gradient(115deg, color-mix(in srgb, var(--lag-cyan) 12%, var(--lag-panel)), var(--lag-panel) 58%);
   border-left: 4px solid var(--lag-cyan);
+}
+
+.lag-home-eyebrow {
+  margin-bottom: var(--lag-space-2);
+  color: var(--lag-state-info);
+  font-size: 0.72rem;
+  font-weight: 750;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.lag-home-hero h1 {
+  color: var(--lag-text);
+  font-size: clamp(1.65rem, 3vw, 2.35rem);
+  font-weight: 720;
+  letter-spacing: -0.025em;
+}
+
+.lag-home-intro {
+  max-width: 620px;
+  margin-top: var(--lag-space-2);
+  color: var(--lag-text-2);
+  font-size: 0.9rem;
+  line-height: 1.55;
+}
+
+.lag-home-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.18fr) minmax(300px, 0.82fr);
+  gap: var(--lag-space-4);
+  align-items: start;
+}
+
+.lag-home-section {
+  display: grid;
+  min-width: 0;
+  gap: var(--lag-space-3);
+  padding: var(--lag-space-4);
+}
+
+.lag-home-section-journal {
+  grid-row: span 2;
+  border-top: 3px solid var(--lag-cyan);
+}
+
+.lag-home-section-journey {
+  border-top: 3px solid var(--lag-violet);
+}
+
+.lag-home-section-achievements {
+  border-top: 3px solid var(--lag-amber);
+}
+
+.lag-home-section-roles {
+  grid-column: 1 / -1;
+  border-top: 3px solid var(--lag-success);
+}
+
+.lag-home-section-header,
+.lag-home-subsection-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--lag-space-3);
+}
+
+.lag-home-section-header h2 {
+  color: var(--lag-text);
+  font-size: 0.92rem;
+  font-weight: 750;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.lag-home-subsection-header h3 {
+  color: var(--lag-text-2);
+  font-size: 0.75rem;
+  font-weight: 750;
+  letter-spacing: 0.06em;
+}
+
+.lag-home-list,
+.lag-home-journey-block {
+  display: grid;
+  gap: var(--lag-space-2);
+}
+
+.lag-home-journey-block + .lag-home-journey-block {
+  padding-top: var(--lag-space-3);
+  border-top: 1px solid var(--lag-divider);
 }
 
 .lag-home-card {
@@ -263,6 +366,90 @@ body {
 
 .lag-home-card:hover {
   border-color: var(--lag-focus);
+  background-color: var(--lag-control-hover-bg);
+}
+
+.lag-home-entry {
+  display: grid;
+  width: 100%;
+  min-height: 48px;
+  gap: var(--lag-space-1);
+  padding: var(--lag-space-3);
+  text-align: left;
+}
+
+.lag-home-entry-title {
+  color: var(--lag-text);
+  font-size: 0.88rem;
+  font-weight: 700;
+  line-height: 1.35;
+}
+
+.lag-home-description {
+  display: -webkit-box;
+  overflow: hidden;
+  color: var(--lag-text-2);
+  font-size: 0.75rem;
+  line-height: 1.45;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.lag-home-meta,
+.lag-home-empty {
+  color: var(--lag-text-2);
+  font-size: 0.75rem;
+  line-height: 1.45;
+}
+
+.lag-home-empty {
+  padding-block: var(--lag-space-2);
+}
+
+.lag-home-action {
+  min-height: 40px;
+  padding: var(--lag-space-2) var(--lag-space-3);
+  font-size: 0.72rem;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.lag-home-role-summary,
+.lag-home-role-list {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--lag-space-2);
+}
+
+.lag-home-role-summary > div {
+  padding: var(--lag-space-3);
+  background: var(--lag-muted-surface);
+  border: 1px solid var(--lag-divider);
+  border-radius: var(--lag-radius-sm);
+}
+
+.lag-home-role-summary dt {
+  color: var(--lag-text-2);
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.lag-home-role-summary dd {
+  margin-top: var(--lag-space-1);
+  color: var(--lag-text);
+  font-size: 1.2rem;
+  font-weight: 750;
+}
+
+.lag-home-error {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--lag-space-4);
+  padding: var(--lag-space-4);
+  border-left: 4px solid var(--lag-state-error);
 }
 
 .lag-text-primary {
@@ -2786,11 +2973,48 @@ body {
   }
 }
 
+@media (max-width: 980px) {
+  .lag-home-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .lag-home-section-journal,
+  .lag-home-section-roles {
+    grid-row: auto;
+    grid-column: auto;
+  }
+}
+
 .lag-settings-shell .lag-panel-frame {
-  width: min(560px, calc(100vw - 32px)) !important;
+  width: min(760px, calc(100vw - 32px)) !important;
+}
+
+.lag-settings-surface {
+  display: grid;
+  gap: var(--lag-space-4);
+  padding-inline: var(--lag-space-4);
+}
+
+.lag-settings-state {
+  padding: var(--lag-space-4);
+  background: var(--lag-muted-surface);
+  border: 1px solid var(--lag-divider);
+  border-radius: var(--lag-radius-sm);
+  color: var(--lag-text-2);
+  font-size: 0.8rem;
+}
+
+.lag-settings-state-error {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--lag-space-3);
+  border-left: 4px solid var(--lag-state-error);
 }
 
 .lag-settings-label {
+  display: grid;
+  gap: var(--lag-space-2);
   color: var(--lag-text-2);
   font-size: 0.68rem;
   font-weight: 700;
@@ -2798,16 +3022,46 @@ body {
   text-transform: uppercase;
 }
 
+.lag-settings-theme,
+.lag-settings-preferences,
+.lag-settings-form {
+  display: grid;
+  gap: var(--lag-space-4);
+}
+
+.lag-settings-theme {
+  padding: var(--lag-space-4);
+  background: var(--lag-raised-surface);
+  border: 1px solid var(--lag-border);
+  border-top: 3px solid var(--lag-cyan);
+  border-radius: var(--lag-radius-md);
+}
+
+.lag-settings-theme > legend,
+.lag-settings-group > legend,
+.lag-settings-group > h3,
+.lag-settings-section-header h2 {
+  color: var(--lag-text);
+  font-weight: 750;
+}
+
+.lag-settings-theme > legend {
+  padding-inline: var(--lag-space-2);
+  font-size: 0.92rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
 .lag-theme-picker {
   display: grid;
   gap: var(--lag-space-3);
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
 .lag-theme-option {
   position: relative;
   display: grid;
-  min-height: 132px;
+  min-height: 142px;
   gap: var(--lag-space-2);
   padding: var(--lag-space-4);
   background-color: var(--lag-panel-2);
@@ -2817,6 +3071,16 @@ body {
   cursor: pointer;
 }
 
+.lag-theme-option > strong {
+  padding-right: var(--lag-space-6);
+  font-size: 0.82rem;
+}
+
+.lag-theme-option > .lag-text-meta {
+  font-size: 0.72rem;
+  line-height: 1.45;
+}
+
 .lag-theme-option:has(input:checked) {
   background-color: color-mix(in srgb, var(--lag-focus) 9%, var(--lag-panel));
   border: 2px solid var(--lag-focus);
@@ -2824,8 +3088,7 @@ body {
 }
 
 .lag-theme-option-system {
-  min-height: 72px;
-  grid-column: 1 / -1;
+  min-height: 142px;
 }
 
 .lag-theme-option input {
@@ -2846,6 +3109,19 @@ body {
   margin-top: auto;
 }
 
+.lag-theme-current {
+  width: fit-content;
+  padding: var(--lag-space-1) var(--lag-space-2);
+  background: var(--lag-selected-surface);
+  border: 1px solid var(--lag-state-selected);
+  border-radius: 999px;
+  color: var(--lag-text);
+  font-size: 0.65rem;
+  font-weight: 750;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
 .lag-theme-swatch {
   width: 22px;
   height: 22px;
@@ -2861,12 +3137,117 @@ body {
 
 .lag-theme-preview {
   display: grid;
-  min-height: 112px;
+  min-height: 88px;
   place-items: center;
   background-color: var(--lag-workspace);
   border: 1px solid var(--lag-border);
   border-radius: var(--lag-radius-md);
   color: var(--lag-text);
+}
+
+.lag-theme-preview > div {
+  display: grid;
+  gap: var(--lag-space-1);
+  text-align: center;
+}
+
+.lag-theme-preview strong {
+  font-size: 0.82rem;
+}
+
+.lag-theme-preview span,
+.lag-settings-group-description,
+.lag-settings-section-header p,
+.lag-settings-pending {
+  color: var(--lag-text-2);
+  font-size: 0.74rem;
+  line-height: 1.5;
+}
+
+.lag-settings-pending {
+  color: var(--lag-state-pending);
+}
+
+.lag-settings-section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--lag-space-4);
+}
+
+.lag-settings-section-header h2 {
+  font-size: 1rem;
+}
+
+.lag-settings-group-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--lag-space-3);
+}
+
+.lag-settings-group {
+  display: grid;
+  min-width: 0;
+  align-content: start;
+  gap: var(--lag-space-2);
+  padding: var(--lag-space-4);
+  background: var(--lag-muted-surface);
+  border: 1px solid var(--lag-divider);
+  border-radius: var(--lag-radius-md);
+}
+
+.lag-settings-group > legend,
+.lag-settings-group > h3 {
+  padding-inline: var(--lag-space-1);
+  font-size: 0.82rem;
+  letter-spacing: 0.04em;
+}
+
+.lag-settings-values,
+.lag-settings-fields {
+  display: grid;
+  gap: var(--lag-space-2);
+  margin-top: var(--lag-space-1);
+}
+
+.lag-settings-values > div {
+  display: flex;
+  min-height: 40px;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--lag-space-3);
+  padding-block: var(--lag-space-2);
+  border-top: 1px solid var(--lag-divider);
+}
+
+.lag-settings-values dt {
+  color: var(--lag-text-2);
+  font-size: 0.74rem;
+}
+
+.lag-settings-values dd {
+  color: var(--lag-text);
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-align: right;
+}
+
+.lag-settings-button {
+  min-height: 40px;
+  padding: var(--lag-space-2) var(--lag-space-3);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+
+.lag-settings-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--lag-space-2);
+  position: sticky;
+  bottom: 0;
+  padding-block: var(--lag-space-3);
+  background: var(--lag-panel);
 }
 
 /* v7 Journal / Quick Record: shared semantic anatomy, theme tokens supply material. */
@@ -3803,9 +4184,45 @@ textarea.lag-journal-control {
     overflow: visible !important;
   }
 
+  .lag-home {
+    width: clamp(280px, calc(100vw - 32px), 344px);
+  }
+
   .lag-home-grid,
-  .lag-theme-picker {
+  .lag-theme-picker,
+  .lag-settings-group-grid {
     grid-template-columns: 1fr;
+  }
+
+  .lag-home-hero {
+    min-height: 0;
+    align-items: start;
+    flex-direction: column;
+    padding: var(--lag-space-4);
+  }
+
+  .lag-home-section,
+  .lag-settings-theme,
+  .lag-settings-group {
+    padding: var(--lag-space-3);
+  }
+
+  .lag-home-section-header,
+  .lag-home-subsection-header,
+  .lag-settings-section-header,
+  .lag-settings-state-error {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .lag-home-action,
+  .lag-settings-button {
+    width: 100%;
+  }
+
+  .lag-home-role-summary,
+  .lag-home-role-list {
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .lag-theme-option-system {
@@ -3818,6 +4235,19 @@ textarea.lag-journal-control {
 
   .lag-settings-shell {
     width: auto;
+  }
+
+  .lag-settings-shell .lag-panel-frame {
+    width: clamp(280px, calc(100vw - 32px), 344px) !important;
+  }
+
+  .lag-settings-surface {
+    padding-inline: var(--lag-space-3);
+  }
+
+  .lag-settings-actions {
+    align-items: stretch;
+    flex-direction: column;
   }
 
   .lag-journal-shell [data-stage-key="lifelog-journal"] .lag-panel-frame,
@@ -4170,6 +4600,8 @@ textarea.lag-journal-control {
   .lag-home-surface,
   .lag-home-card,
   .lag-settings-control,
+  .lag-settings-theme,
+  .lag-settings-group,
   .lag-button-primary,
   .lag-button-secondary,
   .lag-panel-card,

--- a/features/home/HomeShell.test.tsx
+++ b/features/home/HomeShell.test.tsx
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -37,15 +38,19 @@ describe("Home world summary를 표시할 때", () => {
       expect(screen.getByText("Begin with Records")).toBeInTheDocument();
       expect(screen.getByText("Build a Recovery Rhythm")).toBeInTheDocument();
       expect(screen.getByText("5 records · 62.5%")).toBeInTheDocument();
-      expect(screen.getByText("Assigned 8 · Unassigned 2 · Total 10")).toBeInTheDocument();
+      expect(screen.getByText("Assigned").closest("div")).toHaveTextContent("8");
+      expect(screen.getByText("Unassigned").closest("div")).toHaveTextContent("2");
+      expect(screen.getByText("Total records").closest("div")).toHaveTextContent("10");
+      expect(screen.getByRole("button", { name: /Begin with Records/ })).not.toHaveTextContent("%");
+      expect(screen.getByTestId("home-shell")).not.toHaveTextContent(/streak|life score|productivity score|\bXP\b/i);
     });
 
-    it("nullable metadata를 가짜 값 없이 생략하고 nullable Role name에는 실제 ID를 쓴다", () => {
+    it("nullable metadata와 raw relationship ID를 primary copy로 노출하지 않는다", () => {
       render(<HomeShell {...callbacks} />);
 
-      expect(screen.getByText("Role #32")).toBeInTheDocument();
+      expect(screen.getByText("Unnamed Role")).toBeInTheDocument();
       expect(screen.getByTestId("home-shell")).not.toHaveTextContent(/null|undefined|not recorded/i);
-      expect(screen.getByText("Build a Recovery Rhythm").closest("button")).not.toHaveTextContent("Current Step");
+      expect(screen.getByTestId("home-shell")).not.toHaveTextContent(/Role #|Event #|Current Step #/);
     });
 
     it("cards를 canonical feature callback에만 연결한다", () => {
@@ -192,5 +197,14 @@ describe("Home world summary를 표시할 때", () => {
       fireEvent.click(screen.getByRole("button", { name: "Retry" }));
       expect(query.state.reload).toHaveBeenCalledOnce();
     });
+  });
+
+  it("semantic CSS로 compact dashboard를 한 열에 쌓고 Home inline style을 두지 않는다", () => {
+    const source = readFileSync("features/home/HomeShell.tsx", "utf8");
+    const css = readFileSync("app/globals.css", "utf8");
+
+    expect(source).not.toContain("style=");
+    expect(css).toMatch(/@media \(max-width: 980px\)[\s\S]*?\.lag-home-grid\s*\{[\s\S]*?grid-template-columns: minmax\(0, 1fr\)/);
+    expect(css).toMatch(/@media \(max-width: 767px\)[\s\S]*?\.lag-home-role-summary,[\s\S]*?grid-template-columns: minmax\(0, 1fr\)/);
   });
 });

--- a/features/home/HomeShell.tsx
+++ b/features/home/HomeShell.tsx
@@ -13,27 +13,18 @@ type HomeShellProps = {
   onOpenRole: (roleId: number) => void;
 };
 
-const buttonStyle = {
-  borderRadius: "var(--lag-radius-sm)",
-} as const;
-
-const retryStyle = {
-  ...buttonStyle,
-  padding: "7px 12px",
-  fontSize: "0.72rem",
-} as const;
-
-function WorldSection({ title, actionLabel, onOpen, children }: {
+function WorldSection({ title, actionLabel, onOpen, className = "", children }: {
   title: string;
   actionLabel: string;
   onOpen?: () => void;
+  className?: string;
   children: ReactNode;
 }) {
   return (
-    <section className="lag-home-surface min-w-0 space-y-3 p-4">
-      <div className="flex items-center justify-between gap-3">
-        <h2 className="lag-text-primary text-sm font-semibold tracking-[0.12em]">{title}</h2>
-        {onOpen ? <button type="button" className="lag-button-secondary" style={retryStyle} onClick={onOpen}>{actionLabel}</button> : null}
+    <section className={`lag-home-surface lag-home-section ${className}`}>
+      <div className="lag-home-section-header">
+        <h2>{title}</h2>
+        {onOpen ? <button type="button" className="lag-button-secondary lag-home-action" onClick={onOpen}>{actionLabel}</button> : null}
       </div>
       {children}
     </section>
@@ -41,11 +32,11 @@ function WorldSection({ title, actionLabel, onOpen, children }: {
 }
 
 function Empty({ children }: { children: ReactNode }) {
-  return <p className="lag-text-meta text-sm">{children}</p>;
+  return <p className="lag-home-empty">{children}</p>;
 }
 
 function Meta({ children }: { children: ReactNode }) {
-  return <p className="lag-text-meta text-xs">{children}</p>;
+  return <p className="lag-home-meta">{children}</p>;
 }
 
 function journalPreview(entry: HomeJournalEntry) {
@@ -88,9 +79,9 @@ function journalPreview(entry: HomeJournalEntry) {
 
 function HomeError({ message, retry }: { message: string; retry: () => void }) {
   return (
-    <div className="lag-home-surface flex items-center justify-between gap-4 border-l-4 p-4" style={{ borderLeftColor: "var(--lag-state-error)" }}>
+    <div className="lag-home-surface lag-home-error">
       <p role="alert" className="lag-state-error text-sm">Error: {message}</p>
-      <button type="button" className="lag-button-secondary" style={retryStyle} onClick={retry}>Retry</button>
+      <button type="button" className="lag-button-secondary lag-home-action" onClick={retry}>Retry</button>
     </div>
   );
 }
@@ -111,33 +102,34 @@ export default function HomeShell({
   if (!data) return null;
 
   return (
-    <div className="lag-home w-full max-w-[1200px] space-y-4" data-testid="home-shell">
-      <header className="lag-home-surface lag-home-hero px-5 py-4">
-        <p className="lag-text-meta text-xs tracking-[0.18em]">AUTHENTICATED WORLD</p>
-        <h1 className="lag-text-primary mt-1 text-xl font-semibold">Home</h1>
-        <Meta>Generated <time dateTime={data.generatedAt}>{data.generatedAt}</time>{home.loading ? " · Refreshing" : ""}</Meta>
+    <div className="lag-home" data-testid="home-shell">
+      <header className="lag-home-surface lag-home-hero">
+        <div>
+          <p className="lag-home-eyebrow">World overview</p>
+          <h1>Home</h1>
+          <p className="lag-home-intro">Recent records, active journeys, and the roles shaping your world.</p>
+        </div>
+        <Meta>Updated <time dateTime={data.generatedAt}>{data.generatedAt}</time>{home.loading ? " · Refreshing" : ""}</Meta>
       </header>
 
       {home.error ? <HomeError message={home.error} retry={() => void home.reload()} /> : null}
 
-      <div className="lag-home-grid grid grid-cols-2 gap-4">
-        <WorldSection title="Recent Journal" actionLabel="Open Journal" onOpen={onOpenJournal}>
+      <div className="lag-home-grid">
+        <WorldSection title="Recent Journal" actionLabel="Open Journal" onOpen={onOpenJournal} className="lag-home-section-journal">
           {data.recentJournal.length === 0 ? <Empty>No recent Journal entries.</Empty> : (
-            <div className="space-y-2">
+            <div className="lag-home-list">
               {data.recentJournal.map((entry) => {
                 const preview = journalPreview(entry);
                 const metadata = [
                   entry.sourceType,
                   entry.entryMode === "QUICK" ? "QUICK" : entry.entryMode,
                   entry.subtype,
-                  entry.primaryRoleId === null ? null : `Role #${entry.primaryRoleId}`,
-                  entry.roleEventId === null ? null : `Event #${entry.roleEventId}`,
                 ].filter((value): value is string => value !== null);
                 return (
-                  <button key={entry.lifeLogId} type="button" className="lag-home-card block w-full p-3 text-left" style={buttonStyle} onClick={onOpenJournal}>
-                    <p className="text-sm font-semibold">{preview.title}</p>
+                  <button key={entry.lifeLogId} type="button" className="lag-home-card lag-home-entry" onClick={onOpenJournal}>
+                    <p className="lag-home-entry-title">{preview.title}</p>
                     <Meta>{preview.detail.filter((value): value is string => value !== null).join(" · ")}</Meta>
-                    <Meta>{metadata.join(" · ")}</Meta>
+                    {metadata.length > 0 ? <Meta>{metadata.join(" · ")}</Meta> : null}
                     <Meta><time dateTime={entry.recordedAt}>{entry.recordedAt}</time></Meta>
                   </button>
                 );
@@ -146,46 +138,33 @@ export default function HomeShell({
           )}
         </WorldSection>
 
-        <WorldSection title="Recent Achievements" actionLabel="Open Achievements" onOpen={onOpenAchievements}>
-          {data.recentAchievements.length === 0 ? <Empty>No recent Achievements.</Empty> : (
-            <div className="space-y-2">
-              {data.recentAchievements.map((achievement) => (
-                <button key={achievement.achievementId} type="button" className="lag-home-card block w-full p-3 text-left" style={buttonStyle} onClick={onOpenAchievements}>
-                  <p className="text-sm font-semibold">{achievement.name}</p>
-                  <Meta>{achievement.category}</Meta>
-                  <p className="lag-text-secondary line-clamp-2 text-xs">{achievement.descMd}</p>
-                  <Meta><time dateTime={achievement.acquiredAt}>{achievement.acquiredAt}</time></Meta>
-                </button>
-              ))}
-            </div>
-          )}
-        </WorldSection>
-
-        <section className="lag-home-surface min-w-0 space-y-4 p-4">
-          <h2 className="lag-text-primary text-sm font-semibold tracking-[0.12em]">Current Journey</h2>
-          <div className="space-y-2">
-            <div className="flex items-center justify-between gap-3">
-              <h3 className="lag-text-secondary text-xs font-semibold">Current Quests</h3>
-              <button type="button" className="lag-button-secondary" style={retryStyle} onClick={onOpenCurrentQuests}>Open Quests</button>
+        <section className="lag-home-surface lag-home-section lag-home-section-journey">
+          <div className="lag-home-section-header">
+            <h2>Current Journey</h2>
+          </div>
+          <div className="lag-home-journey-block">
+            <div className="lag-home-subsection-header">
+              <h3>Current Quests</h3>
+              <button type="button" className="lag-button-secondary lag-home-action" onClick={onOpenCurrentQuests}>Open Quests</button>
             </div>
             {data.journey.currentQuests.length === 0 ? <Empty>No current Quests.</Empty> : data.journey.currentQuests.map((quest) => (
-              <button key={quest.acceptanceId} type="button" className="lag-home-card block w-full p-3 text-left" style={buttonStyle} onClick={onOpenCurrentQuests}>
-                <p className="text-sm font-semibold">{quest.title}</p>
+              <button key={quest.acceptanceId} type="button" className="lag-home-card lag-home-entry" onClick={onOpenCurrentQuests}>
+                <p className="lag-home-entry-title">{quest.title}</p>
                 <Meta>{quest.status} · {quest.progressValue} / {quest.targetValue}</Meta>
                 <Meta>Accepted <time dateTime={quest.acceptedAt}>{quest.acceptedAt}</time></Meta>
                 {quest.goalReachedAt ? <Meta>Goal reached <time dateTime={quest.goalReachedAt}>{quest.goalReachedAt}</time></Meta> : null}
               </button>
             ))}
           </div>
-          <div className="space-y-2">
-            <div className="flex items-center justify-between gap-3">
-              <h3 className="lag-text-secondary text-xs font-semibold">Selected Routes</h3>
-              <button type="button" className="lag-button-secondary" style={retryStyle} onClick={onOpenRoutes}>Open Routes</button>
+          <div className="lag-home-journey-block">
+            <div className="lag-home-subsection-header">
+              <h3>Selected Routes</h3>
+              <button type="button" className="lag-button-secondary lag-home-action" onClick={onOpenRoutes}>Open Routes</button>
             </div>
             {data.journey.selectedRoutes.length === 0 ? <Empty>No selected Routes.</Empty> : data.journey.selectedRoutes.map((route) => (
-              <button key={route.routeId} type="button" className="lag-home-card block w-full p-3 text-left" style={buttonStyle} onClick={onOpenRoutes}>
-                <p className="text-sm font-semibold">{route.title}</p>
-                <Meta>{route.status}{route.currentStepId === null ? "" : ` · Current Step #${route.currentStepId}`}</Meta>
+              <button key={route.routeId} type="button" className="lag-home-card lag-home-entry" onClick={onOpenRoutes}>
+                <p className="lag-home-entry-title">{route.title}</p>
+                <Meta>{route.status}</Meta>
                 <Meta>Selected <time dateTime={route.selectedAt}>{route.selectedAt}</time></Meta>
                 {route.completedAt ? <Meta>Completed <time dateTime={route.completedAt}>{route.completedAt}</time></Meta> : null}
               </button>
@@ -193,18 +172,38 @@ export default function HomeShell({
           </div>
         </section>
 
+        <WorldSection title="Recent Achievements" actionLabel="Open Achievements" onOpen={onOpenAchievements} className="lag-home-section-achievements">
+          {data.recentAchievements.length === 0 ? <Empty>No recent Achievements.</Empty> : (
+            <div className="lag-home-list">
+              {data.recentAchievements.map((achievement) => (
+                <button key={achievement.achievementId} type="button" className="lag-home-card lag-home-entry" onClick={onOpenAchievements}>
+                  <p className="lag-home-entry-title">{achievement.name}</p>
+                  <Meta>{achievement.category}</Meta>
+                  <p className="lag-home-description">{achievement.descMd}</p>
+                  <Meta><time dateTime={achievement.acquiredAt}>{achievement.acquiredAt}</time></Meta>
+                </button>
+              ))}
+            </div>
+          )}
+        </WorldSection>
+
         <WorldSection
           title="Role Activity — 30 Days"
           actionLabel="Open Roles"
           onOpen={data.roleActivity30d.roles[0] ? () => onOpenRole(data.roleActivity30d.roles[0].roleId) : undefined}
+          className="lag-home-section-roles"
         >
           <Meta><time dateTime={data.roleActivity30d.windowStart}>{data.roleActivity30d.windowStart}</time> — <time dateTime={data.roleActivity30d.windowEnd}>{data.roleActivity30d.windowEnd}</time></Meta>
-          <Meta>Assigned {data.roleActivity30d.assignedRecords} · Unassigned {data.roleActivity30d.unassignedRecords} · Total {data.roleActivity30d.totalRecords}</Meta>
+          <dl className="lag-home-role-summary">
+            <div><dt>Assigned</dt><dd>{data.roleActivity30d.assignedRecords}</dd></div>
+            <div><dt>Unassigned</dt><dd>{data.roleActivity30d.unassignedRecords}</dd></div>
+            <div><dt>Total records</dt><dd>{data.roleActivity30d.totalRecords}</dd></div>
+          </dl>
           {data.roleActivity30d.assignedRecords === 0 ? <Empty>No assigned Role activity.</Empty> : (
-            <div className="space-y-2">
+            <div className="lag-home-role-list">
               {data.roleActivity30d.roles.map((role) => (
-                <button key={role.roleId} type="button" className="lag-home-card block w-full p-3 text-left" style={buttonStyle} onClick={() => onOpenRole(role.roleId)}>
-                  <p className="text-sm font-semibold">{role.roleName ?? `Role #${role.roleId}`}</p>
+                <button key={role.roleId} type="button" className="lag-home-card lag-home-entry" onClick={() => onOpenRole(role.roleId)}>
+                  <p className="lag-home-entry-title">{role.roleName ?? "Unnamed Role"}</p>
                   <Meta>{role.recordCount} records · {percent.format(role.share)}</Meta>
                 </button>
               ))}

--- a/features/system/settings/SettingsShell.test.tsx
+++ b/features/system/settings/SettingsShell.test.tsx
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -21,6 +22,7 @@ const canonical: UserSettingsResponse = {
 describe("System Options surface save timing", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    api.updateSettingsApi.mockReset();
     localStorage.clear();
     vi.stubGlobal("matchMedia", vi.fn(() => ({ matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn() })));
     api.getSettingsApi.mockResolvedValue(canonical);
@@ -29,8 +31,8 @@ describe("System Options surface save timing", () => {
   it("keeps the failed draft open and closes only after a successful canonical response", async () => {
     api.updateSettingsApi.mockRejectedValueOnce(new Error("save failed")).mockResolvedValueOnce({ ...canonical, volume: 25 });
     render(<ThemeProvider><SettingsShell /></ThemeProvider>);
-    expect(await screen.findByText("Master Volume: 70%")).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: "설정 편집" }));
+    expect(await screen.findByText("70%")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Edit Settings" }));
     fireEvent.change(screen.getByRole("spinbutton", { name: "Master Volume" }), { target: { value: "25" } });
     fireEvent.click(screen.getByRole("button", { name: "Save Settings" }));
 
@@ -39,14 +41,14 @@ describe("System Options surface save timing", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Save Settings" }));
     await waitFor(() => expect(screen.queryByRole("spinbutton", { name: "Master Volume" })).not.toBeInTheDocument());
-    expect(screen.getByText("Master Volume: 25%")).toBeInTheDocument();
+    expect(screen.getByText("25%")).toBeInTheDocument();
     expect(toast.showToast).toHaveBeenCalledTimes(1);
   });
 
   it("applies theme selection immediately and keeps it applied when focused persistence fails", async () => {
     api.updateSettingsApi.mockRejectedValueOnce(new Error("theme save failed"));
     render(<ThemeProvider><SettingsShell /></ThemeProvider>);
-    expect(await screen.findByText("Master Volume: 70%")).toBeInTheDocument();
+    expect(await screen.findByText("70%")).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("radio", { name: /Astral Neutral/ }));
     expect(document.documentElement.dataset.theme).toBe("astral");
@@ -58,5 +60,42 @@ describe("System Options surface save timing", () => {
     const request = api.updateSettingsApi.mock.calls[0][0];
     expect(request).toEqual({ flagsJson: expect.any(String) });
     expect(JSON.parse(request.flagsJson)).toMatchObject({ themePreference: "ASTRAL", futureFlag: "keep" });
+  });
+
+  it("groups every canonical field without GoldRow and exposes only canonical theme choices", async () => {
+    render(<ThemeProvider><SettingsShell /></ThemeProvider>);
+    expect(await screen.findByRole("heading", { name: "Preferences" })).toBeInTheDocument();
+
+    for (const heading of ["Appearance", "Audio", "Display & Gameplay", "Controls", "Privacy & Presence", "Notifications", "Language"]) {
+      expect(screen.getByRole("heading", { name: heading })).toBeInTheDocument();
+    }
+    expect(screen.getAllByRole("radio").map((radio) => radio.getAttribute("value"))).toEqual(["ASTRAL", "WARM_BEIGE", "SYSTEM"]);
+    expect(screen.getByTestId("settings-shell")).toHaveTextContent(/Theme[\s\S]*UI Scale[\s\S]*Master Volume[\s\S]*Voice Chat[\s\S]*Graphics Quality[\s\S]*Damage Numbers[\s\S]*Particle Effects[\s\S]*Input Preset[\s\S]*Show Online Status[\s\S]*In-Game Notifications[\s\S]*Email Alerts[\s\S]*Language/);
+    expect(screen.getByTestId("settings-shell").querySelector(".lag-row")).toBeNull();
+  });
+
+  it("restores the canonical draft on Cancel and preserves integer volume validation", async () => {
+    render(<ThemeProvider><SettingsShell /></ThemeProvider>);
+    expect(await screen.findByText("70%")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Edit Settings" }));
+    fireEvent.change(screen.getByRole("spinbutton", { name: "Master Volume" }), { target: { value: "25" } });
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit Settings" }));
+    expect(screen.getByRole("spinbutton", { name: "Master Volume" })).toHaveValue(70);
+    fireEvent.change(screen.getByRole("spinbutton", { name: "Master Volume" }), { target: { value: "25.5" } });
+    fireEvent.submit(screen.getByRole("button", { name: "Save Settings" }).closest("form")!);
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("whole number from 0 to 100");
+    expect(api.updateSettingsApi).not.toHaveBeenCalled();
+  });
+
+  it("keeps responsive Settings groups semantic and free of local visual inline styles", () => {
+    const source = readFileSync("features/system/settings/SettingsShell.tsx", "utf8");
+    const css = readFileSync("app/globals.css", "utf8");
+
+    expect(source).not.toContain("GoldRow");
+    expect(source).not.toContain("style=");
+    expect(css).toMatch(/@media \(max-width: 767px\)[\s\S]*?\.lag-settings-group-grid[\s\S]*?grid-template-columns: 1fr/);
   });
 });

--- a/features/system/settings/SettingsShell.tsx
+++ b/features/system/settings/SettingsShell.tsx
@@ -6,16 +6,8 @@ import { useToast } from "@/context/ToastContext";
 import type { GraphicsQuality, InputPreset, SettingsView, ThemePreference, UiScale, VoiceChatMode } from "@/shared/api/types";
 import PanelStage from "@/shared/ui/PanelStage";
 import { PanelFrame } from "@/widgets/right-panels/ui/PanelFrame";
-import { GoldRow, InfoCard } from "@/widgets/right-panels/ui/Rows";
-import { actionBtnStyle } from "@/widgets/right-panels/ui/styles";
 import { SYSTEM_OPTIONS_FORM_FIELDS } from "../model";
 import { useSettings } from "./useSettings";
-
-const secondaryButton = {
-  padding: "7px 10px",
-  fontSize: "0.68rem",
-  letterSpacing: "0.08em",
-} as const;
 
 const THEME_OPTIONS: Array<{
   value: ThemePreference;
@@ -28,6 +20,16 @@ const THEME_OPTIONS: Array<{
   { value: "SYSTEM", title: "System follow", description: "Dark OS → Astral · Light OS → Warm Beige" },
 ];
 
+const SETTINGS_GROUPS: Array<{ title: string; description: string; keys: string[] }> = [
+  { title: "Appearance", description: "Scale and visual presentation.", keys: ["uiScale"] },
+  { title: "Audio", description: "Master output and voice chat.", keys: ["volume", "voiceChat"] },
+  { title: "Display & Gameplay", description: "Rendering quality and gameplay feedback.", keys: ["graphicsQuality", "showDamageNumbers", "showParticles"] },
+  { title: "Controls", description: "Active control layout.", keys: ["inputPreset"] },
+  { title: "Privacy & Presence", description: "How your online state is shared.", keys: ["showOnlineStatus"] },
+  { title: "Notifications", description: "In-game and email notices.", keys: ["notifications", "emailAlerts"] },
+  { title: "Language", description: "Application language.", keys: ["language"] },
+];
+
 const UI_SCALES = [75, 100, 125, 150] as const;
 const isUiScale = (value: number): value is UiScale => UI_SCALES.some((scale) => scale === value);
 const isGraphicsQuality = (value: string): value is GraphicsQuality => ["LOW", "MEDIUM", "HIGH", "ULTRA"].includes(value);
@@ -35,20 +37,13 @@ const isVoiceChat = (value: string): value is VoiceChatMode => ["OFF", "TEAM_ONL
 const isInputPreset = (value: string): value is InputPreset => ["STANDARD", "ADVANCED", "CUSTOM"].includes(value);
 const isThemePreference = (value: string): value is ThemePreference => ["SYSTEM", "ASTRAL", "WARM_BEIGE"].includes(value);
 
-function summaryRows(settings: SettingsView) {
-  return [
-    `Master Volume: ${settings.volume}%`,
-    `Graphics Quality: ${settings.graphicsQuality}`,
-    `Voice Chat: ${settings.voiceChat}`,
-    `UI Scale: ${settings.uiScale}%`,
-    `Input Preset: ${settings.inputPreset}`,
-    `Damage Numbers: ${settings.showDamageNumbers ? "On" : "Off"}`,
-    `Particle Effects: ${settings.showParticles ? "On" : "Off"}`,
-    `Show Online Status: ${settings.showOnlineStatus ? "On" : "Off"}`,
-    `Notifications: ${settings.notifications ? "On" : "Off"}`,
-    `Email Alerts: ${settings.emailAlerts ? "On" : "Off"}`,
-    `Language: ${settings.language}`,
-  ];
+function displayValue(settings: SettingsView, key: keyof SettingsView) {
+  const value = settings[key];
+  if (typeof value === "boolean") return value ? "On" : "Off";
+  if (key === "volume" || key === "uiScale") return `${value}%`;
+  if (key === "themePreference") return THEME_OPTIONS.find((option) => option.value === value)?.title ?? String(value);
+  const field = SYSTEM_OPTIONS_FORM_FIELDS.find((candidate) => candidate.key === key);
+  return field?.options?.find((option) => option.value === String(value))?.label ?? String(value);
 }
 
 export default function SettingsShell() {
@@ -56,6 +51,7 @@ export default function SettingsShell() {
   const { showToast } = useToast();
   const [editing, setEditing] = useState(false);
   const draft = settings.draft;
+  const canonicalView = settings.canonical?.view;
 
   const change = (key: string, value: string) => {
     if (key === "volume") return settings.updateDraft({ volume: Number(value) });
@@ -79,7 +75,7 @@ export default function SettingsShell() {
     event.preventDefault();
     if (await settings.save()) {
       setEditing(false);
-      showToast({ variant: "success", title: "설정 저장됨", body: "System options updated." });
+      showToast({ variant: "success", title: "Settings saved", body: "System options updated." });
     }
   };
 
@@ -87,94 +83,133 @@ export default function SettingsShell() {
     <div className="lag-settings-shell">
       <PanelStage stageKey="system-options" focusKey={editing ? "edit" : "summary"}>
         <PanelFrame title="Settings" depth={1} contentKey={editing ? "edit" : "summary"}>
-        <div className="space-y-3 px-3" data-testid="settings-shell">
-        {settings.loading && !settings.canonical ? <InfoCard>Loading Settings...</InfoCard> : null}
-        {settings.error ? (
-          <div className="space-y-2">
-            <p role="alert" className="lag-state-error text-xs">{settings.error}</p>
-            <button type="button" className="lag-button-secondary" style={secondaryButton} onClick={() => void settings.retry()}>Retry</button>
-          </div>
-        ) : null}
-
-        {!settings.error && settings.canonical ? (
-          <fieldset aria-label="Appearance" className="space-y-3">
-            <legend className="lag-settings-label">Theme</legend>
-            <div className="lag-theme-preview" aria-live="polite">
-              <div className="text-center">
-                <strong className="block text-sm">Immediate preview</strong>
-                <span className="lag-text-meta mt-1 block text-xs">{settings.themePreference.replace("_", " ")}</span>
+          <div className="lag-settings-surface" data-testid="settings-shell">
+            {settings.loading && !settings.canonical ? <p role="status" className="lag-settings-state">Loading Settings...</p> : null}
+            {settings.error ? (
+              <div className="lag-settings-state lag-settings-state-error">
+                <p role="alert" className="lag-state-error text-xs">{settings.error}</p>
+                <button type="button" className="lag-button-secondary lag-settings-button" onClick={() => void settings.retry()}>Retry</button>
               </div>
-            </div>
-            <div className="lag-theme-picker">
-              {THEME_OPTIONS.map((option) => (
-                <label
-                  key={option.value}
-                  className={`lag-theme-option${option.value === "SYSTEM" ? " lag-theme-option-system" : ""}`}
-                  data-lag-preview-theme={option.previewTheme}
-                >
-                  <input
-                    type="radio"
-                    name="themePreference"
-                    value={option.value}
-                    checked={settings.themePreference === option.value}
-                    disabled={settings.themeSaving || settings.saving}
-                    onChange={(event) => { if (isThemePreference(event.target.value)) void settings.setThemePreference(event.target.value); }}
-                  />
-                  <strong className="text-sm">{option.title}</strong>
-                  <span className="lag-text-meta text-xs">{option.description}</span>
-                  {option.previewTheme ? (
-                    <span className="lag-theme-swatches" aria-hidden>
-                      {Array.from({ length: 5 }, (_, index) => <span key={index} className="lag-theme-swatch" />)}
-                    </span>
-                  ) : null}
-                </label>
-              ))}
-            </div>
-            {settings.themeSaveError ? <p role="alert" className="lag-state-error mt-1 text-xs">{settings.themeSaveError}</p> : null}
-          </fieldset>
-        ) : null}
+            ) : null}
 
-        {!settings.error && settings.canonical && !editing ? (
-          <>
-            <InfoCard>Graphics, audio, controls, and gameplay preferences.</InfoCard>
-            <div className="space-y-1.5">
-              {summaryRows(settings.canonical.view).map((row) => <GoldRow key={row}>{row}</GoldRow>)}
-            </div>
-            <button type="button" className="lag-button-primary" style={actionBtnStyle} onClick={() => setEditing(true)}>설정 편집</button>
-          </>
-        ) : null}
+            {!settings.error && settings.canonical ? (
+              <fieldset className="lag-settings-theme">
+                <legend>Theme</legend>
+                <p className="lag-settings-group-description">Choose a theme. Changes apply immediately and save separately.</p>
+                <div className="lag-theme-preview" aria-live="polite">
+                  <div>
+                    <strong>Current theme</strong>
+                    <span>{THEME_OPTIONS.find((option) => option.value === settings.themePreference)?.title}</span>
+                  </div>
+                </div>
+                <div className="lag-theme-picker">
+                  {THEME_OPTIONS.map((option) => (
+                    <label
+                      key={option.value}
+                      className={`lag-theme-option${option.value === "SYSTEM" ? " lag-theme-option-system" : ""}`}
+                      data-lag-preview-theme={option.previewTheme}
+                    >
+                      <input
+                        type="radio"
+                        name="themePreference"
+                        value={option.value}
+                        checked={settings.themePreference === option.value}
+                        disabled={settings.themeSaving || settings.saving}
+                        onChange={(event) => { if (isThemePreference(event.target.value)) void settings.setThemePreference(event.target.value); }}
+                      />
+                      <strong>{option.title}</strong>
+                      <span className="lag-text-meta">{option.description}</span>
+                      {settings.themePreference === option.value ? <span className="lag-theme-current">Current</span> : null}
+                      {option.previewTheme ? (
+                        <span className="lag-theme-swatches" aria-hidden>
+                          {Array.from({ length: 5 }, (_, index) => <span key={index} className="lag-theme-swatch" />)}
+                        </span>
+                      ) : null}
+                    </label>
+                  ))}
+                </div>
+                {settings.themeSaving ? <p role="status" className="lag-settings-pending">Saving theme...</p> : null}
+                {settings.themeSaveError ? <p role="alert" className="lag-state-error text-xs">{settings.themeSaveError}</p> : null}
+              </fieldset>
+            ) : null}
 
-        {!settings.error && editing && draft ? (
-          <form className="space-y-3" onSubmit={submit}>
-            {SYSTEM_OPTIONS_FORM_FIELDS.map((field) => (
-              <label key={field.key} className="lag-settings-label block">
-                {field.label}
-                {field.type === "select" ? (
-                  <select className="lag-settings-control mt-1" title={field.label} value={String(draft[field.key as keyof SettingsView])} onChange={(event) => change(field.key, event.target.value)}>
-                    {field.options?.map((option) => <option key={option.value} value={option.value}>{option.label}</option>)}
-                  </select>
-                ) : (
-                  <input
-                    aria-label={field.label}
-                    type="number"
-                    min={0}
-                    max={100}
-                    step={1}
-                    value={draft.volume}
-                    onChange={(event) => change(field.key, event.target.value)}
-                    className="lag-settings-control mt-1"
-                  />
-                )}
-              </label>
-            ))}
-            {settings.saveError ? <p role="alert" className="lag-state-error text-xs">{settings.saveError}</p> : null}
-            <div className="flex gap-2">
-              <button type="submit" className="lag-button-primary" disabled={!settings.dirty || settings.saving || settings.themeSaving} style={{ ...actionBtnStyle, flex: 1 }}>{settings.saving ? "Saving..." : "Save Settings"}</button>
-              <button type="button" className="lag-button-secondary" disabled={settings.saving || settings.themeSaving} style={secondaryButton} onClick={() => { settings.cancel(); setEditing(false); }}>Cancel</button>
-            </div>
-          </form>
-        ) : null}
-        </div>
+            {!settings.error && canonicalView && !editing ? (
+              <section className="lag-settings-preferences" aria-labelledby="settings-preferences-title">
+                <div className="lag-settings-section-header">
+                  <div>
+                    <h2 id="settings-preferences-title">Preferences</h2>
+                    <p>Audio, display, controls, privacy, notifications, and language.</p>
+                  </div>
+                  <button type="button" className="lag-button-primary lag-settings-button" onClick={() => setEditing(true)}>Edit Settings</button>
+                </div>
+                <div className="lag-settings-group-grid">
+                  {SETTINGS_GROUPS.map((group) => (
+                    <section key={group.title} className="lag-settings-group">
+                      <h3>{group.title}</h3>
+                      <p className="lag-settings-group-description">{group.description}</p>
+                      <dl className="lag-settings-values">
+                        {group.title === "Appearance" ? (
+                          <div><dt>Theme</dt><dd>{displayValue(canonicalView, "themePreference")}</dd></div>
+                        ) : null}
+                        {SYSTEM_OPTIONS_FORM_FIELDS.filter((field) => group.keys.includes(field.key)).map((field) => (
+                          <div key={field.key}>
+                            <dt>{field.label}</dt>
+                            <dd>{displayValue(canonicalView, field.key as keyof SettingsView)}</dd>
+                          </div>
+                        ))}
+                      </dl>
+                    </section>
+                  ))}
+                </div>
+              </section>
+            ) : null}
+
+            {!settings.error && editing && draft ? (
+              <form className="lag-settings-form" onSubmit={submit}>
+                <div className="lag-settings-section-header">
+                  <div>
+                    <h2>Edit preferences</h2>
+                    <p>Theme changes above remain independent from these settings.</p>
+                  </div>
+                </div>
+                <div className="lag-settings-group-grid">
+                  {SETTINGS_GROUPS.map((group) => (
+                    <fieldset key={group.title} className="lag-settings-group">
+                      <legend>{group.title}</legend>
+                      <p className="lag-settings-group-description">{group.description}</p>
+                      <div className="lag-settings-fields">
+                        {SYSTEM_OPTIONS_FORM_FIELDS.filter((field) => group.keys.includes(field.key)).map((field) => (
+                          <label key={field.key} className="lag-settings-label">
+                            {field.label}
+                            {field.type === "select" ? (
+                              <select className="lag-settings-control" value={String(draft[field.key as keyof SettingsView])} onChange={(event) => change(field.key, event.target.value)}>
+                                {field.options?.map((option) => <option key={option.value} value={option.value}>{option.label}</option>)}
+                              </select>
+                            ) : (
+                              <input
+                                type="number"
+                                min={0}
+                                max={100}
+                                step={1}
+                                value={draft.volume}
+                                onChange={(event) => change(field.key, event.target.value)}
+                                className="lag-settings-control"
+                              />
+                            )}
+                          </label>
+                        ))}
+                      </div>
+                    </fieldset>
+                  ))}
+                </div>
+                {settings.saveError ? <p role="alert" className="lag-state-error text-xs">{settings.saveError}</p> : null}
+                <div className="lag-settings-actions">
+                  <button type="submit" className="lag-button-primary lag-settings-button" disabled={!settings.dirty || settings.saving || settings.themeSaving}>{settings.saving ? "Saving..." : "Save Settings"}</button>
+                  <button type="button" className="lag-button-secondary lag-settings-button" disabled={settings.saving || settings.themeSaving} onClick={() => { settings.cancel(); setEditing(false); }}>Cancel</button>
+                </div>
+              </form>
+            ) : null}
+          </div>
         </PanelFrame>
       </PanelStage>
     </div>


### PR DESCRIPTION
## Purpose

Complete the remaining primary Home and Settings visual surfaces in one focused UI pass while preserving their existing real data and runtime contracts.

Closes #70

## Delivered

- refined Home dashboard hierarchy
- real HomeSummary-driven Journal/Journey/Achievement/Role activity presentation
- preserved Home destination shortcuts
- responsive Home desktop/mobile composition
- semantic Settings grouping
- refined immediate theme picker
- preserved Settings draft/save/cancel behavior
- responsive Settings desktop/mobile composition
- reduced Home/Settings inline visual styling
- accessibility and semantic-state improvements

## Home Data Authority

Home continues to use the existing real HomeSummary data:

- Recent Journal
- Recent Achievements
- Current Quests
- Selected Routes
- Role Activity

No screenshot-only streak, XP, productivity/life score, or unsupported progress model is introduced.

Existing Home shortcuts continue to open the established Journal, Achievement, Journey, Route, and Role destinations.

## Home Composition

The dashboard now gives clearer visual priority to recent life records and current Journey context while retaining real secondary Achievement and Role activity information.

Mobile uses a readable stacked dashboard rather than compressed desktop card geometry.

## Settings Data Authority

Settings continues to use the existing real fields:

- volume
- graphicsQuality
- voiceChat
- uiScale
- inputPreset
- showDamageNumbers
- showParticles
- showOnlineStatus
- notifications
- emailAlerts
- language
- themePreference

No unsupported settings are introduced.

## Theme Contract

Theme behavior remains unchanged:

```text
SYSTEM
ASTRAL
WARM_BEIGE
```

Theme selection applies immediately and persists asynchronously.

No separate Apply action is introduced for theme.

Astral and Warm Beige share one component tree.

## Settings Editing

Ordinary Settings preserve:

- canonical/draft separation
- dirty detection
- Save Settings
- Cancel
- validation
- save locks
- load/save error states

Theme persistence remains independent from the ordinary Settings save flow.

## System Boundary

No fake Help, FAQ, Support, Patch Notes, or Terms destination is introduced.

Logout behavior is unchanged.

## Responsive / Accessibility

Home and Settings use semantic dual-theme tokens, visible focus, readable metadata, practical touch targets, and reduced-motion-compatible interactions.

Global camera behavior is not retuned in this PR.

## Scope Boundaries

This PR does not add:

- backend changes
- new Home metrics
- new Settings fields
- new Help/support routes
- login/onboarding redesign
- global camera final tuning

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Redesigned the home page with clearer hero content, record metrics, journal, journey, achievements, and role sections.
  - Improved responsive layouts for home and settings on mobile and desktop.
  - Reorganized settings into categorized groups with formatted values, theme previews, and a current-theme indicator.
  - Added clearer loading, empty, error, save-success, and retry states.
  - Improved settings editing with validation and explicit save/error feedback.

- **Bug Fixes**
  - Removed confusing identifiers and numeric fallback names from displayed content.
  - Corrected settings volume validation and cancel behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->