### PR TITLE
[Camera] Finalize stage viewpoint and parent-context transitions

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -380,7 +380,7 @@ export default function Home() {
     clearDetailSelectionsForMain(main);
     setActiveFormPanel(null);
     setEditingItemId(null);
-    requestStageFocus(`${main}-stage-0`, "center");
+    requestStageFocus(`${main}-stage-0`, "back");
   };
 
   // ─── Form panel helpers ────────────────────────────────────────────────────
@@ -412,7 +412,7 @@ export default function Home() {
         setSelectedSubByMain((prev) => ({ ...prev, skills: null }));
         updateDetailSelections({ skills: null });
       }
-      requestStageFocus(`skills-stage-${Math.max(0, panelIndex - 1)}`, "center");
+      requestStageFocus(`skills-stage-${Math.max(0, panelIndex - 1)}`, "back");
       return;
     }
 

--- a/features/inventory/GearShell.tsx
+++ b/features/inventory/GearShell.tsx
@@ -60,13 +60,13 @@ export default function GearShell({ onBack }: { onBack?: () => void }) {
     setPart(null);
     setSelectedSlotId(null);
     setSelectedItemInstanceId(null);
-    requestStageFocus("inventory-gear-parts", "center");
+    requestStageFocus("inventory-gear-parts", "back");
   };
 
   const closeAction = () => {
     setSelectedSlotId(null);
     setSelectedItemInstanceId(null);
-    requestStageFocus("inventory-gear-workspace", "center");
+    requestStageFocus("inventory-gear-workspace", "back");
   };
 
   return (
@@ -91,7 +91,7 @@ export default function GearShell({ onBack }: { onBack?: () => void }) {
 
       <AnimatePresence initial={false}>
         {part ? (
-          <PanelStage stageKey="inventory-gear-workspace" focusKey={part} index={1}>
+          <PanelStage stageKey="inventory-gear-workspace" index={1}>
             <PanelFrame title={`${INVENTORY_GEAR_PARTS.find(({ id }) => id === part)?.label ?? part} Workspace`} depth={1} contentKey={part} backButton={<BackButton label="Back to Gear Parts" onClick={closeWorkspace} />}>
               <div className="lag-gear-workspace">
                 <section className="lag-gear-section" aria-labelledby="gear-slots-title">
@@ -148,7 +148,7 @@ export default function GearShell({ onBack }: { onBack?: () => void }) {
 
       <AnimatePresence initial={false}>
         {selectedSlot ? (
-          <PanelStage stageKey="inventory-gear-action" focusKey={`${selectedSlot.slot.slotId}-${selectedCandidate?.itemInstanceId ?? "none"}`} index={2}>
+          <PanelStage stageKey="inventory-gear-action" index={2}>
             <PanelFrame title="Gear Action" depth={0} contentKey={`${selectedSlot.slot.slotId}-${selectedCandidate?.itemInstanceId ?? "none"}`} backButton={<BackButton label={`Back to ${INVENTORY_GEAR_PARTS.find(({ id }) => id === part)?.label ?? "Part"} Workspace`} onClick={closeAction} />}>
               <article className="lag-gear-action-detail">
                 <header className="lag-inventory-hero">

--- a/features/inventory/InventoryShell.test.tsx
+++ b/features/inventory/InventoryShell.test.tsx
@@ -155,14 +155,15 @@ describe("Inventory Items와 Inbox surface를 사용할 때", () => {
       fireEvent.click(entries[0]);
       const detail = document.querySelector('[data-stage-key="inventory-items-detail"]');
       expect(detail).toBeInTheDocument();
+      focus.mockClear();
       fireEvent.click(entries[1]);
       expect(document.querySelector('[data-stage-key="inventory-items-detail"]')).toBe(detail);
       expectData("Item instance ID", "502");
+      expect(focus).not.toHaveBeenCalled();
 
-      focus.mockClear();
       fireEvent.click(screen.getByRole("button", { name: "Back to Items" }));
       await waitFor(() => expect(document.querySelector('[data-stage-key="inventory-items-detail"]')).not.toBeInTheDocument());
-      expect(focus.mock.calls.at(-1)?.[0]).toMatchObject({ detail: { key: "inventory-items-list", align: "center" } });
+      expect(focus.mock.calls.at(-1)?.[0]).toMatchObject({ detail: { key: "inventory-items-list", align: "back" } });
       fireEvent.click(screen.getByRole("button", { name: "Back to Inventory" }));
       expect(onBack).toHaveBeenCalledTimes(1);
 

--- a/features/inventory/InventoryShell.tsx
+++ b/features/inventory/InventoryShell.tsx
@@ -169,7 +169,7 @@ export default function InventoryShell({ surface, onBack }: { surface: Inventory
   const closeDetail = () => {
     setSelectedItemInstanceId(null);
     setSelectedMailId(null);
-    requestStageFocus(`inventory-${surface}-list`, "center");
+    requestStageFocus(`inventory-${surface}-list`, "back");
   };
 
   return (
@@ -201,7 +201,7 @@ export default function InventoryShell({ surface, onBack }: { surface: Inventory
 
       <AnimatePresence initial={false}>
         {selectedItem || selectedMail ? (
-          <PanelStage stageKey={`inventory-${surface}-detail`} focusKey={selectedItemInstanceId ?? selectedMailId} index={1}>
+          <PanelStage stageKey={`inventory-${surface}-detail`} index={1}>
             <PanelFrame title={items ? "Item Detail" : "Mail Detail"} depth={0} contentKey={selectedItemInstanceId ?? selectedMailId ?? undefined} backButton={<BackButton label={`Back to ${items ? "Items" : "Inbox"}`} onClick={closeDetail} />}>
               {items && selectedItem ? <ItemDetail item={selectedItem} /> : null}
               {!items && selectedMail ? (

--- a/features/lifelog/CollectionShell.tsx
+++ b/features/lifelog/CollectionShell.tsx
@@ -200,7 +200,7 @@ export default function CollectionShell() {
 
       <AnimatePresence initial={false}>
         {collections.selectedId ? (
-          <PanelStage stageKey="lifelog-collection-detail" focusKey={collections.selectedId} index={2}>
+          <PanelStage stageKey="lifelog-collection-detail" index={2}>
             <PanelFrame title="Collection Detail" depth={0} contentKey={collections.selectedId}>
               {collections.detail.loading && !collections.detail.data ? <InfoCard>Loading Collection...</InfoCard> : null}
               {collections.detail.error ? <ErrorState message={collections.detail.error} retry={() => void collections.detail.retry()} /> : null}

--- a/features/lifelog/ExerciseShell.tsx
+++ b/features/lifelog/ExerciseShell.tsx
@@ -193,7 +193,7 @@ export default function ExerciseShell() {
 
       <AnimatePresence initial={false}>
         {exercises.selectedId ? (
-          <PanelStage stageKey="lifelog-exercise-detail" focusKey={exercises.selectedId} index={2}>
+          <PanelStage stageKey="lifelog-exercise-detail" index={2}>
             <PanelFrame title="Exercise Detail" depth={0} contentKey={exercises.selectedId}>
               {exercises.detail.loading && !exercises.detail.data ? <InfoCard>Loading Exercise...</InfoCard> : null}
               {exercises.detail.error ? <ErrorState message={exercises.detail.error} retry={() => void exercises.detail.retry()} /> : null}

--- a/features/lifelog/JournalShell.test.tsx
+++ b/features/lifelog/JournalShell.test.tsx
@@ -3,6 +3,7 @@ import { act, fireEvent, render, screen, waitFor, within } from "@testing-librar
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { JournalPage, QuickRecordResult, RoleDetail } from "@/shared/api/types";
+import { STAGE_FOCUS_EVENT } from "@/shared/hooks/useStageCamera";
 import JournalShell from "./JournalShell";
 import { journalMock, MOCK_JOURNAL_ENTRIES } from "./mock";
 
@@ -142,6 +143,8 @@ describe("LifeLog Journal v7 surface", () => {
   });
 
   it("opens detail only after selection, keeps its stage stable across entries, and Back closes it", async () => {
+    const focus = vi.fn();
+    window.addEventListener(STAGE_FOCUS_EVENT, focus);
     await renderJournal();
     expect(document.querySelector('[data-stage-key="lifelog-journal-detail"]')).not.toBeInTheDocument();
     const entries = screen.getAllByTestId("journal-entry");
@@ -152,13 +155,17 @@ describe("LifeLog Journal v7 surface", () => {
     expect(detailStage).toBeInTheDocument();
     expectDetail("Condition", "Annotated");
 
+    focus.mockClear();
     fireEvent.click(entries[1]);
     await screen.findByText("Morning run");
     expect(document.querySelector('[data-stage-key="lifelog-journal-detail"]')).toBe(detailStage);
     expectDetail("Entry mode", "QUICK");
+    expect(focus).not.toHaveBeenCalled();
 
     fireEvent.click(screen.getByRole("button", { name: "Back to Journal" }));
     await waitFor(() => expect(document.querySelector('[data-stage-key="lifelog-journal-detail"]')).not.toBeInTheDocument());
+    expect(focus.mock.calls.at(-1)?.[0]).toMatchObject({ detail: { key: "lifelog-journal", align: "back" } });
+    window.removeEventListener(STAGE_FOCUS_EVENT, focus);
   });
 
   it("renders all current detail fields in semantic common/source sections", async () => {

--- a/features/lifelog/JournalShell.tsx
+++ b/features/lifelog/JournalShell.tsx
@@ -378,7 +378,7 @@ export default function JournalShell({ roles, rolesLoading = false, rolesError =
   const previousDisabled = loading || journal.params.page === 0;
   const nextDisabled = loading || page.totalPages === 0 || journal.params.page + 1 >= page.totalPages;
 
-  const returnToJournal = () => requestStageFocus("lifelog-journal", "nearest");
+  const returnToJournal = () => requestStageFocus("lifelog-journal", "back");
   const openQuickRecord = () => {
     journal.clearSelection();
     setQuickRecordOpen(true);
@@ -513,7 +513,7 @@ export default function JournalShell({ roles, rolesLoading = false, rolesError =
 
       <AnimatePresence initial={false}>
         {!quickRecordOpen && journal.selectedLifeLogId ? (
-          <PanelStage stageKey="lifelog-journal-detail" focusKey={journal.selectedLifeLogId}>
+          <PanelStage stageKey="lifelog-journal-detail">
             <PanelFrame
               title="Journal Detail"
               depth={0}

--- a/features/lifelog/MediaShell.tsx
+++ b/features/lifelog/MediaShell.tsx
@@ -166,7 +166,7 @@ export default function MediaShell() {
 
       <AnimatePresence initial={false}>
         {media.detail ? (
-          <PanelStage stageKey="lifelog-media-detail" focusKey={media.detail.id} index={2}>
+          <PanelStage stageKey="lifelog-media-detail" index={2}>
             <PanelFrame title="Media Detail" depth={0} contentKey={media.detail.id}>
               <Detail item={media.detail} pending={pending} update={(body) => media.update(media.detail!.id, body)} remove={() => media.remove(media.detail!.id)} rate={(score) => media.rate(media.detail!.id, score)} advance={() => media.advance(media.detail!.id)} markStatus={(next) => media.markStatus(media.detail!.id, next)} rewatch={() => media.rewatch(media.detail!.id)} />
             </PanelFrame>

--- a/features/market/ExchangeShell.test.tsx
+++ b/features/market/ExchangeShell.test.tsx
@@ -98,6 +98,28 @@ describe("canonical Exchange surfaces", () => {
     window.removeEventListener(STAGE_FOCUS_EVENT, focus);
   });
 
+  it("keeps Shop tab replacement camera-stable while real detail Back focuses the parent", async () => {
+    const focus = vi.fn();
+    window.addEventListener(STAGE_FOCUS_EVENT, focus);
+    render(<ExchangeShell surface="shop" playerId={7} onBack={vi.fn()} />);
+
+    fireEvent.click(await screen.findByRole("button", { name: /Item #1010/ }));
+    focus.mockClear();
+    fireEvent.click(screen.getByRole("button", { name: "Marketplace" }));
+
+    expect(document.querySelector('[data-stage-key="market-stage-2"]')).toHaveAttribute("aria-hidden", "true");
+    expect(screen.queryByRole("button", { name: "Back to System Shop" })).not.toBeInTheDocument();
+    expect(focus).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: /Item #3011/ }));
+    focus.mockClear();
+    fireEvent.click(screen.getByRole("button", { name: "Back to Marketplace" }));
+
+    expect(focus).toHaveBeenCalledTimes(1);
+    expect(focus.mock.calls[0][0]).toMatchObject({ detail: { key: "market-stage-1", align: "back" } });
+    window.removeEventListener(STAGE_FOCUS_EVENT, focus);
+  });
+
   it("recovers a reserved purchase by returned id and explicitly confirms its canonical history token", async () => {
     api.getShopPurchasesApi
       .mockResolvedValueOnce([])

--- a/features/market/ExchangeShell.test.tsx
+++ b/features/market/ExchangeShell.test.tsx
@@ -3,6 +3,7 @@ import { readFileSync } from "node:fs";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { InventoryEntry, ListingSummary, ShopItem, ShopPurchaseSummary, TradeSummary } from "@/shared/api/types";
+import { STAGE_FOCUS_EVENT } from "@/shared/hooks/useStageCamera";
 import ExchangeShell from "./ExchangeShell";
 
 const api = vi.hoisted(() => ({
@@ -79,6 +80,8 @@ describe("canonical Exchange surfaces", () => {
   });
 
   it("loads canonical ShopItems, blocks unavailable purchase, and keeps one detail frame during replacement", async () => {
+    const focus = vi.fn();
+    window.addEventListener(STAGE_FOCUS_EVENT, focus);
     render(<ExchangeShell surface="shop" playerId={7} onBack={vi.fn()} />);
 
     fireEvent.click(await screen.findByRole("button", { name: /Item #1010/ }));
@@ -86,10 +89,13 @@ describe("canonical Exchange surfaces", () => {
     expect(detail).toBeInTheDocument();
     expect(screen.getByText("Global stock limit").nextElementSibling).toHaveTextContent("None");
 
+    focus.mockClear();
     fireEvent.click(screen.getByRole("button", { name: /Item #5010/ }));
     expect(document.querySelector('[data-stage-key="market-stage-2"]')).toBe(detail);
     expect(screen.getByRole("button", { name: "Purchase" })).toBeDisabled();
     expect(screen.getByText("This item is unavailable.")).toBeInTheDocument();
+    expect(focus).not.toHaveBeenCalled();
+    window.removeEventListener(STAGE_FOCUS_EVENT, focus);
   });
 
   it("recovers a reserved purchase by returned id and explicitly confirms its canonical history token", async () => {

--- a/features/market/ExchangeShell.tsx
+++ b/features/market/ExchangeShell.tsx
@@ -311,7 +311,7 @@ export default function ExchangeShell({ surface, playerId, onBack }: { surface: 
     setListingReservation(null);
     setCreatingListing(false);
     mutations.clearError();
-    requestStageFocus("market-stage-1", "center");
+    requestStageFocus("market-stage-1", "back");
   };
 
   return (

--- a/features/market/ExchangeShell.tsx
+++ b/features/market/ExchangeShell.tsx
@@ -304,13 +304,16 @@ export default function ExchangeShell({ surface, playerId, onBack }: { surface: 
       : selectedListing
         ? `${shopSurface}-${selectedListing.id}-${listingReservation?.reservationToken ?? "new"}`
         : null;
-  const closeDetail = () => {
+  const clearDetailState = () => {
     setSelectedShopItemId(null);
     setActivePurchaseId(null);
     setSelectedListingId(null);
     setListingReservation(null);
     setCreatingListing(false);
     mutations.clearError();
+  };
+  const closeDetail = () => {
+    clearDetailState();
     requestStageFocus("market-stage-1", "back");
   };
 
@@ -325,7 +328,7 @@ export default function ExchangeShell({ surface, playerId, onBack }: { surface: 
                 ["system-shop", "System Shop"],
                 ["marketplace", "Marketplace"],
                 ["my-listings", "My Listings"],
-              ] as const).map(([id, label]) => <button key={id} type="button" data-selected={shopSurface === id} aria-pressed={shopSurface === id} onClick={() => { setShopSurface(id); closeDetail(); }}>{label}</button>)}
+              ] as const).map(([id, label]) => <button key={id} type="button" data-selected={shopSurface === id} aria-pressed={shopSurface === id} onClick={() => { setShopSurface(id); clearDetailState(); }}>{label}</button>)}
             </div>
             {shopSurface === "system-shop" ? (
               <QueryState query={queries.shopItems} empty="No System Shop items.">

--- a/features/player/AchievementShell.tsx
+++ b/features/player/AchievementShell.tsx
@@ -59,10 +59,10 @@ export default function AchievementShell({ onBack }: { onBack?: () => void }) {
 
       <AnimatePresence initial={false} mode="popLayout">
         {achievements.selectedId ? (
-          <PanelStage key="player-achievement-detail" stageKey="player-achievement-detail" focusKey={achievements.selectedId} index={1}>
+          <PanelStage key="player-achievement-detail" stageKey="player-achievement-detail" index={1}>
             <PanelFrame title="Achievement Detail" depth={0} contentKey={achievements.selectedId} backButton={<BackButton label="Back to Acquired Achievements" onClick={() => {
               achievements.clearSelection();
-              requestStageFocus("player-achievement-list", "center");
+              requestStageFocus("player-achievement-list", "back");
             }} />}>
               {achievements.detail.loading && !detail ? <InfoCard>Loading Achievement...</InfoCard> : null}
               {achievements.detail.error ? <ErrorState message={achievements.detail.error} retry={() => void achievements.detail.retry()} /> : null}

--- a/features/player/CertificationShell.test.tsx
+++ b/features/player/CertificationShell.test.tsx
@@ -103,7 +103,7 @@ describe("Certification management surface를 사용할 때", () => {
     fireEvent.click(screen.getByRole("button", { name: "Back to My Certifications" }));
 
     await waitFor(() => expect(document.querySelector('[data-stage-key="player-certification-detail"]')).not.toBeInTheDocument());
-    expect(focus.mock.calls.at(-1)?.[0]).toMatchObject({ detail: { key: "player-certification-list", align: "center" } });
+    expect(focus.mock.calls.at(-1)?.[0]).toMatchObject({ detail: { key: "player-certification-list", align: "back" } });
     window.removeEventListener(STAGE_FOCUS_EVENT, focus);
   });
 });

--- a/features/player/CertificationShell.tsx
+++ b/features/player/CertificationShell.tsx
@@ -61,13 +61,13 @@ export default function CertificationShell({ onBack }: { onBack?: () => void }) 
     : null;
 
   useEffect(() => {
-    if (selectedCertification && !selected) clearSelection();
+    if (selectedCertification && !selected) {
+      clearSelection();
+      requestStageFocus("player-certification-list", "back");
+    }
   }, [clearSelection, selected, selectedCertification]);
 
-  const changeCategory = (next: string) => {
-    setCategory(next);
-    if (selectedCertification && next !== "ALL" && selectedCertification.category !== next) clearSelection();
-  };
+  const changeCategory = (next: string) => setCategory(next);
 
   return (
     <div className="lag-panel-rail lag-semantic-controls relative" data-testid="certification-shell">
@@ -111,7 +111,7 @@ export default function CertificationShell({ onBack }: { onBack?: () => void }) 
         </PanelFrame>
       </PanelStage>
 
-      <PanelStage stageKey="player-certification-list" focusKey={category} index={1}>
+      <PanelStage stageKey="player-certification-list" index={1}>
         <PanelFrame title="My Certifications" depth={1} backButton={onBack ? <BackButton label="Back to Player" onClick={onBack} /> : undefined}>
         <div className="space-y-3">
           {certifications.owned.loading && certifications.owned.items.length === 0 ? <InfoCard>Loading Certifications...</InfoCard> : null}
@@ -130,10 +130,10 @@ export default function CertificationShell({ onBack }: { onBack?: () => void }) 
 
       <AnimatePresence initial={false} mode="popLayout">
         {selected ? (
-          <PanelStage key="player-certification-detail" stageKey="player-certification-detail" focusKey={selected.certificationId} index={2}>
+          <PanelStage key="player-certification-detail" stageKey="player-certification-detail" index={2}>
             <PanelFrame title="Certification Detail" depth={0} contentKey={selected.certificationId} backButton={<BackButton label="Back to My Certifications" onClick={() => {
               clearSelection();
-              requestStageFocus("player-certification-list", "center");
+              requestStageFocus("player-certification-list", "back");
             }} />}>
               <div className="space-y-3 px-3">
             <InfoCard>{selected.name}</InfoCard>

--- a/features/player/GrowthShell.tsx
+++ b/features/player/GrowthShell.tsx
@@ -43,7 +43,7 @@ export default function GrowthShell({ onBack }: { onBack?: () => void }) {
   const openHistory = () => requestStageFocus("player-growth-history", "center");
   const closeDetail = () => {
     setSelectedChangeId(null);
-    requestStageFocus("player-growth-history", "center");
+    requestStageFocus("player-growth-history", "back");
   };
 
   return (
@@ -89,7 +89,7 @@ export default function GrowthShell({ onBack }: { onBack?: () => void }) {
       </PanelStage>
 
       <PanelStage stageKey="player-growth-history" autoFocus={false}>
-        <PanelFrame title="Recent EXP Changes" depth={1} backButton={<BackButton label="Back to Growth Profile" onClick={() => requestStageFocus("player-growth-profile", "center")} />}>
+        <PanelFrame title="Recent EXP Changes" depth={1} backButton={<BackButton label="Back to Growth Profile" onClick={() => requestStageFocus("player-growth-profile", "back")} />}>
           <section className="lag-growth-history" aria-label="Recent EXP Changes">
             <header><p>Canonical EXP history</p><span>{changes.length} changes</span></header>
             {growth.loading && !growth.data ? <div role="status" className="lag-growth-state">Loading EXP history...</div> : null}
@@ -116,7 +116,7 @@ export default function GrowthShell({ onBack }: { onBack?: () => void }) {
 
       <AnimatePresence initial={false}>
         {selectedChange ? (
-          <PanelStage stageKey="player-growth-change-detail" focusKey={selectedChange.changeId}>
+          <PanelStage stageKey="player-growth-change-detail">
             <PanelFrame title="EXP Change Detail" depth={0} contentKey={selectedChange.changeId} backButton={<BackButton label="Back to EXP History" onClick={closeDetail} />}>
               <ExpChangeDetail change={selectedChange} />
             </PanelFrame>

--- a/features/player/HobbyShell.tsx
+++ b/features/player/HobbyShell.tsx
@@ -90,10 +90,10 @@ export default function HobbyShell({ onBack }: { onBack?: () => void }) {
 
       <AnimatePresence initial={false} mode="popLayout">
         {selected ? (
-          <PanelStage key="player-hobby-detail" stageKey="player-hobby-detail" focusKey={selected.hobbyId} index={2}>
+          <PanelStage key="player-hobby-detail" stageKey="player-hobby-detail" index={2}>
             <PanelFrame title="Hobby Detail" depth={0} contentKey={selected.hobbyId} backButton={<BackButton label="Back to My Hobbies" onClick={() => {
               hobbies.clearSelection();
-              requestStageFocus("player-hobby-list", "center");
+              requestStageFocus("player-hobby-list", "back");
             }} />}>
               <div className="space-y-3 px-3">
             <InfoCard>{selected.customName}</InfoCard>

--- a/features/player/TitleShell.tsx
+++ b/features/player/TitleShell.tsx
@@ -65,10 +65,10 @@ export default function TitleShell({ onBack }: { onBack?: () => void }) {
 
       <AnimatePresence initial={false} mode="popLayout">
         {selected ? (
-          <PanelStage key="player-title-detail" stageKey="player-title-detail" focusKey={selected.titleId} index={1}>
+          <PanelStage key="player-title-detail" stageKey="player-title-detail" index={1}>
             <PanelFrame title="Title Detail" depth={0} contentKey={selected.titleId} backButton={<BackButton label="Back to Acquired Titles" onClick={() => {
               titles.clearSelection();
-              requestStageFocus("player-title-list", "center");
+              requestStageFocus("player-title-list", "back");
             }} />}>
               <div className="space-y-3 px-3">
                 <InfoCard>{selected.name}</InfoCard>

--- a/features/quests/JourneyShell.tsx
+++ b/features/quests/JourneyShell.tsx
@@ -208,13 +208,13 @@ export default function JourneyShell({ initialSurface = null }: { initialSurface
 
   const closeDetail = () => {
     clearDetail();
-    requestStageFocus("journey-list", "nearest");
+    requestStageFocus("journey-list", "back");
   };
 
   const closeList = () => {
     clearDetail();
     setSurface(null);
-    requestStageFocus("journey-root", "nearest");
+    requestStageFocus("journey-root", "back");
   };
 
   const mineById = new Map(queries.routes.data.mine.map((route) => [route.id, route]));
@@ -543,7 +543,7 @@ export default function JourneyShell({ initialSurface = null }: { initialSurface
 
       <AnimatePresence initial={false}>
         {surface ? (
-          <PanelStage stageKey="journey-list" focusKey={surface}>
+          <PanelStage stageKey="journey-list">
             <PanelFrame title={listTitle} depth={1} contentKey={surface} backButton={<BackButton label="Back to Journey" onClick={closeList} />}>
               <section className="lag-journey-list-surface" aria-label={`${listTitle} list`}>
                 <header><p className="lag-journey-eyebrow">Journey child surface</p><h4>{listTitle}</h4><p>{SURFACE_COPY[surface]}</p></header>
@@ -556,7 +556,7 @@ export default function JourneyShell({ initialSurface = null }: { initialSurface
 
       <AnimatePresence initial={false} mode="popLayout">
         {detailContentKey ? (
-          <PanelStage stageKey="journey-detail" focusKey={detailContentKey}>
+          <PanelStage stageKey="journey-detail">
             <PanelFrame title={detailTitle} depth={0} contentKey={detailContentKey} backButton={<BackButton label={`Back to ${listTitle}`} onClick={closeDetail} />}>
               {surface === "current" ? renderCurrentDetail() : surface === "catalog" ? renderCatalogDetail() : renderRouteDetail()}
             </PanelFrame>

--- a/features/role/RoleShell.test.tsx
+++ b/features/role/RoleShell.test.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { PersonDetail, RoleDetail, RoleEventDetail, RoleRelationDetail } from "@/shared/api/types";
+import { STAGE_FOCUS_EVENT } from "@/shared/hooks/useStageCamera";
 import { RoleContextPanel } from "@/widgets/left-context/ui/RoleContextPanel";
 import RoleShell from "./RoleShell";
 
@@ -155,6 +156,8 @@ describe("실제 Role shell을 사용할 때", () => {
     });
 
     it("Role 선택은 surfaces만 열고 surface 선택 후 detail을 열며 Role 교체 시 detail을 닫는다", async () => {
+      const focus = vi.fn();
+      window.addEventListener(STAGE_FOCUS_EVENT, focus);
       render(<Harness initialRoleId={null} />);
       const selector = document.querySelector("[data-role-selector]");
 
@@ -165,6 +168,10 @@ describe("실제 Role shell을 사용할 때", () => {
 
       fireEvent.click(screen.getByRole("button", { name: /Overview/ }));
       expect(document.querySelector('[data-stage-key="role-detail"]')).toBeInTheDocument();
+      focus.mockClear();
+      fireEvent.click(screen.getByRole("button", { name: /Events/ }));
+      await waitFor(() => expect(api.listRoleEventsApi).toHaveBeenCalledWith(1));
+      expect(focus).not.toHaveBeenCalled();
 
       fireEvent.click(screen.getByRole("button", { name: /Family Member/ }));
       await waitFor(() => expect(document.querySelector('[data-stage-key="role-detail"]')).not.toBeInTheDocument());
@@ -174,6 +181,7 @@ describe("실제 Role shell을 사용할 때", () => {
       fireEvent.click(screen.getByRole("button", { name: /Backend Engineer/ }));
       expect(document.querySelector('[data-stage-key="role-detail"]')).not.toBeInTheDocument();
       expect(screen.queryByText("Role Overview")).not.toBeInTheDocument();
+      window.removeEventListener(STAGE_FOCUS_EVENT, focus);
     });
 
     it("surface Back은 selected Role summary를 유지하고 summary Back은 selector로 돌아간다", async () => {

--- a/features/role/RoleShell.tsx
+++ b/features/role/RoleShell.tsx
@@ -457,7 +457,7 @@ export default function RoleShell({
     setSurface(null);
     setSurfaceRoleId(null);
     setEditingRoleId(null);
-    requestStageFocus("role-summary", "nearest");
+    requestStageFocus("role-summary", "back");
   };
 
   const closeSummary = () => {
@@ -465,7 +465,7 @@ export default function RoleShell({
     setSurfaceRoleId(null);
     setEditingRoleId(null);
     onSelectRole(null);
-    requestStageFocus("left-context", "nearest");
+    requestStageFocus("left-context", "back");
   };
 
   const archiveRole = async (role: RoleDetail) => {
@@ -484,7 +484,7 @@ export default function RoleShell({
     <div className="lag-panel-rail lag-role-shell relative" data-testid="role-shell">
       <AnimatePresence initial={false}>
         {selectedRole ? (
-          <PanelStage stageKey="role-summary" focusKey={selectedRole.id} index={1}>
+          <PanelStage stageKey="role-summary" index={1}>
             <PanelFrame title={selectedRole.name} depth={1} contentKey={selectedRole.id} backButton={<BackButton label="Back to Role selector" onClick={closeSummary} />}>
               <article className="lag-role-summary">
                 {actionError ? <p role="alert" className="lag-role-feedback" data-state="error">{actionError}</p> : null}
@@ -516,7 +516,7 @@ export default function RoleShell({
 
       <AnimatePresence initial={false} mode="popLayout">
         {selectedRole && (editingRole || activeSurface) ? (
-          <PanelStage stageKey="role-detail" focusKey={`${selectedRole.id}-${editingRole ? "edit" : activeSurface}`} index={2}>
+          <PanelStage stageKey="role-detail" index={2}>
             <PanelFrame title={editingRole ? "Edit Role" : ROLE_SURFACES.find(({ id }) => id === activeSurface)?.label ?? "Role"} depth={0} contentKey={`${selectedRole.id}-${editingRole ? "edit" : activeSurface}`} backButton={<BackButton label={`Back to ${selectedRole.name}`} onClick={closeDetail} />}>
               {editingRole ? (
                 <RoleEditForm role={selectedRole} onSaved={async () => { await onRefresh(); closeDetail(); }} onCancel={closeDetail} />

--- a/features/system/settings/SettingsShell.test.tsx
+++ b/features/system/settings/SettingsShell.test.tsx
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { UserSettingsResponse } from "@/shared/api/types";
 import { ThemeProvider } from "@/features/theme/ThemeProvider";
+import { STAGE_FOCUS_EVENT } from "@/shared/hooks/useStageCamera";
 import SettingsShell from "./SettingsShell";
 
 const api = vi.hoisted(() => ({ getSettingsApi: vi.fn(), updateSettingsApi: vi.fn() }));
@@ -43,6 +44,20 @@ describe("System Options surface save timing", () => {
     await waitFor(() => expect(screen.queryByRole("spinbutton", { name: "Master Volume" })).not.toBeInTheDocument());
     expect(screen.getByText("25%")).toBeInTheDocument();
     expect(toast.showToast).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the Settings camera stable between summary and edit content", async () => {
+    const focus = vi.fn();
+    window.addEventListener(STAGE_FOCUS_EVENT, focus);
+    render(<ThemeProvider><SettingsShell /></ThemeProvider>);
+    expect(await screen.findByText("70%")).toBeInTheDocument();
+    focus.mockClear();
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit Settings" }));
+
+    expect(screen.getByRole("button", { name: "Save Settings" })).toBeInTheDocument();
+    expect(focus).not.toHaveBeenCalled();
+    window.removeEventListener(STAGE_FOCUS_EVENT, focus);
   });
 
   it("applies theme selection immediately and keeps it applied when focused persistence fails", async () => {

--- a/features/system/settings/SettingsShell.tsx
+++ b/features/system/settings/SettingsShell.tsx
@@ -81,7 +81,7 @@ export default function SettingsShell() {
 
   return (
     <div className="lag-settings-shell">
-      <PanelStage stageKey="system-options" focusKey={editing ? "edit" : "summary"}>
+      <PanelStage stageKey="system-options">
         <PanelFrame title="Settings" depth={1} contentKey={editing ? "edit" : "summary"}>
           <div className="lag-settings-surface" data-testid="settings-shell">
             {settings.loading && !settings.canonical ? <p role="status" className="lag-settings-state">Loading Settings...</p> : null}

--- a/shared/hooks/useStageCamera.test.ts
+++ b/shared/hooks/useStageCamera.test.ts
@@ -1,7 +1,49 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { cameraInsets, cameraProfileForWidth, focusStage, requestStageFocus, stageFocusPlan, useStageCamera } from "./useStageCamera";
+import {
+  cameraInsets,
+  cameraProfileForWidth,
+  cameraScrollTarget,
+  focusStage,
+  requestStageFocus,
+  stageFocusPlan,
+  useStageCamera,
+} from "./useStageCamera";
+
+const domRect = (left: number, width: number) => ({
+  left,
+  right: left + width,
+  top: 0,
+  bottom: 600,
+  width,
+  height: 600,
+  x: left,
+  y: 0,
+  toJSON: () => ({}),
+});
+
+function cameraOwner(clientWidth = 400, scrollWidth = 1200) {
+  const owner = document.createElement("div");
+  const scrollTo = vi.fn(({ left }: { left: number }) => { owner.scrollLeft = left; });
+  Object.defineProperties(owner, {
+    scrollLeft: { configurable: true, writable: true, value: 0 },
+    scrollTo: { configurable: true, value: scrollTo },
+    clientWidth: { configurable: true, value: clientWidth },
+    scrollWidth: { configurable: true, value: scrollWidth },
+  });
+  owner.getBoundingClientRect = () => domRect(0, clientWidth);
+  return { owner, scrollTo };
+}
+
+function appendStage(owner: HTMLElement, key: string, left: number, width = 300, autoFocus = true) {
+  const stage = document.createElement("div");
+  stage.dataset.stageKey = key;
+  if (!autoFocus) stage.dataset.stageAutoFocus = "false";
+  stage.getBoundingClientRect = () => domRect(left - owner.scrollLeft, width);
+  owner.append(stage);
+  return stage;
+}
 
 describe("stage camera contract", () => {
   beforeEach(() => {
@@ -11,9 +53,10 @@ describe("stage camera contract", () => {
     vi.stubGlobal("matchMedia", vi.fn(() => ({ matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn() })));
   });
 
-  it("targets a newly opened stage while stable detail replacement uses explicit intent", () => {
-    expect(stageFocusPlan(["root"], ["root", "detail-a"])).toEqual({ key: "detail-a", align: "nearest" });
+  it("targets only genuine stage topology changes and returns to the immediate parent", () => {
+    expect(stageFocusPlan(["root"], ["root", "detail"])).toEqual({ key: "detail", align: "forward" });
     expect(stageFocusPlan(["root", "detail"], ["root", "detail"])).toBeNull();
+    expect(stageFocusPlan(["root", "list", "detail"], ["root", "list"])).toEqual({ key: "list", align: "back" });
   });
 
   it("selects wide, compact, and mobile policy from viewport width", () => {
@@ -22,113 +65,116 @@ describe("stage camera contract", () => {
     expect(cameraProfileForWidth(390)).toBe("mobile");
   });
 
-  it("returns focus to the parent when a stage closes", () => {
-    expect(stageFocusPlan(["root", "list", "detail"], ["root", "list"])).toEqual({ key: "list", align: "center" });
+  it("clamps both scroll bounds and aligns an over-wide target from its readable start", () => {
+    const base = { scrollLeft: 0, scrollWidth: 900, clientWidth: 400, targetWidth: 300, profile: "mobile" as const, align: "forward" as const, insets: { leading: 24, trailing: 24 } };
+    expect(cameraScrollTarget({ ...base, targetLeft: -80 })).toBe(0);
+    expect(cameraScrollTarget({ ...base, targetLeft: 1_200 })).toBe(500);
+    expect(cameraScrollTarget({ ...base, targetLeft: 500, targetWidth: 460 })).toBe(500);
+  });
+
+  it.each([
+    ["wide", 164],
+    ["compact", 628],
+    ["mobile", 676],
+  ] as const)("uses the %s forward composition policy", (profile, expected) => {
+    expect(cameraScrollTarget({
+      scrollLeft: 0,
+      scrollWidth: 2_000,
+      clientWidth: 1_000,
+      targetLeft: 700,
+      targetWidth: 344,
+      profile,
+      align: "forward",
+      insets: profile === "wide" ? { leading: 32, trailing: 120 } : profile === "compact" ? { leading: 72, trailing: 32 } : { leading: 24, trailing: 24 },
+    })).toBe(expected);
+  });
+
+  it.each([
+    ["wide", 164],
+    ["compact", 628],
+    ["mobile", 676],
+  ] as const)("uses the %s Back composition policy", (profile, expected) => {
+    expect(cameraScrollTarget({
+      scrollLeft: 900,
+      scrollWidth: 2_000,
+      clientWidth: 1_000,
+      targetLeft: 700,
+      targetWidth: 344,
+      profile,
+      align: "back",
+      insets: profile === "wide" ? { leading: 32, trailing: 120 } : profile === "compact" ? { leading: 72, trailing: 32 } : { leading: 24, trailing: 24 },
+    })).toBe(expected);
+  });
+
+  it("centers a mobile near-viewport-width stage instead of preserving a desktop-style parent peek", () => {
+    expect(cameraScrollTarget({
+      scrollLeft: 0,
+      scrollWidth: 1_200,
+      clientWidth: 400,
+      targetLeft: 500,
+      targetWidth: 368,
+      profile: "mobile",
+      align: "forward",
+      insets: { leading: 48, trailing: 24 },
+    })).toBe(484);
   });
 
   it("uses non-animated scrolling for reduced motion", () => {
-    const owner = document.createElement("div");
-    const target = document.createElement("div");
-    const scrollTo = vi.fn();
-    Object.defineProperties(owner, {
-      scrollTo: { configurable: true, value: scrollTo },
-      clientWidth: { configurable: true, value: 400 },
-      scrollWidth: { configurable: true, value: 900 },
-    });
-    owner.getBoundingClientRect = () => ({ left: 0, right: 400, top: 0, bottom: 600, width: 400, height: 600, x: 0, y: 0, toJSON: () => ({}) });
-    target.getBoundingClientRect = () => ({ left: 500, right: 800, top: 100, bottom: 500, width: 300, height: 400, x: 500, y: 100, toJSON: () => ({}) });
+    const { owner, scrollTo } = cameraOwner(400, 900);
+    const target = appendStage(owner, "detail", 500);
 
-    focusStage(owner, target, "nearest", true);
+    focusStage(owner, target, "forward", true);
 
     expect(scrollTo).toHaveBeenCalledWith({ left: 448, behavior: "auto" });
   });
 
-  it("keeps the larger mobile leading inset when revealing a stage", () => {
-    const owner = document.createElement("div");
-    const target = document.createElement("div");
-    const scrollTo = vi.fn();
-    Object.defineProperties(owner, {
-      scrollLeft: { configurable: true, writable: true, value: 100 },
-      scrollTo: { configurable: true, value: scrollTo },
-      clientWidth: { configurable: true, value: 400 },
-      scrollWidth: { configurable: true, value: 900 },
-    });
-    owner.getBoundingClientRect = () => ({ left: 0, right: 400, top: 0, bottom: 600, width: 400, height: 600, x: 0, y: 0, toJSON: () => ({}) });
-    target.getBoundingClientRect = () => ({ left: 10, right: 310, top: 0, bottom: 400, width: 300, height: 400, x: 10, y: 0, toJSON: () => ({}) });
+  it("focuses a new child topology but ignores arbitrary child-list changes", async () => {
+    const { owner, scrollTo } = cameraOwner();
+    const root = appendStage(owner, "root", 100);
+    const ref = { current: owner };
+    renderHook(() => useStageCamera(ref, ref, "player"));
+    scrollTo.mockClear();
 
-    focusStage(owner, target, "nearest", false, { leading: 48, trailing: 24 });
+    act(() => appendStage(owner, "detail", 600));
+    await waitFor(() => expect(scrollTo).toHaveBeenCalledTimes(1));
+    scrollTo.mockClear();
 
-    expect(scrollTo).toHaveBeenCalledWith({ left: 62, behavior: "smooth" });
+    act(() => root.append(document.createElement("span")));
+    await act(async () => { await Promise.resolve(); });
+    expect(scrollTo).not.toHaveBeenCalled();
   });
 
-  it.each([
-    ["wide", 448],
-    ["compact", 428],
-    ["mobile", 436],
-  ] as const)("uses the %s composition when revealing a child", (profile, expectedLeft) => {
-    const owner = document.createElement("div");
-    const target = document.createElement("div");
-    const scrollTo = vi.fn();
-    Object.defineProperties(owner, {
-      scrollTo: { configurable: true, value: scrollTo },
-      clientWidth: { configurable: true, value: 400 },
-      scrollWidth: { configurable: true, value: 900 },
-    });
-    owner.getBoundingClientRect = () => ({ left: 0, right: 400, top: 0, bottom: 600, width: 400, height: 600, x: 0, y: 0, toJSON: () => ({}) });
-    target.getBoundingClientRect = () => ({ left: 500, right: 800, top: 0, bottom: 400, width: 300, height: 400, x: 500, y: 0, toJSON: () => ({}) });
+  it("preserves a spatial stage that opts out of forward auto-focus", async () => {
+    const { owner, scrollTo } = cameraOwner();
+    appendStage(owner, "profile", 100);
+    const ref = { current: owner };
+    renderHook(() => useStageCamera(ref, ref, "player"));
+    scrollTo.mockClear();
 
-    focusStage(owner, target, "nearest", false, cameraInsets(owner, profile), profile);
+    act(() => appendStage(owner, "history", 420, 300, false));
+    await act(async () => { await Promise.resolve(); });
 
-    expect(scrollTo).toHaveBeenCalledWith({ left: expectedLeft, behavior: "smooth" });
+    expect(scrollTo).not.toHaveBeenCalled();
   });
 
-  it("keeps useful parent context while making a wide-desktop child readable", () => {
-    const owner = document.createElement("div");
-    const target = document.createElement("div");
-    const scrollTo = vi.fn();
-    Object.defineProperties(owner, {
-      scrollTo: { configurable: true, value: scrollTo },
-      clientWidth: { configurable: true, value: 1000 },
-      scrollWidth: { configurable: true, value: 1400 },
-    });
-    owner.getBoundingClientRect = () => ({ left: 0, right: 1000, top: 0, bottom: 600, width: 1000, height: 600, x: 0, y: 0, toJSON: () => ({}) });
-    target.getBoundingClientRect = () => ({ left: 720, right: 1064, top: 0, bottom: 400, width: 344, height: 400, x: 720, y: 0, toJSON: () => ({}) });
+  it("focuses the immediate surviving parent when the deepest stage is removed", async () => {
+    const { owner, scrollTo } = cameraOwner();
+    appendStage(owner, "root", 100);
+    const list = appendStage(owner, "list", 420);
+    const detail = appendStage(owner, "detail", 740);
+    const ref = { current: owner };
+    renderHook(() => useStageCamera(ref, ref, "player"));
+    scrollTo.mockClear();
 
-    focusStage(owner, target, "nearest", false, cameraInsets(owner, "wide"), "wide");
+    act(() => detail.remove());
 
-    expect(scrollTo).toHaveBeenCalledWith({ left: 184, behavior: "smooth" });
+    await waitFor(() => expect(scrollTo).toHaveBeenCalledTimes(1));
+    expect(list.dataset.stageKey).toBe("list");
   });
 
-  it.each(["wide", "compact", "mobile"] as const)("centers the parent on Back under the %s profile", (profile) => {
-    const owner = document.createElement("div");
-    const target = document.createElement("div");
-    const scrollTo = vi.fn();
-    Object.defineProperties(owner, {
-      scrollTo: { configurable: true, value: scrollTo },
-      clientWidth: { configurable: true, value: 400 },
-      scrollWidth: { configurable: true, value: 900 },
-    });
-    owner.getBoundingClientRect = () => ({ left: 0, right: 400, top: 0, bottom: 600, width: 400, height: 600, x: 0, y: 0, toJSON: () => ({}) });
-    target.getBoundingClientRect = () => ({ left: 200, right: 500, top: 0, bottom: 400, width: 300, height: 400, x: 200, y: 0, toJSON: () => ({}) });
-
-    focusStage(owner, target, "center", false, cameraInsets(owner, profile), profile);
-
-    expect(scrollTo).toHaveBeenCalledWith({ left: 150, behavior: "smooth" });
-  });
-
-  it("moves the camera when an existing stage sends explicit focus intent", () => {
-    const owner = document.createElement("div");
-    const target = document.createElement("div");
-    target.dataset.stageKey = "detail";
-    owner.append(target);
-    const scrollTo = vi.fn();
-    Object.defineProperties(owner, {
-      scrollTo: { configurable: true, value: scrollTo },
-      clientWidth: { configurable: true, value: 400 },
-      scrollWidth: { configurable: true, value: 900 },
-    });
-    owner.getBoundingClientRect = () => ({ left: 0, right: 400, top: 0, bottom: 600, width: 400, height: 600, x: 0, y: 0, toJSON: () => ({}) });
-    target.getBoundingClientRect = () => ({ left: 500, right: 800, top: 0, bottom: 400, width: 300, height: 400, x: 500, y: 0, toJSON: () => ({}) });
+  it("moves an existing stage only for explicit focus intent", () => {
+    const { owner, scrollTo } = cameraOwner();
+    appendStage(owner, "detail", 500);
     const ref = { current: owner };
     renderHook(() => useStageCamera(ref, ref, "player"));
     scrollTo.mockClear();
@@ -138,31 +184,55 @@ describe("stage camera contract", () => {
     expect(scrollTo).toHaveBeenCalledWith({ left: 450, behavior: "smooth" });
   });
 
-  it("keeps a focus request until its stage is committed and focuses it once", async () => {
-    const owner = document.createElement("div");
-    const scrollTo = vi.fn();
-    Object.defineProperties(owner, {
-      scrollTo: { configurable: true, value: scrollTo },
-      clientWidth: { configurable: true, value: 400 },
-      scrollWidth: { configurable: true, value: 900 },
-    });
-    owner.getBoundingClientRect = () => ({ left: 0, right: 400, top: 0, bottom: 600, width: 400, height: 600, x: 0, y: 0, toJSON: () => ({}) });
+  it("keeps a same-context request until its stage mounts", async () => {
+    const { owner, scrollTo } = cameraOwner();
     const ref = { current: owner };
     renderHook(() => useStageCamera(ref, ref, "player"));
 
-    act(() => requestStageFocus("late-detail", "nearest"));
+    act(() => requestStageFocus("late-detail", "forward"));
     expect(scrollTo).not.toHaveBeenCalled();
-
-    const target = document.createElement("div");
-    target.dataset.stageKey = "late-detail";
-    target.getBoundingClientRect = () => ({ left: 500, right: 800, top: 0, bottom: 400, width: 300, height: 400, x: 500, y: 0, toJSON: () => ({}) });
-    act(() => owner.append(target));
+    act(() => appendStage(owner, "late-detail", 600));
 
     await waitFor(() => expect(scrollTo).toHaveBeenCalledTimes(1));
-    expect(scrollTo).toHaveBeenCalledWith({ left: 448, behavior: "smooth" });
   });
 
-  it("coalesces competing focus intents from one commit to the final child target", () => {
+  it("does not keep a focus target that exists outside the active camera owner", async () => {
+    const { owner, scrollTo } = cameraOwner();
+    appendStage(owner, "root", 100);
+    const outside = appendStage(document.body, "left-context", 0);
+    const ref = { current: owner };
+    renderHook(() => useStageCamera(ref, ref, "role"));
+    scrollTo.mockClear();
+
+    act(() => requestStageFocus("left-context", "back"));
+    act(() => appendStage(owner, "role-summary", 420));
+
+    await waitFor(() => expect(scrollTo).toHaveBeenCalledTimes(1));
+    outside.remove();
+  });
+
+  it("invalidates stale pending focus on main context switch and ignores its late old mount", async () => {
+    const { owner, scrollTo } = cameraOwner();
+    const oldRoot = appendStage(owner, "player-root", 100);
+    const ref = { current: owner };
+    const view = renderHook(({ context }) => useStageCamera(ref, ref, context), { initialProps: { context: "player" } });
+    scrollTo.mockClear();
+    act(() => requestStageFocus("player-late-detail", "forward"));
+
+    act(() => {
+      oldRoot.remove();
+      appendStage(owner, "inventory-root", 100);
+      view.rerender({ context: "inventory" });
+    });
+    await waitFor(() => expect(scrollTo).toHaveBeenCalledTimes(1));
+    scrollTo.mockClear();
+
+    act(() => appendStage(owner, "player-late-detail", 600));
+    await act(async () => { await Promise.resolve(); });
+    expect(scrollTo).not.toHaveBeenCalled();
+  });
+
+  it("coalesces rapid explicit requests to the final valid target", () => {
     const frames = new Map<number, FrameRequestCallback>();
     let frameId = 0;
     vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
@@ -170,28 +240,16 @@ describe("stage camera contract", () => {
       return frameId;
     });
     vi.stubGlobal("cancelAnimationFrame", (id: number) => frames.delete(id));
-    const owner = document.createElement("div");
-    const list = document.createElement("div");
-    const detail = document.createElement("div");
-    list.dataset.stageKey = "list";
-    detail.dataset.stageKey = "detail";
-    owner.append(list, detail);
-    const scrollTo = vi.fn();
-    Object.defineProperties(owner, {
-      scrollTo: { configurable: true, value: scrollTo },
-      clientWidth: { configurable: true, value: 400 },
-      scrollWidth: { configurable: true, value: 1200 },
-    });
-    owner.getBoundingClientRect = () => ({ left: 0, right: 400, top: 0, bottom: 600, width: 400, height: 600, x: 0, y: 0, toJSON: () => ({}) });
-    list.getBoundingClientRect = () => ({ left: 400, right: 700, top: 0, bottom: 400, width: 300, height: 400, x: 400, y: 0, toJSON: () => ({}) });
-    detail.getBoundingClientRect = () => ({ left: 720, right: 1020, top: 0, bottom: 400, width: 300, height: 400, x: 720, y: 0, toJSON: () => ({}) });
+    const { owner, scrollTo } = cameraOwner();
+    appendStage(owner, "list", 400);
+    appendStage(owner, "detail", 720);
     const ref = { current: owner };
     renderHook(() => useStageCamera(ref, ref, "player"));
     frames.clear();
 
     act(() => {
-      requestStageFocus("list");
-      requestStageFocus("detail");
+      requestStageFocus("list", "forward");
+      requestStageFocus("detail", "forward");
     });
     [...frames.values()].forEach((callback) => callback(0));
 
@@ -199,26 +257,80 @@ describe("stage camera contract", () => {
     expect(scrollTo).toHaveBeenCalledWith({ left: 668, behavior: "smooth" });
   });
 
-  it("re-applies the active stage through the shared profile when the viewport resizes", async () => {
-    const owner = document.createElement("div");
-    const target = document.createElement("div");
-    target.dataset.stageKey = "root";
-    owner.append(target);
-    const scrollTo = vi.fn();
-    Object.defineProperties(owner, {
-      scrollTo: { configurable: true, value: scrollTo },
-      clientWidth: { configurable: true, value: 400 },
-      scrollWidth: { configurable: true, value: 900 },
-    });
-    owner.getBoundingClientRect = () => ({ left: 0, right: 400, top: 0, bottom: 600, width: 400, height: 600, x: 0, y: 0, toJSON: () => ({}) });
-    target.getBoundingClientRect = () => ({ left: 500, right: 800, top: 0, bottom: 400, width: 300, height: 400, x: 500, y: 0, toJSON: () => ({}) });
+  it("preserves the semantic active stage when switching from desktop to mobile owner", async () => {
+    const { owner: viewport, scrollTo: viewportScroll } = cameraOwner();
+    const { owner: workspace, scrollTo: workspaceScroll } = cameraOwner();
+    viewport.append(workspace);
+    appendStage(workspace, "root", 100);
+    appendStage(workspace, "detail", 600);
+    const viewportRef = { current: viewport };
+    const workspaceRef = { current: workspace };
+    renderHook(() => useStageCamera(viewportRef, workspaceRef, "player"));
+    viewportScroll.mockClear();
+
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: 390 });
+    act(() => window.dispatchEvent(new Event("resize")));
+
+    await waitFor(() => expect(viewportScroll).toHaveBeenCalledTimes(1));
+    expect(workspaceScroll).toHaveBeenLastCalledWith({ left: 0, behavior: "auto" });
+  });
+
+  it("restores contextual wide composition when switching from mobile to desktop owner", async () => {
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: 390 });
+    const { owner: viewport } = cameraOwner();
+    const { owner: workspace, scrollTo: workspaceScroll } = cameraOwner();
+    viewport.append(workspace);
+    appendStage(workspace, "root", 100);
+    appendStage(workspace, "detail", 600);
+    const viewportRef = { current: viewport };
+    const workspaceRef = { current: workspace };
+    renderHook(() => useStageCamera(viewportRef, workspaceRef, "player"));
+    workspaceScroll.mockClear();
+
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: 1440 });
+    act(() => window.dispatchEvent(new Event("resize")));
+
+    await waitFor(() => expect(workspaceScroll).toHaveBeenCalledTimes(1));
+    expect(workspaceScroll).toHaveBeenCalledWith({ left: 548, behavior: "smooth" });
+  });
+
+  it("falls back to the deepest surviving stage when the active stage is missing after profile switch", async () => {
+    const { owner: viewport, scrollTo: viewportScroll } = cameraOwner();
+    const { owner: workspace } = cameraOwner();
+    viewport.append(workspace);
+    const root = appendStage(workspace, "root", 100);
+    const detail = appendStage(workspace, "detail", 600);
+    const viewportRef = { current: viewport };
+    const workspaceRef = { current: workspace };
+    renderHook(() => useStageCamera(viewportRef, workspaceRef, "player"));
+    detail.remove();
+    viewportScroll.mockClear();
+
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: 390 });
+    act(() => window.dispatchEvent(new Event("resize")));
+
+    await waitFor(() => expect(viewportScroll).toHaveBeenCalledTimes(1));
+    expect(root.dataset.stageKey).toBe("root");
+  });
+
+  it("does not reassert the camera for manual scrolling alone", () => {
+    const { owner, scrollTo } = cameraOwner();
+    appendStage(owner, "root", 100);
     const ref = { current: owner };
     renderHook(() => useStageCamera(ref, ref, "player"));
     scrollTo.mockClear();
 
-    Object.defineProperty(window, "innerWidth", { configurable: true, value: 1000 });
-    act(() => window.dispatchEvent(new Event("resize")));
+    act(() => {
+      owner.scrollLeft = 275;
+      owner.dispatchEvent(new Event("scroll"));
+    });
 
-    await waitFor(() => expect(scrollTo).toHaveBeenCalledWith({ left: 428, behavior: "smooth" }));
+    expect(scrollTo).not.toHaveBeenCalled();
+  });
+
+  it("derives profile insets without carrying the old mobile parent-peek minimum", () => {
+    const { owner } = cameraOwner(400);
+    expect(cameraInsets(owner, "mobile")).toEqual({ leading: 24, trailing: 24 });
+    expect(cameraInsets(owner, "compact")).toEqual({ leading: 48, trailing: 32 });
   });
 });

--- a/shared/hooks/useStageCamera.test.ts
+++ b/shared/hooks/useStageCamera.test.ts
@@ -257,6 +257,87 @@ describe("stage camera contract", () => {
     expect(scrollTo).toHaveBeenCalledWith({ left: 668, behavior: "smooth" });
   });
 
+  it.each([
+    ["wide", 1440, 1300, 1000, 800, 700, 296],
+    ["compact", 1100, 900, 1000, 600, 700, 628],
+    ["mobile", 700, 500, 700, 500, 600, 576],
+  ] as const)("recomposes the active detail after a same-profile %s resize", async (
+    _profile,
+    initialViewportWidth,
+    resizedViewportWidth,
+    initialOwnerWidth,
+    resizedOwnerWidth,
+    resizedTargetLeft,
+    expectedLeft,
+  ) => {
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: initialViewportWidth });
+    const { owner, scrollTo } = cameraOwner(initialOwnerWidth, 2_000);
+    appendStage(owner, "root", 100);
+    const detail = appendStage(owner, "detail", 700);
+    const ref = { current: owner };
+    renderHook(() => useStageCamera(ref, ref, "player"));
+    act(() => requestStageFocus("detail", "forward"));
+    scrollTo.mockClear();
+
+    Object.defineProperty(owner, "clientWidth", { configurable: true, value: resizedOwnerWidth });
+    owner.getBoundingClientRect = () => domRect(0, resizedOwnerWidth);
+    detail.getBoundingClientRect = () => domRect(resizedTargetLeft - owner.scrollLeft, 300);
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: resizedViewportWidth });
+    act(() => window.dispatchEvent(new Event("resize")));
+
+    await waitFor(() => expect(scrollTo).toHaveBeenCalledTimes(1));
+    expect(scrollTo).toHaveBeenCalledWith({ left: expectedLeft, behavior: "smooth" });
+  });
+
+  it("coalesces a resize burst into one camera recomposition", async () => {
+    const frames = new Map<number, FrameRequestCallback>();
+    let frameId = 0;
+    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+      frames.set(++frameId, callback);
+      return frameId;
+    });
+    vi.stubGlobal("cancelAnimationFrame", (id: number) => frames.delete(id));
+    const { owner, scrollTo } = cameraOwner(1_000, 2_000);
+    appendStage(owner, "root", 100);
+    appendStage(owner, "detail", 700);
+    const ref = { current: owner };
+    renderHook(() => useStageCamera(ref, ref, "player"));
+
+    act(() => {
+      const initialFocus = [...frames.values()];
+      frames.clear();
+      initialFocus.forEach((callback) => callback(0));
+    });
+    scrollTo.mockClear();
+
+    Object.defineProperty(owner, "clientWidth", { configurable: true, value: 800 });
+    owner.getBoundingClientRect = () => domRect(0, 800);
+    act(() => {
+      Object.defineProperty(window, "innerWidth", { configurable: true, value: 1380 });
+      window.dispatchEvent(new Event("resize"));
+      Object.defineProperty(window, "innerWidth", { configurable: true, value: 1340 });
+      window.dispatchEvent(new Event("resize"));
+      Object.defineProperty(window, "innerWidth", { configurable: true, value: 1300 });
+      window.dispatchEvent(new Event("resize"));
+    });
+    expect(frames.size).toBe(1);
+
+    act(() => {
+      const resize = [...frames.values()];
+      frames.clear();
+      resize.forEach((callback) => callback(0));
+    });
+    await waitFor(() => expect(frames.size).toBe(1));
+    act(() => {
+      const focus = [...frames.values()];
+      frames.clear();
+      focus.forEach((callback) => callback(0));
+    });
+
+    expect(scrollTo).toHaveBeenCalledTimes(1);
+    expect(scrollTo).toHaveBeenCalledWith({ left: 296, behavior: "smooth" });
+  });
+
   it("preserves the semantic active stage when switching from desktop to mobile owner", async () => {
     const { owner: viewport, scrollTo: viewportScroll } = cameraOwner();
     const { owner: workspace, scrollTo: workspaceScroll } = cameraOwner();

--- a/shared/hooks/useStageCamera.test.ts
+++ b/shared/hooks/useStageCamera.test.ts
@@ -184,16 +184,74 @@ describe("stage camera contract", () => {
     expect(scrollTo).toHaveBeenCalledWith({ left: 450, behavior: "smooth" });
   });
 
-  it("keeps a same-context request until its stage mounts", async () => {
+  it("keeps a same-context request through unrelated mutations until its stage mounts", async () => {
     const { owner, scrollTo } = cameraOwner();
     const ref = { current: owner };
     renderHook(() => useStageCamera(ref, ref, "player"));
 
     act(() => requestStageFocus("late-detail", "forward"));
     expect(scrollTo).not.toHaveBeenCalled();
+    act(() => owner.append(document.createElement("span")));
+    await act(async () => { await Promise.resolve(); });
+    expect(scrollTo).not.toHaveBeenCalled();
     act(() => appendStage(owner, "late-detail", 600));
 
     await waitFor(() => expect(scrollTo).toHaveBeenCalledTimes(1));
+    expect(scrollTo).toHaveBeenCalledWith({ left: 548, behavior: "smooth" });
+  });
+
+  it("allows a later valid topology focus while a pending target is unresolved", async () => {
+    const { owner, scrollTo } = cameraOwner();
+    appendStage(owner, "root", 100);
+    const ref = { current: owner };
+    renderHook(() => useStageCamera(ref, ref, "player"));
+    scrollTo.mockClear();
+
+    act(() => requestStageFocus("missing-detail", "forward"));
+    act(() => appendStage(owner, "actual-detail", 600));
+
+    await waitFor(() => expect(scrollTo).toHaveBeenCalledTimes(1));
+    expect(scrollTo).toHaveBeenCalledWith({ left: 548, behavior: "smooth" });
+  });
+
+  it("does not let an unresolved target steal focus after a newer topology takes ownership", async () => {
+    const { owner, scrollTo } = cameraOwner();
+    appendStage(owner, "root", 100);
+    const ref = { current: owner };
+    renderHook(() => useStageCamera(ref, ref, "player"));
+    scrollTo.mockClear();
+
+    act(() => requestStageFocus("stale-detail", "forward"));
+    act(() => appendStage(owner, "actual-detail", 600));
+    await waitFor(() => expect(scrollTo).toHaveBeenCalledTimes(1));
+    expect(scrollTo).toHaveBeenCalledWith({ left: 548, behavior: "smooth" });
+    scrollTo.mockClear();
+
+    act(() => appendStage(owner, "stale-detail", 900));
+    await act(async () => { await Promise.resolve(); });
+
+    expect(scrollTo).not.toHaveBeenCalled();
+  });
+
+  it("lets a newer explicit request supersede an older unresolved target", async () => {
+    const { owner, scrollTo } = cameraOwner();
+    appendStage(owner, "root", 100);
+    const ref = { current: owner };
+    renderHook(() => useStageCamera(ref, ref, "player"));
+    scrollTo.mockClear();
+
+    act(() => {
+      requestStageFocus("old-detail", "forward");
+      requestStageFocus("new-detail", "forward");
+      appendStage(owner, "old-detail", 600);
+    });
+    await act(async () => { await Promise.resolve(); });
+    expect(scrollTo).not.toHaveBeenCalled();
+
+    act(() => appendStage(owner, "new-detail", 900));
+
+    await waitFor(() => expect(scrollTo).toHaveBeenCalledTimes(1));
+    expect(scrollTo).toHaveBeenCalledWith({ left: 800, behavior: "smooth" });
   });
 
   it("does not keep a focus target that exists outside the active camera owner", async () => {

--- a/shared/hooks/useStageCamera.ts
+++ b/shared/hooks/useStageCamera.ts
@@ -122,7 +122,7 @@ function prefersReducedMotion() {
   return typeof window.matchMedia === "function" && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 }
 
-type ScopedFocus = StageFocusDetail & { context: string; id: number };
+type ScopedFocus = StageFocusDetail & { context: string; id: number; awaitingMount: boolean };
 
 export function useStageCamera(
   viewportRef: React.RefObject<HTMLDivElement | null>,
@@ -194,9 +194,10 @@ export function useStageCamera(
       const nextStages = stages(owner, invalidatedKeys.current);
       const next = nextStages.map((stage) => stage.dataset.stageKey!);
       const pending = pendingFocus.current?.context === context ? pendingFocus.current : null;
-      if (pending) {
+      const pendingTarget = pending && nextStages.find((stage) => stage.dataset.stageKey === pending.key);
+      if (pendingTarget) {
         previous = next;
-        if (nextStages.some((stage) => stage.dataset.stageKey === pending.key)) focus(pending, pending.id);
+        focus(pending, pending.id);
         return;
       }
       const plan = stageFocusPlan(previous, next);
@@ -204,12 +205,20 @@ export function useStageCamera(
       const target = plan && nextStages.find((stage) => stage.dataset.stageKey === plan.key);
       if (!plan || !target || lastFocusedStage.current?.context === context && lastFocusedStage.current.key === plan.key) return;
       if (plan.align === "forward" && target.dataset.stageAutoFocus === "false") return;
+      if (pending) {
+        invalidatedKeys.current.add(pending.key);
+        pendingFocus.current = null;
+      }
       focus(plan);
     });
 
     const focusRequested = (event: Event) => {
       if (contextRef.current !== context) return;
       const detail = (event as CustomEvent<StageFocusDetail>).detail;
+      const previousPending = pendingFocus.current?.context === context ? pendingFocus.current : null;
+      if (previousPending?.awaitingMount && previousPending.key !== detail.key) {
+        invalidatedKeys.current.add(previousPending.key);
+      }
       invalidatedKeys.current.delete(detail.key);
       const targetInOwner = stages(owner, invalidatedKeys.current).some((stage) => stage.dataset.stageKey === detail.key);
       const targetOutsideOwner = !targetInOwner && [...document.querySelectorAll<HTMLElement>("[data-stage-key]")]
@@ -218,7 +227,7 @@ export function useStageCamera(
         pendingFocus.current = null;
         return;
       }
-      const pending = { ...detail, context, id: ++focusId.current };
+      const pending = { ...detail, context, id: ++focusId.current, awaitingMount: !targetInOwner };
       pendingFocus.current = pending;
       focus(pending, pending.id);
     };

--- a/shared/hooks/useStageCamera.ts
+++ b/shared/hooks/useStageCamera.ts
@@ -2,39 +2,70 @@
 
 import { useEffect, useRef, useState } from "react";
 
-type StageFocusPlan = { key: string; align: "center" | "nearest" } | null;
-type StageFocusDetail = NonNullable<StageFocusPlan>;
 export type CameraProfile = "wide" | "compact" | "mobile";
+export type CameraFocusIntent = "forward" | "back" | "center" | "nearest";
+type StageFocusPlan = { key: string; align: CameraFocusIntent } | null;
+type StageFocusDetail = NonNullable<StageFocusPlan>;
 
 export const STAGE_FOCUS_EVENT = "lag:stage-focus";
-let pendingFocus: StageFocusDetail | null = null;
 
-export function requestStageFocus(key: string, align: StageFocusDetail["align"] = "nearest") {
+export function requestStageFocus(key: string, align: CameraFocusIntent = "nearest") {
   if (typeof window === "undefined") return;
-  pendingFocus = { key, align };
-  window.dispatchEvent(new CustomEvent<StageFocusDetail>(STAGE_FOCUS_EVENT, { detail: pendingFocus }));
-}
-
-export function pendingStageFocus(): StageFocusDetail | null {
-  return pendingFocus;
+  window.dispatchEvent(new CustomEvent<StageFocusDetail>(STAGE_FOCUS_EVENT, { detail: { key, align } }));
 }
 
 export function stageFocusPlan(previous: string[], next: string[]): StageFocusPlan {
   const previousSet = new Set(previous);
   const added = next.filter((key) => !previousSet.has(key));
-  if (added.length > 0) {
-    return { key: added.at(-1)!, align: next.length === previous.length ? "center" : "nearest" };
-  }
+  if (added.length > 0) return { key: added.at(-1)!, align: "forward" };
   if (previous.at(-1) && !next.includes(previous.at(-1)!) && next.at(-1)) {
-    return { key: next.at(-1)!, align: "center" };
+    return { key: next.at(-1)!, align: "back" };
   }
   return null;
+}
+
+export function cameraScrollTarget({
+  scrollLeft,
+  scrollWidth,
+  clientWidth,
+  targetLeft,
+  targetWidth,
+  profile,
+  align,
+  insets,
+}: {
+  scrollLeft: number;
+  scrollWidth: number;
+  clientWidth: number;
+  targetLeft: number;
+  targetWidth: number;
+  profile: CameraProfile;
+  align: CameraFocusIntent;
+  insets: { leading: number; trailing: number };
+}) {
+  const maxScroll = Math.max(0, scrollWidth - clientWidth);
+  const clamp = (value: number) => Math.max(0, Math.min(value, maxScroll));
+  if (align === "center") return clamp(targetLeft + targetWidth / 2 - clientWidth / 2);
+
+  const visibleLeft = scrollLeft + insets.leading;
+  const visibleRight = scrollLeft + clientWidth - insets.trailing;
+  if (align === "nearest" && targetLeft >= visibleLeft && targetLeft + targetWidth <= visibleRight) {
+    return clamp(scrollLeft);
+  }
+
+  const usableWidth = Math.max(0, clientWidth - insets.leading - insets.trailing);
+  const targetViewportLeft = targetWidth > usableWidth
+    ? Math.max(0, clientWidth - targetWidth) / 2
+    : profile === "wide"
+      ? Math.max(insets.leading, clientWidth - insets.trailing - targetWidth)
+      : insets.leading;
+  return clamp(targetLeft - targetViewportLeft);
 }
 
 export function focusStage(
   owner: HTMLElement,
   target: HTMLElement,
-  align: "center" | "nearest",
+  align: CameraFocusIntent,
   reducedMotion: boolean,
   insets = cameraInsets(owner, "wide"),
   profile: CameraProfile = "wide",
@@ -42,20 +73,17 @@ export function focusStage(
   const ownerRect = owner.getBoundingClientRect();
   const targetRect = target.getBoundingClientRect();
   const targetLeft = owner.scrollLeft + targetRect.left - ownerRect.left;
-  let left = owner.scrollLeft;
-
-  if (align === "center") {
-    left = targetLeft + targetRect.width / 2 - owner.clientWidth / 2;
-  } else if (profile !== "wide") {
-    left = targetLeft - insets.leading;
-  } else if (targetLeft < owner.scrollLeft + insets.leading) {
-    left = targetLeft - insets.leading;
-  } else if (targetLeft + targetRect.width > owner.scrollLeft + owner.clientWidth - insets.trailing) {
-    left = targetLeft + targetRect.width - owner.clientWidth + insets.trailing;
-  }
-
   owner.scrollTo({
-    left: Math.max(0, Math.min(left, Math.max(0, owner.scrollWidth - owner.clientWidth))),
+    left: cameraScrollTarget({
+      scrollLeft: owner.scrollLeft,
+      scrollWidth: owner.scrollWidth,
+      clientWidth: owner.clientWidth,
+      targetLeft,
+      targetWidth: targetRect.width,
+      profile,
+      align,
+      insets,
+    }),
     behavior: reducedMotion ? "auto" : "smooth",
   });
 }
@@ -71,11 +99,11 @@ export function cameraInsets(owner: HTMLElement, profile: CameraProfile) {
   const cssLeading = Number.parseFloat(style.scrollPaddingLeft) || 24;
   const cssTrailing = Number.parseFloat(style.scrollPaddingRight) || 24;
   if (profile === "mobile") {
-    return { leading: Math.max(cssLeading, 64), trailing: Math.max(cssTrailing, 24) };
+    return { leading: Math.max(cssLeading, 16), trailing: Math.max(cssTrailing, 16) };
   }
   if (profile === "compact") {
     return {
-      leading: Math.max(cssLeading, Math.min(128, Math.max(72, owner.clientWidth * 0.16))),
+      leading: Math.max(cssLeading, Math.min(112, Math.max(48, owner.clientWidth * 0.12))),
       trailing: Math.max(cssTrailing, 32),
     };
   }
@@ -85,13 +113,16 @@ export function cameraInsets(owner: HTMLElement, profile: CameraProfile) {
   };
 }
 
-function stages(owner: HTMLElement) {
-  return [...owner.querySelectorAll<HTMLElement>("[data-stage-key]")];
+function stages(owner: HTMLElement, invalidated: Set<string>) {
+  return [...owner.querySelectorAll<HTMLElement>("[data-stage-key]")]
+    .filter((stage) => stage.getAttribute("aria-hidden") !== "true" && !invalidated.has(stage.dataset.stageKey!));
 }
 
 function prefersReducedMotion() {
   return typeof window.matchMedia === "function" && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 }
+
+type ScopedFocus = StageFocusDetail & { context: string; id: number };
 
 export function useStageCamera(
   viewportRef: React.RefObject<HTMLDivElement | null>,
@@ -101,9 +132,19 @@ export function useStageCamera(
   const [profile, setProfile] = useState<CameraProfile>(() =>
     cameraProfileForWidth(typeof window === "undefined" ? 1200 : window.innerWidth),
   );
-  const profileRef = useRef(profile);
-  profileRef.current = profile;
-  const lastFocusedStage = useRef<string | null>(null);
+  const contextRef = useRef(mainSelectionKey);
+  const pendingFocus = useRef<ScopedFocus | null>(null);
+  const invalidatedKeys = useRef(new Set<string>());
+  const lastFocusedStage = useRef<{ context: string; key: string } | null>(null);
+  const focusId = useRef(0);
+
+  if (contextRef.current !== mainSelectionKey) {
+    invalidatedKeys.current.clear();
+    if (pendingFocus.current) invalidatedKeys.current.add(pendingFocus.current.key);
+    pendingFocus.current = null;
+    lastFocusedStage.current = null;
+    contextRef.current = mainSelectionKey;
+  }
 
   useEffect(() => {
     const update = () => setProfile(cameraProfileForWidth(window.innerWidth));
@@ -113,67 +154,84 @@ export function useStageCamera(
   }, []);
 
   useEffect(() => {
+    const context = mainSelectionKey;
     const owner = profile === "mobile" ? viewportRef.current : workspaceRef.current;
     if (!owner) return;
-    let previous = stages(owner).map((stage) => stage.dataset.stageKey!);
+    const inactiveOwner = profile === "mobile" ? workspaceRef.current : viewportRef.current;
+    if (inactiveOwner && inactiveOwner !== owner && inactiveOwner.scrollLeft !== 0) {
+      inactiveOwner.scrollTo({ left: 0, behavior: "auto" });
+    }
+    let previous = stages(owner, invalidatedKeys.current).map((stage) => stage.dataset.stageKey!);
     let frame = 0;
-    const focus = (detail: StageFocusDetail) => {
+    let scheduledFocus = 0;
+
+    const focus = (detail: StageFocusDetail, pendingId?: number) => {
+      const scheduled = ++scheduledFocus;
       cancelAnimationFrame(frame);
       frame = requestAnimationFrame(() => {
-        const target = stages(owner).find((stage) => stage.dataset.stageKey === detail.key);
+        if (scheduled !== scheduledFocus || contextRef.current !== context) return;
+        const target = stages(owner, invalidatedKeys.current).find((stage) => stage.dataset.stageKey === detail.key);
         if (!target) return;
         focusStage(owner, target, detail.align, prefersReducedMotion(), cameraInsets(owner, profile), profile);
-        lastFocusedStage.current = detail.key;
-        if (pendingFocus?.key === detail.key) pendingFocus = null;
+        lastFocusedStage.current = { context, key: detail.key };
+        if (pendingId && pendingFocus.current?.id === pendingId) pendingFocus.current = null;
       });
     };
+
     const observer = new MutationObserver(() => {
-      cancelAnimationFrame(frame);
-      frame = requestAnimationFrame(() => {
-        const nextStages = stages(owner);
-        if (pendingFocus) {
-          const target = nextStages.find((stage) => stage.dataset.stageKey === pendingFocus?.key);
-          if (target) {
-            const detail = pendingFocus;
-            focusStage(owner, target, detail.align, prefersReducedMotion(), cameraInsets(owner, profile), profile);
-            lastFocusedStage.current = detail.key;
-            if (pendingFocus?.key === detail.key) pendingFocus = null;
-          }
-          previous = nextStages.map((stage) => stage.dataset.stageKey!);
-          return;
-        }
-        const plan = stageFocusPlan(previous, nextStages.map((stage) => stage.dataset.stageKey!));
-        previous = nextStages.map((stage) => stage.dataset.stageKey!);
-        const target = plan && nextStages.find((stage) => stage.dataset.stageKey === plan.key);
-        if (plan && target) {
-          focusStage(owner, target, plan.align, prefersReducedMotion(), cameraInsets(owner, profile), profile);
-          lastFocusedStage.current = plan.key;
-        }
-      });
+      if (contextRef.current !== context) return;
+      const nextStages = stages(owner, invalidatedKeys.current);
+      const next = nextStages.map((stage) => stage.dataset.stageKey!);
+      const pending = pendingFocus.current?.context === context ? pendingFocus.current : null;
+      if (pending) {
+        previous = next;
+        if (nextStages.some((stage) => stage.dataset.stageKey === pending.key)) focus(pending, pending.id);
+        return;
+      }
+      const plan = stageFocusPlan(previous, next);
+      previous = next;
+      const target = plan && nextStages.find((stage) => stage.dataset.stageKey === plan.key);
+      if (!plan || !target || lastFocusedStage.current?.context === context && lastFocusedStage.current.key === plan.key) return;
+      if (plan.align === "forward" && target.dataset.stageAutoFocus === "false") return;
+      focus(plan);
     });
+
     const focusRequested = (event: Event) => {
-      focus((event as CustomEvent<StageFocusDetail>).detail);
+      if (contextRef.current !== context) return;
+      const detail = (event as CustomEvent<StageFocusDetail>).detail;
+      invalidatedKeys.current.delete(detail.key);
+      const targetInOwner = stages(owner, invalidatedKeys.current).some((stage) => stage.dataset.stageKey === detail.key);
+      const targetOutsideOwner = !targetInOwner && [...document.querySelectorAll<HTMLElement>("[data-stage-key]")]
+        .some((stage) => stage.getAttribute("aria-hidden") !== "true" && stage.dataset.stageKey === detail.key);
+      if (targetOutsideOwner) {
+        pendingFocus.current = null;
+        return;
+      }
+      const pending = { ...detail, context, id: ++focusId.current };
+      pendingFocus.current = pending;
+      focus(pending, pending.id);
     };
+
     observer.observe(owner, { childList: true, subtree: true });
     window.addEventListener(STAGE_FOCUS_EVENT, focusRequested);
-    if (pendingFocus) focus(pendingFocus);
-    else if (lastFocusedStage.current) focus({ key: lastFocusedStage.current, align: "nearest" });
+
+    const currentPending = pendingFocus.current?.context === context ? pendingFocus.current : null;
+    const currentStages = stages(owner, invalidatedKeys.current);
+    const pendingTarget = currentPending && currentStages.find((stage) => stage.dataset.stageKey === currentPending.key);
+    if (currentPending && pendingTarget) focus(currentPending, currentPending.id);
+    else {
+      const active = lastFocusedStage.current?.context === context
+        ? currentStages.find((stage) => stage.dataset.stageKey === lastFocusedStage.current?.key)
+        : null;
+      const fallback = active ?? currentStages.at(-1);
+      if (fallback) focus({ key: fallback.dataset.stageKey!, align: "forward" });
+    }
+
     return () => {
+      scheduledFocus += 1;
       cancelAnimationFrame(frame);
       observer.disconnect();
       window.removeEventListener(STAGE_FOCUS_EVENT, focusRequested);
     };
-  }, [profile, viewportRef, workspaceRef]);
-
-  useEffect(() => {
-    const currentProfile = profileRef.current;
-    const owner = currentProfile === "mobile" ? viewportRef.current : workspaceRef.current;
-    const target = owner && stages(owner)[0];
-    if (!owner || !target || pendingFocus) return;
-    const frame = requestAnimationFrame(() => {
-      focusStage(owner, target, currentProfile === "wide" ? "center" : "nearest", prefersReducedMotion(), cameraInsets(owner, currentProfile), currentProfile);
-      lastFocusedStage.current = target.dataset.stageKey ?? null;
-    });
-    return () => cancelAnimationFrame(frame);
-  }, [mainSelectionKey, viewportRef, workspaceRef]);
+  }, [mainSelectionKey, profile, viewportRef, workspaceRef]);
 }

--- a/shared/hooks/useStageCamera.ts
+++ b/shared/hooks/useStageCamera.ts
@@ -132,6 +132,7 @@ export function useStageCamera(
   const [profile, setProfile] = useState<CameraProfile>(() =>
     cameraProfileForWidth(typeof window === "undefined" ? 1200 : window.innerWidth),
   );
+  const [viewportRevision, setViewportRevision] = useState(0);
   const contextRef = useRef(mainSelectionKey);
   const pendingFocus = useRef<ScopedFocus | null>(null);
   const invalidatedKeys = useRef(new Set<string>());
@@ -147,10 +148,20 @@ export function useStageCamera(
   }
 
   useEffect(() => {
-    const update = () => setProfile(cameraProfileForWidth(window.innerWidth));
-    update();
-    window.addEventListener("resize", update);
-    return () => window.removeEventListener("resize", update);
+    let frame = 0;
+    const resize = () => {
+      cancelAnimationFrame(frame);
+      frame = requestAnimationFrame(() => {
+        setProfile(cameraProfileForWidth(window.innerWidth));
+        setViewportRevision((value) => value + 1);
+      });
+    };
+    setProfile(cameraProfileForWidth(window.innerWidth));
+    window.addEventListener("resize", resize);
+    return () => {
+      cancelAnimationFrame(frame);
+      window.removeEventListener("resize", resize);
+    };
   }, []);
 
   useEffect(() => {
@@ -233,5 +244,5 @@ export function useStageCamera(
       observer.disconnect();
       window.removeEventListener(STAGE_FOCUS_EVENT, focusRequested);
     };
-  }, [mainSelectionKey, profile, viewportRef, workspaceRef]);
+  }, [mainSelectionKey, profile, viewportRef, viewportRevision, workspaceRef]);
 }

--- a/shared/ui/PanelStage.test.tsx
+++ b/shared/ui/PanelStage.test.tsx
@@ -9,6 +9,7 @@ describe("PanelStage camera contract", () => {
   const focus = vi.fn();
 
   beforeEach(() => {
+    focus.mockClear();
     vi.stubGlobal("matchMedia", vi.fn(() => ({ matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn() })));
     window.addEventListener(STAGE_FOCUS_EVENT, focus);
   });
@@ -24,11 +25,10 @@ describe("PanelStage camera contract", () => {
 
   it("keeps camera position stable when content identity changes in the same stage", () => {
     const view = render(<PanelStage stageKey="detail"><span>Detail A</span></PanelStage>);
-    focus.mockClear();
 
     view.rerender(<PanelStage stageKey="detail"><span>Detail B</span></PanelStage>);
 
-    expect(focus).not.toHaveBeenCalled();
+    expect(focus).toHaveBeenCalledTimes(1);
   });
 
   it("preserves opt-out topology metadata and reduced-motion panel behavior", () => {

--- a/shared/ui/PanelStage.test.tsx
+++ b/shared/ui/PanelStage.test.tsx
@@ -1,0 +1,43 @@
+import { render } from "@testing-library/react";
+import { readFileSync } from "node:fs";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { STAGE_FOCUS_EVENT } from "@/shared/hooks/useStageCamera";
+import PanelStage from "./PanelStage";
+
+describe("PanelStage camera contract", () => {
+  const focus = vi.fn();
+
+  beforeEach(() => {
+    vi.stubGlobal("matchMedia", vi.fn(() => ({ matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn() })));
+    window.addEventListener(STAGE_FOCUS_EVENT, focus);
+  });
+
+  afterEach(() => window.removeEventListener(STAGE_FOCUS_EVENT, focus));
+
+  it("focuses a genuine spatial stage once when it mounts", () => {
+    render(<PanelStage stageKey="detail"><span>Detail A</span></PanelStage>);
+
+    expect(focus).toHaveBeenCalledTimes(1);
+    expect(focus.mock.calls[0][0]).toMatchObject({ detail: { key: "detail", align: "forward" } });
+  });
+
+  it("keeps camera position stable when content identity changes in the same stage", () => {
+    const view = render(<PanelStage stageKey="detail"><span>Detail A</span></PanelStage>);
+    focus.mockClear();
+
+    view.rerender(<PanelStage stageKey="detail"><span>Detail B</span></PanelStage>);
+
+    expect(focus).not.toHaveBeenCalled();
+  });
+
+  it("preserves opt-out topology metadata and reduced-motion panel behavior", () => {
+    const { container } = render(<PanelStage stageKey="history" autoFocus={false}><span>History</span></PanelStage>);
+    const source = readFileSync("shared/ui/PanelStage.tsx", "utf8");
+
+    expect(container.querySelector('[data-stage-auto-focus="false"]')).toBeInTheDocument();
+    expect(focus).not.toHaveBeenCalled();
+    expect(source).toContain("initial={reducedMotion ? false");
+    expect(source).toContain("transition={reducedMotion ? { duration: 0 }");
+  });
+});

--- a/shared/ui/PanelStage.tsx
+++ b/shared/ui/PanelStage.tsx
@@ -8,14 +8,12 @@ import { requestStageFocus } from "@/shared/hooks/useStageCamera";
 
 export default function PanelStage({
   stageKey,
-  focusKey,
   autoFocus = true,
   children,
   onPointerDownCapture,
   zIndex,
 }: {
   stageKey: string;
-  focusKey?: string | number | null;
   autoFocus?: boolean;
   index?: number;
   children: React.ReactNode;
@@ -27,14 +25,15 @@ export default function PanelStage({
 
   useLayoutEffect(() => {
     if (!autoFocus) return;
-    requestStageFocus(stageKey, "nearest");
-  }, [autoFocus, focusKey, stageKey]);
+    requestStageFocus(stageKey, "forward");
+  }, [autoFocus, stageKey]);
 
   return (
     <motion.div
       layout="position"
       className="lag-panel-stage relative"
       data-stage-key={stageKey}
+      data-stage-auto-focus={autoFocus ? undefined : "false"}
       aria-hidden={isPresent ? undefined : true}
       onPointerDownCapture={onPointerDownCapture}
       initial={reducedMotion ? false : MOTION.panelSlot.initial}

--- a/widgets/right-panels/RightPanels.test.tsx
+++ b/widgets/right-panels/RightPanels.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import type { PanelStackItem } from "@/entities/nav";
+import { STAGE_FOCUS_EVENT } from "@/shared/hooks/useStageCamera";
 import RightPanels from "./RightPanels";
 
 const root = (selectedId?: string): PanelStackItem => ({
@@ -35,6 +36,8 @@ const detail = (id: string): PanelStackItem => ({
 
 describe("RightPanels stable stage frames", () => {
   it("preserves the root and detail DOM frames while child content changes", () => {
+    const focus = vi.fn();
+    window.addEventListener(STAGE_FOCUS_EVENT, focus);
     const props = { selectedMain: "player" as const, onPanelItemSelect: vi.fn() };
     const view = render(<RightPanels {...props} panelStack={[root()]} />);
     const rootStage = document.querySelector('[data-stage-key="player-stage-0"]');
@@ -43,10 +46,13 @@ describe("RightPanels stable stage frames", () => {
     const detailStage = document.querySelector('[data-stage-key="player-stage-2"]');
     expect(document.querySelector('[data-stage-key="player-stage-0"]')).toBe(rootStage);
 
+    focus.mockClear();
     view.rerender(<RightPanels {...props} panelStack={[root("title"), list("skill-b"), detail("skill-b")]} />);
     expect(document.querySelector('[data-stage-key="player-stage-0"]')).toBe(rootStage);
     expect(document.querySelector('[data-stage-key="player-stage-2"]')).toBe(detailStage);
     expect(screen.getByText("skill-b")).toBeInTheDocument();
+    expect(focus).not.toHaveBeenCalled();
+    window.removeEventListener(STAGE_FOCUS_EVENT, focus);
   });
 
   it("gives Skills child stages a feature-state Back affordance", () => {

--- a/widgets/right-panels/RightPanels.tsx
+++ b/widgets/right-panels/RightPanels.tsx
@@ -253,7 +253,6 @@ export default function RightPanels({
                 <PanelStage
                   key={`${selectedMain}-stage-${panelIndex}`}
                   stageKey={`${selectedMain}-stage-${panelIndex}`}
-                  focusKey={panel.id}
                   autoFocus={panelIndex > 0}
                   index={panelIndex}
                   onPointerDownCapture={() => onPanelFocus?.(panelIndex, panel.id)}


### PR DESCRIPTION
## Purpose

Complete the deferred cross-cutting stage-camera/viewpoint polish now that the primary application surfaces have stable structure.

Closes #72

## Delivered

- finalized wide / compact / mobile camera composition
- scoped pending-focus lifetime
- stale cross-feature focus invalidation
- stable same-depth content replacement
- immediate-parent Back composition
- deterministic rapid-focus coalescing
- responsive profile/owner re-composition
- manual-pan-safe camera behavior
- representative staged-feature regression coverage
- preserved reduced-motion behavior

## Camera Contract

The camera follows semantic stage depth rather than arbitrary DOM mutation.

```text
new child stage
-> move viewpoint to child composition

same stage, different content
-> keep viewpoint stable

Back
-> immediate surviving parent

main surface switch
-> invalidate stale previous-surface focus
```

## Responsive Composition

Wide prioritizes the active stage while preserving useful immediate-parent context where geometry allows.

Compact gives the active child stronger viewport priority with secondary parent context.

Mobile follows one-screen-one-purpose and does not preserve desktop-style parent peeking at the cost of readability.

## Pending Focus

A pending focus request is scoped to the current camera context.

Stale focus keys from an unmounted previous feature cannot block later stage transitions.

Same-context late-mounted stages remain supported.

## PanelStage

Spatial-stage focus is separated from same-depth content identity.

Changing the selected entity inside an existing detail stage no longer causes a full camera transition.

Intentional focus of an existing stage remains available through explicit camera requests.

## Back / Resize

Closing the deepest stage returns camera ownership to the immediate surviving parent.

Viewport/profile changes preserve the semantically active valid stage and recompute composition for the new profile.

## Boundaries

This PR does not change:

- domain/API behavior
- OrbNav product navigation
- LeftContext semantics
- Connections/Direct Chat utility-window logic
- Notification popup behavior
- application feature hierarchy

## Accessibility / Motion

Reduced-motion mode keeps non-animated camera movement and zero/immediate staged transitions according to the existing accessibility contract.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation across player, inventory, market, journal, quests, roles, and settings screens.
  * Returning to a previous list now restores the camera to the expected back position.
  * Changing selections or editing content no longer causes unwanted camera refocusing.
  * Opening new content uses a consistent forward transition.
  * Improved handling of category changes and unavailable items while preserving the current detail view.
  * Camera positioning now better adapts to screen size, scrolling limits, and reduced-motion preferences.

* **Tests**
  * Expanded coverage for camera focus, navigation transitions, and autofocus behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->