### PR TITLE
[Admin] Add read-only Player Lookup and quick detail

### DIFF
--- a/app/admin/page.test.tsx
+++ b/app/admin/page.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { readFileSync } from "node:fs";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -10,10 +10,16 @@ const source = vi.hoisted(() => ({
   descriptor: { mode: "api" as const, badge: "API" as const, label: "/admin/v1", eventLabel: "/admin/v1/audit-events" },
   getEvents: vi.fn(),
 }));
+const playerSource = vi.hoisted(() => ({
+  descriptor: { mode: "api" as const, badge: "API" as const, label: "/admin/v1", playerLabel: "/admin/v1/players" },
+  lookupByUserId: vi.fn(),
+  getByPlayerId: vi.fn(),
+}));
 
 vi.mock("next/navigation", () => ({ useRouter: () => router }));
 vi.mock("@/features/auth/AuthContext", () => ({ useAuth: () => auth }));
 vi.mock("@/features/admin/api/audit.source", () => ({ adminAuditDataSource: source }));
+vi.mock("@/features/admin/api/player.source", () => ({ adminPlayerDataSource: playerSource }));
 
 describe("/admin route", () => {
   beforeEach(() => {
@@ -21,22 +27,28 @@ describe("/admin route", () => {
     source.getEvents.mockResolvedValue({ items: [], nextCursor: null });
   });
 
-  it("composes the canonical shell and Audit screen without legacy Admin authority", async () => {
+  it("composes Player Lookup and preserves the supported Audit route", async () => {
     render(<AdminPage />);
 
     expect(screen.getByText("operator@lag")).toBeInTheDocument();
     expect(screen.getByText("API")).toBeInTheDocument();
     expect(screen.getByText("/admin/v1")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Player Lookup" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Ready for exact lookup" })).toBeInTheDocument();
+    expect(playerSource.lookupByUserId).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "System, SUPPORTED" }));
     expect(screen.getByRole("heading", { name: "Admin Audit Explorer" })).toBeInTheDocument();
     expect(await screen.findByRole("heading", { name: "No audit events" })).toBeInTheDocument();
     expect(source.getEvents).toHaveBeenCalledWith({ size: 50 });
 
     const pageSource = readFileSync("app/admin/page.tsx", "utf8");
     expect(pageSource).not.toMatch(/admin\.api|OrbNav|adjustWallet|grant|revoke|deleteUser/i);
-    expect(pageSource.split("\n").length).toBeLessThan(45);
+    expect(pageSource.split("\n").length).toBeLessThan(50);
 
     const css = readFileSync("features/admin/admin.module.css", "utf8");
     expect(css).toMatch(/\.auditLayout\s*\{[^}]*grid-template-columns:\s*minmax\(0, 1fr\) minmax\(320px, 390px\)/);
+    expect(css).toMatch(/\.playerLayout\s*\{[^}]*grid-template-columns:\s*minmax\(0, 1fr\) minmax\(320px, 390px\)/);
     expect(css).toMatch(/\.tableWrap\s*\{[^}]*overflow:\s*auto/);
   });
 });

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -4,6 +4,8 @@ import { useRouter } from "next/navigation";
 
 import { AuditExplorer } from "@/features/admin/audit/AuditExplorer";
 import { adminAuditDataSource } from "@/features/admin/api/audit.source";
+import { adminPlayerDataSource } from "@/features/admin/api/player.source";
+import { PlayerLookup } from "@/features/admin/player/PlayerLookup";
 import { AdminShell } from "@/features/admin/shell/AdminShell";
 import { useAuth } from "@/features/auth/AuthContext";
 
@@ -17,6 +19,7 @@ export default function AdminPage() {
       operator={currentUser?.email ?? "Session not authenticated"}
       source={adminAuditDataSource.descriptor}
       audit={<AuditExplorer access={access} onLogin={() => router.push("/login")} dataSource={adminAuditDataSource} />}
+      player={<PlayerLookup access={access} onLogin={() => router.push("/login")} dataSource={adminPlayerDataSource} />}
     />
   );
 }

--- a/features/admin/admin.module.css
+++ b/features/admin/admin.module.css
@@ -741,6 +741,135 @@
   border-radius: 8px;
 }
 
+.playerLookupForm {
+  display: grid;
+  grid-template-columns: minmax(220px, 360px) auto minmax(0, 1fr);
+  align-items: end;
+  gap: 10px;
+  padding: 12px;
+  background: var(--admin-panel);
+  border: 1px solid var(--admin-border);
+  border-radius: 10px;
+}
+
+.playerLookupForm label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  color: var(--admin-text-2);
+  font-size: 10px;
+  font-weight: 700;
+}
+
+.playerLookupForm input {
+  width: 100%;
+  height: 36px;
+  padding: 0 10px;
+  color: var(--admin-text);
+  background: var(--admin-workspace);
+  border: 1px solid var(--admin-border);
+  border-radius: 6px;
+  font: inherit;
+}
+
+.playerLookupForm p {
+  align-self: center;
+  margin: 0;
+  color: var(--admin-failed);
+  font-size: 11px;
+}
+
+.playerLayout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(320px, 390px);
+  align-items: start;
+  gap: 14px;
+}
+
+.playerLayout > section {
+  min-width: 0;
+}
+
+.resultTitle {
+  margin: 0 0 8px;
+  color: var(--admin-text);
+  font-size: 13px;
+}
+
+.playerTable {
+  min-width: 560px;
+}
+
+.playerStats,
+.playerEffects {
+  margin-top: 16px;
+}
+
+.playerStats h3,
+.playerEffects h3 {
+  margin: 0 0 8px;
+  color: var(--admin-text);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.playerStats dl {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 6px;
+  margin: 0;
+}
+
+.playerStats dl > div {
+  padding: 8px;
+  background: color-mix(in srgb, var(--admin-shell) 72%, var(--admin-panel));
+  border: 1px solid var(--admin-row-divider);
+  border-radius: 6px;
+  text-align: center;
+}
+
+.playerStats dt {
+  color: var(--admin-muted);
+  font-size: 9px;
+}
+
+.playerStats dd {
+  margin: 3px 0 0;
+  color: var(--admin-text);
+  font-weight: 750;
+}
+
+.playerEffects ul {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.playerEffects li {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 7px 8px;
+  color: var(--admin-text-2);
+  background: color-mix(in srgb, var(--admin-shell) 72%, var(--admin-panel));
+  border: 1px solid var(--admin-row-divider);
+  border-radius: 6px;
+  font-size: 10px;
+}
+
+.playerEffects code {
+  color: var(--admin-id);
+  user-select: text;
+}
+
+.playerEffects p {
+  color: var(--admin-muted);
+  font-size: 11px;
+}
+
 @media (max-width: 1179px) {
   .root {
     grid-template:
@@ -774,6 +903,10 @@
   }
 
   .auditLayout {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .playerLayout {
     grid-template-columns: minmax(0, 1fr);
   }
 
@@ -857,6 +990,14 @@
 
   .filterGrid {
     grid-template-columns: minmax(0, 1fr);
+  }
+
+  .playerLookupForm {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .playerLookupForm button {
+    width: 100%;
   }
 
   .filterActions {

--- a/features/admin/api/audit.source.ts
+++ b/features/admin/api/audit.source.ts
@@ -1,18 +1,14 @@
 import type { AdminAuditPage, AdminAuditQuery } from "../model";
 import { getAdminAuditEvents } from "./audit";
 import { getMockAdminAuditEvents } from "./audit.mock";
+import { resolveAdminDataSourceMode } from "./source";
+import type { AdminDataSourceDescriptor } from "./source";
 
-export type AdminDataSourceMode = "api" | "mock";
-
-export type AdminDataSourceDescriptor = {
-  mode: AdminDataSourceMode;
-  badge: "API" | "MOCK DATA";
-  label: string;
-  eventLabel: string;
-};
+export { resolveAdminDataSourceMode } from "./source";
+export type { AdminDataSourceDescriptor, AdminDataSourceMode } from "./source";
 
 export type AdminAuditDataSource = {
-  descriptor: AdminDataSourceDescriptor;
+  descriptor: AdminDataSourceDescriptor & { eventLabel: string };
   getEvents: (query: AdminAuditQuery) => Promise<AdminAuditPage>;
 };
 
@@ -25,10 +21,6 @@ const MOCK_SOURCE: AdminAuditDataSource = {
   descriptor: { mode: "mock", badge: "MOCK DATA", label: "Local Admin Mock", eventLabel: "Local Admin Mock" },
   getEvents: getMockAdminAuditEvents,
 };
-
-export function resolveAdminDataSourceMode(value: unknown): AdminDataSourceMode {
-  return value === "mock" ? "mock" : "api";
-}
 
 export function getAdminAuditDataSource(value: unknown): AdminAuditDataSource {
   return resolveAdminDataSourceMode(value) === "mock" ? MOCK_SOURCE : API_SOURCE;

--- a/features/admin/api/player.mock.test.ts
+++ b/features/admin/api/player.mock.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { getMockAdminPlayerById, lookupMockAdminPlayerByUserId } from "./player.mock";
+
+describe("read-only Admin Player mock adapter", () => {
+  it("returns deterministic Summary and PlayerInfo with only proven DTO fields", async () => {
+    const summary = await lookupMockAdminPlayerByUserId(8314);
+    const detail = await getMockAdminPlayerById(summary.playerId);
+
+    expect(summary).toEqual({ playerId: 10218, userId: 8314, name: "HANEUL" });
+    expect(Object.keys(detail)).toEqual([
+      "playerId", "name", "gender", "job", "level", "totalExp", "currentHealth", "healthCapacity", "currentMana", "manaCapacity",
+      "str", "agi", "dex", "intel", "vit", "luc", "effects", "representativeTitleId",
+    ]);
+    expect(detail.effects).toEqual([{ code: "FOCUSED", category: "BUFF" }]);
+    expect(detail).not.toHaveProperty("wallet");
+    expect(detail).not.toHaveProperty("inventory");
+    expect(detail).not.toHaveProperty("lifeLog");
+    expect(detail).not.toHaveProperty("person");
+    expect(detail).not.toHaveProperty("directChat");
+  });
+
+  it("returns the same deterministic value and reports not-found without fake fallback data", async () => {
+    expect(await lookupMockAdminPlayerByUserId(8314)).toEqual(await lookupMockAdminPlayerByUserId(8314));
+    await expect(lookupMockAdminPlayerByUserId(9999)).rejects.toMatchObject({ status: 404 });
+    await expect(getMockAdminPlayerById(9999)).rejects.toMatchObject({ status: 404 });
+  });
+});

--- a/features/admin/api/player.mock.test.ts
+++ b/features/admin/api/player.mock.test.ts
@@ -25,4 +25,15 @@ describe("read-only Admin Player mock adapter", () => {
     await expect(lookupMockAdminPlayerByUserId(9999)).rejects.toMatchObject({ status: 404 });
     await expect(getMockAdminPlayerById(9999)).rejects.toMatchObject({ status: 404 });
   });
+
+  it.each([
+    ["userId", () => lookupMockAdminPlayerByUserId(0)],
+    ["playerId", () => getMockAdminPlayerById(-1)],
+  ])("rejects invalid %s values instead of treating them as not-found", async (_field, request) => {
+    const result = request();
+
+    expect(result).toBeInstanceOf(Promise);
+    await expect(result).rejects.toThrow(RangeError);
+    await expect(result).rejects.toThrow("positive integer");
+  });
 });

--- a/features/admin/api/player.mock.ts
+++ b/features/admin/api/player.mock.ts
@@ -1,5 +1,6 @@
 import { ApiError } from "@/shared/api/client";
 import type { AdminPlayerInfo, AdminPlayerSummary } from "../player/model";
+import { requirePositiveAdminPlayerId } from "./player.query";
 
 const SUMMARY: AdminPlayerSummary = { playerId: 10218, userId: 8314, name: "HANEUL" };
 const INFO: AdminPlayerInfo = {
@@ -26,11 +27,13 @@ const INFO: AdminPlayerInfo = {
 const notFound = () => new ApiError(404, "PLAYER_NOT_FOUND", "Player was not found.");
 
 export async function lookupMockAdminPlayerByUserId(userId: number): Promise<AdminPlayerSummary> {
+  requirePositiveAdminPlayerId(userId, "userId");
   if (userId !== SUMMARY.userId) throw notFound();
   return { ...SUMMARY };
 }
 
 export async function getMockAdminPlayerById(playerId: number): Promise<AdminPlayerInfo> {
+  requirePositiveAdminPlayerId(playerId, "playerId");
   if (playerId !== INFO.playerId) throw notFound();
   return { ...INFO, effects: INFO.effects.map((effect) => ({ ...effect })) };
 }

--- a/features/admin/api/player.mock.ts
+++ b/features/admin/api/player.mock.ts
@@ -1,0 +1,36 @@
+import { ApiError } from "@/shared/api/client";
+import type { AdminPlayerInfo, AdminPlayerSummary } from "../player/model";
+
+const SUMMARY: AdminPlayerSummary = { playerId: 10218, userId: 8314, name: "HANEUL" };
+const INFO: AdminPlayerInfo = {
+  playerId: 10218,
+  name: "HANEUL",
+  gender: "FEMALE",
+  job: "KNIGHT",
+  level: 17,
+  totalExp: 48200,
+  currentHealth: 840,
+  healthCapacity: 1000,
+  currentMana: 310,
+  manaCapacity: 420,
+  str: 32,
+  agi: 28,
+  dex: 30,
+  intel: 19,
+  vit: 34,
+  luc: 14,
+  effects: [{ code: "FOCUSED", category: "BUFF" }],
+  representativeTitleId: 41,
+};
+
+const notFound = () => new ApiError(404, "PLAYER_NOT_FOUND", "Player was not found.");
+
+export async function lookupMockAdminPlayerByUserId(userId: number): Promise<AdminPlayerSummary> {
+  if (userId !== SUMMARY.userId) throw notFound();
+  return { ...SUMMARY };
+}
+
+export async function getMockAdminPlayerById(playerId: number): Promise<AdminPlayerInfo> {
+  if (playerId !== INFO.playerId) throw notFound();
+  return { ...INFO, effects: INFO.effects.map((effect) => ({ ...effect })) };
+}

--- a/features/admin/api/player.query.ts
+++ b/features/admin/api/player.query.ts
@@ -1,0 +1,4 @@
+export function requirePositiveAdminPlayerId(value: number, field: "userId" | "playerId") {
+  if (!Number.isInteger(value) || value < 1) throw new RangeError(`${field} must be a positive integer.`);
+  return value;
+}

--- a/features/admin/api/player.source.test.ts
+++ b/features/admin/api/player.source.test.ts
@@ -1,0 +1,32 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getAdminPlayerDataSource } from "./player.source";
+
+const api = vi.hoisted(() => ({ lookup: vi.fn(), detail: vi.fn() }));
+const mock = vi.hoisted(() => ({ lookup: vi.fn(), detail: vi.fn() }));
+vi.mock("./player", () => ({ lookupAdminPlayerByUserId: api.lookup, getAdminPlayerById: api.detail }));
+vi.mock("./player.mock", () => ({ lookupMockAdminPlayerByUserId: mock.lookup, getMockAdminPlayerById: mock.detail }));
+
+describe("Admin Player data-source selector", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it.each([
+    [undefined, "api"],
+    ["api", "api"],
+    ["mock", "mock"],
+    ["invalid", "api"],
+  ] as const)("resolves %s to %s using the shared Admin mode rule", (value, expected) => {
+    expect(getAdminPlayerDataSource(value).descriptor.mode).toBe(expected);
+  });
+
+  it("exposes truthful Player source labels", () => {
+    expect(getAdminPlayerDataSource("api").descriptor).toEqual({ mode: "api", badge: "API", label: "/admin/v1", playerLabel: "/admin/v1/players" });
+    expect(getAdminPlayerDataSource("mock").descriptor).toEqual({ mode: "mock", badge: "MOCK DATA", label: "Local Admin Mock", playerLabel: "Local Admin Mock" });
+  });
+
+  it("does not fall back to Mock when the API source fails", async () => {
+    api.lookup.mockRejectedValueOnce(new Error("API unavailable"));
+    await expect(getAdminPlayerDataSource("api").lookupByUserId(8314)).rejects.toThrow("API unavailable");
+    expect(mock.lookup).not.toHaveBeenCalled();
+  });
+});

--- a/features/admin/api/player.source.ts
+++ b/features/admin/api/player.source.ts
@@ -1,0 +1,29 @@
+import type { AdminPlayerInfo, AdminPlayerSummary } from "../player/model";
+import { getAdminPlayerById, lookupAdminPlayerByUserId } from "./player";
+import { getMockAdminPlayerById, lookupMockAdminPlayerByUserId } from "./player.mock";
+import { resolveAdminDataSourceMode } from "./source";
+import type { AdminDataSourceDescriptor } from "./source";
+
+export type AdminPlayerDataSource = {
+  descriptor: AdminDataSourceDescriptor & { playerLabel: string };
+  lookupByUserId: (userId: number) => Promise<AdminPlayerSummary>;
+  getByPlayerId: (playerId: number) => Promise<AdminPlayerInfo>;
+};
+
+const API_SOURCE: AdminPlayerDataSource = {
+  descriptor: { mode: "api", badge: "API", label: "/admin/v1", playerLabel: "/admin/v1/players" },
+  lookupByUserId: lookupAdminPlayerByUserId,
+  getByPlayerId: getAdminPlayerById,
+};
+
+const MOCK_SOURCE: AdminPlayerDataSource = {
+  descriptor: { mode: "mock", badge: "MOCK DATA", label: "Local Admin Mock", playerLabel: "Local Admin Mock" },
+  lookupByUserId: lookupMockAdminPlayerByUserId,
+  getByPlayerId: getMockAdminPlayerById,
+};
+
+export function getAdminPlayerDataSource(value: unknown): AdminPlayerDataSource {
+  return resolveAdminDataSourceMode(value) === "mock" ? MOCK_SOURCE : API_SOURCE;
+}
+
+export const adminPlayerDataSource = getAdminPlayerDataSource(process.env.NEXT_PUBLIC_ADMIN_DATA_SOURCE);

--- a/features/admin/api/player.test.ts
+++ b/features/admin/api/player.test.ts
@@ -24,8 +24,11 @@ describe("canonical Admin Player API adapter", () => {
     ["userId", () => lookupAdminPlayerByUserId(0)],
     ["playerId", () => getAdminPlayerById(-1)],
     ["playerId", () => getAdminPlayerById(1.5)],
-  ])("rejects invalid %s values", (_field, request) => {
-    expect(request).toThrow("positive integer");
+  ])("rejects invalid %s values through its Promise contract", async (_field, request) => {
+    const result = request();
+
+    expect(result).toBeInstanceOf(Promise);
+    await expect(result).rejects.toThrow("positive integer");
     expect(client.apiGet).not.toHaveBeenCalled();
   });
 });

--- a/features/admin/api/player.test.ts
+++ b/features/admin/api/player.test.ts
@@ -1,0 +1,31 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getAdminPlayerById, lookupAdminPlayerByUserId } from "./player";
+
+const client = vi.hoisted(() => ({ apiGet: vi.fn() }));
+vi.mock("@/shared/api/client", () => client);
+
+describe("canonical Admin Player API adapter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    client.apiGet.mockResolvedValue({});
+  });
+
+  it("uses the exact userId lookup and playerId detail endpoints", async () => {
+    await lookupAdminPlayerByUserId(8314);
+    await getAdminPlayerById(10218);
+
+    expect(client.apiGet).toHaveBeenNthCalledWith(1, "/admin/v1/players?userId=8314");
+    expect(client.apiGet).toHaveBeenNthCalledWith(2, "/admin/v1/players/10218");
+    expect(client.apiGet.mock.calls.flat().join(" ")).not.toContain("/api/v1/admin/");
+  });
+
+  it.each([
+    ["userId", () => lookupAdminPlayerByUserId(0)],
+    ["playerId", () => getAdminPlayerById(-1)],
+    ["playerId", () => getAdminPlayerById(1.5)],
+  ])("rejects invalid %s values", (_field, request) => {
+    expect(request).toThrow("positive integer");
+    expect(client.apiGet).not.toHaveBeenCalled();
+  });
+});

--- a/features/admin/api/player.ts
+++ b/features/admin/api/player.ts
@@ -1,0 +1,17 @@
+import { apiGet } from "@/shared/api/client";
+import type { AdminPlayerInfo, AdminPlayerSummary } from "../player/model";
+
+export const ADMIN_PLAYERS_PATH = "/admin/v1/players";
+
+function positiveId(value: number, field: string) {
+  if (!Number.isInteger(value) || value < 1) throw new RangeError(`${field} must be a positive integer.`);
+  return value;
+}
+
+export function lookupAdminPlayerByUserId(userId: number): Promise<AdminPlayerSummary> {
+  return apiGet<AdminPlayerSummary>(`${ADMIN_PLAYERS_PATH}?userId=${positiveId(userId, "userId")}`);
+}
+
+export function getAdminPlayerById(playerId: number): Promise<AdminPlayerInfo> {
+  return apiGet<AdminPlayerInfo>(`${ADMIN_PLAYERS_PATH}/${positiveId(playerId, "playerId")}`);
+}

--- a/features/admin/api/player.ts
+++ b/features/admin/api/player.ts
@@ -1,17 +1,13 @@
 import { apiGet } from "@/shared/api/client";
 import type { AdminPlayerInfo, AdminPlayerSummary } from "../player/model";
+import { requirePositiveAdminPlayerId } from "./player.query";
 
 export const ADMIN_PLAYERS_PATH = "/admin/v1/players";
 
-function positiveId(value: number, field: string) {
-  if (!Number.isInteger(value) || value < 1) throw new RangeError(`${field} must be a positive integer.`);
-  return value;
+export async function lookupAdminPlayerByUserId(userId: number): Promise<AdminPlayerSummary> {
+  return apiGet<AdminPlayerSummary>(`${ADMIN_PLAYERS_PATH}?userId=${requirePositiveAdminPlayerId(userId, "userId")}`);
 }
 
-export function lookupAdminPlayerByUserId(userId: number): Promise<AdminPlayerSummary> {
-  return apiGet<AdminPlayerSummary>(`${ADMIN_PLAYERS_PATH}?userId=${positiveId(userId, "userId")}`);
-}
-
-export function getAdminPlayerById(playerId: number): Promise<AdminPlayerInfo> {
-  return apiGet<AdminPlayerInfo>(`${ADMIN_PLAYERS_PATH}/${positiveId(playerId, "playerId")}`);
+export async function getAdminPlayerById(playerId: number): Promise<AdminPlayerInfo> {
+  return apiGet<AdminPlayerInfo>(`${ADMIN_PLAYERS_PATH}/${requirePositiveAdminPlayerId(playerId, "playerId")}`);
 }

--- a/features/admin/api/source.ts
+++ b/features/admin/api/source.ts
@@ -1,0 +1,11 @@
+export type AdminDataSourceMode = "api" | "mock";
+
+export type AdminDataSourceDescriptor = {
+  mode: AdminDataSourceMode;
+  badge: "API" | "MOCK DATA";
+  label: string;
+};
+
+export function resolveAdminDataSourceMode(value: unknown): AdminDataSourceMode {
+  return value === "mock" ? "mock" : "api";
+}

--- a/features/admin/model.ts
+++ b/features/admin/model.ts
@@ -18,11 +18,11 @@ export type AdminArea = {
 
 export const ADMIN_AREAS: AdminArea[] = [
   { id: "dashboard", label: "Dashboard", shortLabel: "D", state: "DEFERRED", reason: "BACKEND_READ_MODEL_REQUIRED" },
-  { id: "players", label: "Players", shortLabel: "P", state: "GATED", reason: "Player administration is not enabled in Phase A1." },
+  { id: "players", label: "Players", shortLabel: "P", state: "SUPPORTED", reason: "Exact User ID lookup and read-only Player detail are supported." },
   { id: "content", label: "Content", shortLabel: "C", state: "DEFERRED", reason: "Content administration is deferred to a later approved slice." },
-  { id: "economy", label: "Economy", shortLabel: "E", state: "GATED", reason: "Economy commands are not enabled in Phase A1." },
+  { id: "economy", label: "Economy", shortLabel: "E", state: "GATED", reason: "Economy commands are not enabled in the current Admin slice." },
   { id: "social", label: "Social & Trust", shortLabel: "S", state: "PRIVACY_GATED", reason: "Private social content is outside this Admin slice." },
-  { id: "system", label: "System", shortLabel: "Y", state: "SUPPORTED", reason: "Admin Audit is the only active Phase A1 capability." },
+  { id: "system", label: "System", shortLabel: "Y", state: "SUPPORTED", reason: "Admin Audit remains supported." },
 ];
 
 export type AdminAuditResult = "SUCCESS" | "FAILED";

--- a/features/admin/player/PlayerLookup.test.tsx
+++ b/features/admin/player/PlayerLookup.test.tsx
@@ -80,6 +80,26 @@ describe("read-only Player Lookup", () => {
     expect(dataSource.lookupByUserId).toHaveBeenCalledTimes(3);
   });
 
+  it("rejects a mismatched lookup identity and retries the same userId", async () => {
+    const dataSource = source();
+    vi.mocked(dataSource.lookupByUserId)
+      .mockResolvedValueOnce({ ...summary, userId: 9999, name: "WRONG PLAYER" })
+      .mockResolvedValueOnce(summary);
+    render(<PlayerLookup access="ready" onLogin={vi.fn()} dataSource={dataSource} />);
+
+    submitUserId();
+    expect(await screen.findByRole("heading", { name: "Unable to load Player" })).toBeInTheDocument();
+    expect(screen.getByText("Player lookup response did not match the requested User ID.")).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Lookup result" })).not.toBeInTheDocument();
+    expect(screen.queryByText("WRONG PLAYER")).not.toBeInTheDocument();
+    expect(screen.queryByText("9999")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(await screen.findByRole("button", { name: "Open read-only detail" })).toBeInTheDocument();
+    expect(dataSource.lookupByUserId).toHaveBeenNthCalledWith(1, 8314);
+    expect(dataSource.lookupByUserId).toHaveBeenNthCalledWith(2, 8314);
+  });
+
   it("keeps Summary and retries the same playerId when detail is not found", async () => {
     const dataSource = source();
     vi.mocked(dataSource.lookupByUserId).mockResolvedValue(summary);
@@ -102,6 +122,30 @@ describe("read-only Player Lookup", () => {
     expect(dataSource.getByPlayerId).toHaveBeenNthCalledWith(1, 10218);
     expect(dataSource.getByPlayerId).toHaveBeenNthCalledWith(2, 10218);
     expect(dataSource.lookupByUserId).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps Summary when detail identity mismatches and retries the same playerId", async () => {
+    const dataSource = source();
+    vi.mocked(dataSource.lookupByUserId).mockResolvedValue(summary);
+    vi.mocked(dataSource.getByPlayerId)
+      .mockResolvedValueOnce({ ...detail, playerId: 55555, name: "WRONG DETAIL" })
+      .mockResolvedValueOnce(detail);
+    render(<PlayerLookup access="ready" onLogin={vi.fn()} dataSource={dataSource} />);
+
+    submitUserId();
+    fireEvent.click(await screen.findByRole("button", { name: "Open read-only detail" }));
+
+    expect(await screen.findByRole("heading", { name: "Unable to load Player detail" })).toBeInTheDocument();
+    expect(screen.getByText("Player detail response did not match the requested Player ID.")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Lookup result" })).toBeInTheDocument();
+    expect(screen.getByText("HANEUL")).toBeInTheDocument();
+    expect(screen.queryByText("WRONG DETAIL")).not.toBeInTheDocument();
+    expect(screen.queryByText("55555")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(await screen.findByRole("heading", { name: "HANEUL" })).toHaveFocus();
+    expect(dataSource.getByPlayerId).toHaveBeenNthCalledWith(1, 10218);
+    expect(dataSource.getByPlayerId).toHaveBeenNthCalledWith(2, 10218);
   });
 
   it.each([

--- a/features/admin/player/PlayerLookup.test.tsx
+++ b/features/admin/player/PlayerLookup.test.tsx
@@ -1,0 +1,108 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ApiError } from "@/shared/api/client";
+import type { AdminPlayerDataSource } from "../api/player.source";
+import type { AdminPlayerInfo, AdminPlayerSummary } from "./model";
+import { PlayerLookup } from "./PlayerLookup";
+
+const summary: AdminPlayerSummary = { playerId: 10218, userId: 8314, name: "HANEUL" };
+const detail: AdminPlayerInfo = {
+  playerId: 10218, name: "HANEUL", gender: "FEMALE", job: "KNIGHT", level: 17, totalExp: 48200,
+  currentHealth: 840, healthCapacity: 1000, currentMana: 310, manaCapacity: 420,
+  str: 32, agi: 28, dex: 30, intel: 19, vit: 34, luc: 14,
+  effects: [{ code: "FOCUSED", category: "BUFF" }], representativeTitleId: 41,
+};
+
+const source = (): AdminPlayerDataSource => ({
+  descriptor: { mode: "api", badge: "API", label: "/admin/v1", playerLabel: "/admin/v1/players" },
+  lookupByUserId: vi.fn(),
+  getByPlayerId: vi.fn(),
+});
+
+function submitUserId(value = "8314") {
+  fireEvent.change(screen.getByLabelText("User ID"), { target: { value } });
+  fireEvent.click(screen.getByRole("button", { name: "Lookup Player" }));
+}
+
+describe("read-only Player Lookup", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => { callback(0); return 1; });
+  });
+
+  it("starts without an unbounded request and exposes only exact User ID lookup", () => {
+    const dataSource = source();
+    render(<PlayerLookup access="ready" onLogin={vi.fn()} dataSource={dataSource} />);
+
+    expect(screen.getByRole("heading", { name: "Ready for exact lookup" })).toBeInTheDocument();
+    expect(dataSource.lookupByUserId).not.toHaveBeenCalled();
+    expect(screen.queryByLabelText(/email|nickname|search text/i)).not.toBeInTheDocument();
+    expect(screen.getByText("Exact lookup key: User ID · no list or text search")).toBeInTheDocument();
+  });
+
+  it("shows loading, Summary, then fetches full detail only on explicit open", async () => {
+    const dataSource = source();
+    let resolveLookup!: (value: AdminPlayerSummary) => void;
+    vi.mocked(dataSource.lookupByUserId).mockReturnValue(new Promise((resolve) => { resolveLookup = resolve; }));
+    vi.mocked(dataSource.getByPlayerId).mockResolvedValue(detail);
+    render(<PlayerLookup access="ready" onLogin={vi.fn()} dataSource={dataSource} />);
+
+    submitUserId();
+    expect(await screen.findByRole("heading", { name: "Loading Player" })).toBeInTheDocument();
+    resolveLookup(summary);
+    expect(await screen.findByRole("button", { name: "Open read-only detail" })).toBeInTheDocument();
+    expect(dataSource.getByPlayerId).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Open read-only detail" }));
+    expect(await screen.findByRole("heading", { name: "HANEUL" })).toHaveFocus();
+    expect(dataSource.getByPlayerId).toHaveBeenCalledWith(10218);
+    expect(screen.getByText("48200")).toBeInTheDocument();
+    expect(screen.getByText("FOCUSED")).toBeInTheDocument();
+    expect(screen.queryByText(/wallet|inventory|mailbox|life score|exp progress/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /grant|revoke|rename|adjust|deliver|override|set hp|set mp/i })).not.toBeInTheDocument();
+  });
+
+  it("renders not-found and generic retry without switching sources", async () => {
+    const dataSource = source();
+    vi.mocked(dataSource.lookupByUserId)
+      .mockRejectedValueOnce(new ApiError(404, "PLAYER_NOT_FOUND", "Player was not found."))
+      .mockRejectedValueOnce(new Error("Network unavailable"))
+      .mockResolvedValueOnce(summary);
+    render(<PlayerLookup access="ready" onLogin={vi.fn()} dataSource={dataSource} />);
+
+    submitUserId();
+    expect(await screen.findByRole("heading", { name: "Player not found" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(await screen.findByRole("heading", { name: "Unable to load Player" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(await screen.findByRole("button", { name: "Open read-only detail" })).toBeInTheDocument();
+    expect(dataSource.lookupByUserId).toHaveBeenCalledTimes(3);
+  });
+
+  it.each([
+    [401, "Authentication required"],
+    [403, "Admin access denied"],
+  ])("renders %s without cached Player data", async (status, title) => {
+    const dataSource = source();
+    vi.mocked(dataSource.lookupByUserId).mockRejectedValueOnce(new ApiError(status, `HTTP_${status}`, "Denied"));
+    render(<PlayerLookup access="ready" onLogin={vi.fn()} dataSource={dataSource} />);
+
+    submitUserId();
+    expect(await screen.findByRole("heading", { name: title })).toBeInTheDocument();
+    expect(screen.queryByText("HANEUL")).not.toBeInTheDocument();
+  });
+
+  it("keeps API and Mock screen anatomy identical while labeling the selected source", async () => {
+    const apiSource = source();
+    vi.mocked(apiSource.lookupByUserId).mockResolvedValue(summary);
+    const mockSource: AdminPlayerDataSource = { ...apiSource, descriptor: { mode: "mock", badge: "MOCK DATA", label: "Local Admin Mock", playerLabel: "Local Admin Mock" } };
+    const view = render(<PlayerLookup access="ready" onLogin={vi.fn()} dataSource={apiSource} />);
+    expect(screen.getByRole("heading", { name: "Player Lookup" })).toBeInTheDocument();
+    expect(screen.getByText("/admin/v1/players")).toBeInTheDocument();
+
+    view.rerender(<PlayerLookup access="ready" onLogin={vi.fn()} dataSource={mockSource} />);
+    await waitFor(() => expect(screen.getByText("Local Admin Mock")).toBeInTheDocument());
+    expect(screen.getByRole("heading", { name: "Player Lookup" })).toBeInTheDocument();
+  });
+});

--- a/features/admin/player/PlayerLookup.test.tsx
+++ b/features/admin/player/PlayerLookup.test.tsx
@@ -80,6 +80,30 @@ describe("read-only Player Lookup", () => {
     expect(dataSource.lookupByUserId).toHaveBeenCalledTimes(3);
   });
 
+  it("keeps Summary and retries the same playerId when detail is not found", async () => {
+    const dataSource = source();
+    vi.mocked(dataSource.lookupByUserId).mockResolvedValue(summary);
+    vi.mocked(dataSource.getByPlayerId)
+      .mockRejectedValueOnce(new ApiError(404, "PLAYER_NOT_FOUND", "Player was not found."))
+      .mockResolvedValueOnce(detail);
+    render(<PlayerLookup access="ready" onLogin={vi.fn()} dataSource={dataSource} />);
+
+    submitUserId();
+    fireEvent.click(await screen.findByRole("button", { name: "Open read-only detail" }));
+
+    expect(await screen.findByRole("heading", { name: "Player detail unavailable" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Lookup result" })).toBeInTheDocument();
+    expect(screen.getByText("The Player detail could not be found for the returned Player ID.")).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Player not found" })).not.toBeInTheDocument();
+    expect(screen.queryByText("No Player is linked to that User ID.")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(await screen.findByRole("heading", { name: "HANEUL" })).toHaveFocus();
+    expect(dataSource.getByPlayerId).toHaveBeenNthCalledWith(1, 10218);
+    expect(dataSource.getByPlayerId).toHaveBeenNthCalledWith(2, 10218);
+    expect(dataSource.lookupByUserId).toHaveBeenCalledTimes(1);
+  });
+
   it.each([
     [401, "Authentication required"],
     [403, "Admin access denied"],

--- a/features/admin/player/PlayerLookup.tsx
+++ b/features/admin/player/PlayerLookup.tsx
@@ -84,8 +84,10 @@ export function PlayerLookup({ access, onLogin, dataSource = adminPlayerDataSour
 
   const authRequired = access === "unauthenticated" || player.error?.status === 401;
   const forbidden = player.error?.status === 403;
-  const notFound = player.error?.status === 404;
-  const genericError = player.error && !authRequired && !forbidden && !notFound ? player.error : null;
+  const lookupError = player.error?.kind === "lookup" && !authRequired && !forbidden ? player.error : null;
+  const detailError = player.error?.kind === "detail" && !authRequired && !forbidden ? player.error : null;
+  const lookupNotFound = lookupError?.status === 404;
+  const detailNotFound = detailError?.status === 404;
 
   return (
     <div className={styles.auditScreen}>
@@ -115,8 +117,8 @@ export function PlayerLookup({ access, onLogin, dataSource = adminPlayerDataSour
       {forbidden ? <StatePanel title="Admin access denied" message="The server did not authorize this session for Player Lookup. No Player data is shown." /> : null}
       {access === "ready" && !player.summary && !player.error && player.loading === null ? <StatePanel title="Ready for exact lookup" message="Enter a positive User ID. Email, nickname, and unbounded Player search are not supported." /> : null}
       {access === "ready" && player.loading === "lookup" ? <StatePanel title="Loading Player" message={`Looking up User ID ${userId}.`} /> : null}
-      {access === "ready" && notFound ? <StatePanel title="Player not found" message="No Player is linked to that User ID." action={<button type="button" className={styles.primaryButton} onClick={() => void player.retry()}>Retry</button>} /> : null}
-      {access === "ready" && genericError && !player.summary ? <StatePanel title="Unable to load Player" message={genericError.message} action={<button type="button" className={styles.primaryButton} onClick={() => void player.retry()}>Retry</button>} /> : null}
+      {access === "ready" && lookupNotFound ? <StatePanel title="Player not found" message="No Player is linked to that User ID." action={<button type="button" className={styles.primaryButton} onClick={() => void player.retry()}>Retry</button>} /> : null}
+      {access === "ready" && lookupError && !lookupNotFound ? <StatePanel title="Unable to load Player" message={lookupError.message} action={<button type="button" className={styles.primaryButton} onClick={() => void player.retry()}>Retry</button>} /> : null}
 
       {access === "ready" && player.summary ? (
         <div className={styles.playerLayout}>
@@ -130,7 +132,7 @@ export function PlayerLookup({ access, onLogin, dataSource = adminPlayerDataSour
               </table>
             </div>
           </section>
-          {player.detail ? <PlayerDetail player={player.detail} headingRef={detailHeading} onClose={closeDetail} /> : player.loading === "detail" ? <StatePanel title="Loading Player detail" message={`Requesting Player ID ${player.summary.playerId}.`} /> : genericError ? <StatePanel title="Unable to load Player detail" message={genericError.message} action={<button type="button" className={styles.primaryButton} onClick={() => void player.retry()}>Retry</button>} /> : <aside className={styles.detailPlaceholder}><span className={styles.badge} data-state="READ_ONLY">▣ READ_ONLY</span><h2>Player quick detail</h2><p>Open the exact result to fetch allowed Player fields.</p></aside>}
+          {player.detail ? <PlayerDetail player={player.detail} headingRef={detailHeading} onClose={closeDetail} /> : player.loading === "detail" ? <StatePanel title="Loading Player detail" message={`Requesting Player ID ${player.summary.playerId}.`} /> : detailNotFound ? <StatePanel title="Player detail unavailable" message="The Player detail could not be found for the returned Player ID." action={<button type="button" className={styles.primaryButton} onClick={() => void player.retry()}>Retry</button>} /> : detailError ? <StatePanel title="Unable to load Player detail" message={detailError.message} action={<button type="button" className={styles.primaryButton} onClick={() => void player.retry()}>Retry</button>} /> : <aside className={styles.detailPlaceholder}><span className={styles.badge} data-state="READ_ONLY">▣ READ_ONLY</span><h2>Player quick detail</h2><p>Open the exact result to fetch allowed Player fields.</p></aside>}
         </div>
       ) : null}
     </div>

--- a/features/admin/player/PlayerLookup.tsx
+++ b/features/admin/player/PlayerLookup.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import type { FormEvent } from "react";
+
+import { adminPlayerDataSource } from "../api/player.source";
+import type { AdminPlayerDataSource } from "../api/player.source";
+import type { AdminAccess } from "../model";
+import styles from "../admin.module.css";
+import type { AdminPlayerInfo } from "./model";
+import { usePlayerLookup } from "./usePlayerLookup";
+
+function StatePanel({ title, message, action }: { title: string; message: string; action?: React.ReactNode }) {
+  return <section className={styles.statePanel} role="status" aria-live="polite"><h2>{title}</h2><p>{message}</p>{action}</section>;
+}
+
+function PlayerDetail({ player, headingRef, onClose }: { player: AdminPlayerInfo; headingRef: React.RefObject<HTMLHeadingElement | null>; onClose: () => void }) {
+  const identity = [
+    ["Player ID", player.playerId],
+    ["Name", player.name],
+    ["Gender", player.gender],
+    ["Job", player.job],
+    ["Level", player.level],
+    ["Total EXP", player.totalExp],
+    ["Current health", player.currentHealth],
+    ["Health capacity", player.healthCapacity],
+    ["Current mana", player.currentMana],
+    ["Mana capacity", player.manaCapacity],
+    ["Representative title ID", player.representativeTitleId ?? "Not set"],
+  ] as const;
+  const stats = [["STR", player.str], ["AGI", player.agi], ["DEX", player.dex], ["INT", player.intel], ["VIT", player.vit], ["LUC", player.luc]] as const;
+
+  return (
+    <aside className={styles.detail} aria-labelledby="player-detail-title">
+      <div className={styles.detailHeader}>
+        <div><p className={styles.eyebrow}>Read-only quick detail</p><h2 id="player-detail-title" ref={headingRef} tabIndex={-1}>{player.name}</h2></div>
+        <button type="button" className={styles.secondaryButton} onClick={onClose}>Close detail</button>
+      </div>
+      <span className={styles.badge} data-state="READ_ONLY">▣ READ_ONLY</span>
+      <code className={styles.detailId}>{player.playerId}</code>
+      <dl className={styles.detailList}>
+        {identity.map(([label, value]) => <div key={label}><dt>{label}</dt><dd className={label.includes("ID") ? styles.mono : undefined}>{value}</dd></div>)}
+      </dl>
+      <section className={styles.playerStats} aria-labelledby="player-stats-title">
+        <h3 id="player-stats-title">Core stats</h3>
+        <dl>{stats.map(([label, value]) => <div key={label}><dt>{label}</dt><dd>{value}</dd></div>)}</dl>
+      </section>
+      <section className={styles.playerEffects} aria-labelledby="player-effects-title">
+        <h3 id="player-effects-title">Status effects</h3>
+        {player.effects.length > 0 ? <ul>{player.effects.map((effect) => <li key={`${effect.code}:${effect.category}`}><code>{effect.code}</code><span>{effect.category}</span></li>)}</ul> : <p>None</p>}
+      </section>
+      <div className={styles.privacyNote}><span className={styles.badge} data-state="PRIVACY_GATED">◆ PRIVACY_GATED</span><p>Private LifeLog, Person, and Direct Chat content is not part of Player detail.</p></div>
+    </aside>
+  );
+}
+
+export function PlayerLookup({ access, onLogin, dataSource = adminPlayerDataSource }: { access: AdminAccess; onLogin: () => void; dataSource?: AdminPlayerDataSource }) {
+  const [userId, setUserId] = useState("");
+  const [validationError, setValidationError] = useState<string | null>(null);
+  const detailTrigger = useRef<HTMLButtonElement | null>(null);
+  const detailHeading = useRef<HTMLHeadingElement | null>(null);
+  const player = usePlayerLookup(access === "ready", dataSource);
+  const source = dataSource.descriptor;
+
+  useEffect(() => {
+    if (player.detail) detailHeading.current?.focus();
+  }, [player.detail]);
+
+  const submit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const id = Number(userId);
+    if (!Number.isInteger(id) || id < 1) {
+      setValidationError("User ID must be a positive integer.");
+      return;
+    }
+    setValidationError(null);
+    void player.lookupByUserId(id);
+  };
+
+  const closeDetail = () => {
+    player.closeDetail();
+    requestAnimationFrame(() => detailTrigger.current?.focus());
+  };
+
+  const authRequired = access === "unauthenticated" || player.error?.status === 401;
+  const forbidden = player.error?.status === 403;
+  const notFound = player.error?.status === 404;
+  const genericError = player.error && !authRequired && !forbidden && !notFound ? player.error : null;
+
+  return (
+    <div className={styles.auditScreen}>
+      <div className={styles.screenHeader}>
+        <div><p className={styles.eyebrow}>Players / Player Lookup</p><h1>Player Lookup</h1><p>Find one Player using an exact User ID.</p></div>
+        <div className={styles.screenActions}>
+          <span className={styles.badge} data-state="READ_ONLY">▣ READ_ONLY</span>
+          <button type="button" className={styles.secondaryButton} onClick={() => void player.retry()} disabled={access !== "ready" || player.loading !== null || (!player.summary && !player.detail)}>Refresh</button>
+        </div>
+      </div>
+
+      {access === "ready" ? (
+        <form className={styles.playerLookupForm} aria-label="Player lookup" onSubmit={submit}>
+          <label>User ID<input type="number" min="1" step="1" required value={userId} onChange={(event) => setUserId(event.target.value)} placeholder="Exact User ID" /></label>
+          <button type="submit" className={styles.primaryButton} disabled={player.loading !== null}>Lookup Player</button>
+          {validationError ? <p role="alert">{validationError}</p> : null}
+        </form>
+      ) : null}
+
+      <div className={styles.feedMeta}>
+        <span>Exact lookup key: User ID · no list or text search</span>
+        <span>Source: <code>{source.playerLabel}</code>{player.loadedAt ? ` · refreshed ${player.loadedAt.toLocaleTimeString()}` : ""}</span>
+      </div>
+
+      {access === "loading" ? <StatePanel title="Validating session" message="Checking the authenticated operator session." /> : null}
+      {authRequired ? <StatePanel title="Authentication required" message="Sign in with an authorized operator account, then retry Player Lookup." action={<button type="button" className={styles.primaryButton} onClick={onLogin}>Go to login</button>} /> : null}
+      {forbidden ? <StatePanel title="Admin access denied" message="The server did not authorize this session for Player Lookup. No Player data is shown." /> : null}
+      {access === "ready" && !player.summary && !player.error && player.loading === null ? <StatePanel title="Ready for exact lookup" message="Enter a positive User ID. Email, nickname, and unbounded Player search are not supported." /> : null}
+      {access === "ready" && player.loading === "lookup" ? <StatePanel title="Loading Player" message={`Looking up User ID ${userId}.`} /> : null}
+      {access === "ready" && notFound ? <StatePanel title="Player not found" message="No Player is linked to that User ID." action={<button type="button" className={styles.primaryButton} onClick={() => void player.retry()}>Retry</button>} /> : null}
+      {access === "ready" && genericError && !player.summary ? <StatePanel title="Unable to load Player" message={genericError.message} action={<button type="button" className={styles.primaryButton} onClick={() => void player.retry()}>Retry</button>} /> : null}
+
+      {access === "ready" && player.summary ? (
+        <div className={styles.playerLayout}>
+          <section aria-labelledby="player-result-title">
+            <h2 id="player-result-title" className={styles.resultTitle}>Lookup result</h2>
+            <div className={styles.tableWrap}>
+              <table className={`${styles.table} ${styles.playerTable}`}>
+                <caption>Exact Player lookup result</caption>
+                <thead><tr><th>Player ID</th><th>User ID</th><th>Name</th><th>Detail</th></tr></thead>
+                <tbody><tr><td className={styles.mono}>{player.summary.playerId}</td><td className={styles.mono}>{player.summary.userId}</td><td>{player.summary.name}</td><td><button ref={detailTrigger} type="button" className={styles.idButton} onClick={() => void player.openDetail(player.summary!.playerId)}>Open read-only detail</button></td></tr></tbody>
+              </table>
+            </div>
+          </section>
+          {player.detail ? <PlayerDetail player={player.detail} headingRef={detailHeading} onClose={closeDetail} /> : player.loading === "detail" ? <StatePanel title="Loading Player detail" message={`Requesting Player ID ${player.summary.playerId}.`} /> : genericError ? <StatePanel title="Unable to load Player detail" message={genericError.message} action={<button type="button" className={styles.primaryButton} onClick={() => void player.retry()}>Retry</button>} /> : <aside className={styles.detailPlaceholder}><span className={styles.badge} data-state="READ_ONLY">▣ READ_ONLY</span><h2>Player quick detail</h2><p>Open the exact result to fetch allowed Player fields.</p></aside>}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/features/admin/player/model.ts
+++ b/features/admin/player/model.ts
@@ -1,0 +1,26 @@
+export type AdminPlayerSummary = {
+  playerId: number;
+  userId: number;
+  name: string;
+};
+
+export type AdminPlayerInfo = {
+  playerId: number;
+  name: string;
+  gender: string;
+  job: string;
+  level: number;
+  totalExp: number;
+  currentHealth: number;
+  healthCapacity: number;
+  currentMana: number;
+  manaCapacity: number;
+  str: number;
+  agi: number;
+  dex: number;
+  intel: number;
+  vit: number;
+  luc: number;
+  effects: Array<{ code: string; category: string }>;
+  representativeTitleId: number | null;
+};

--- a/features/admin/player/usePlayerLookup.ts
+++ b/features/admin/player/usePlayerLookup.ts
@@ -33,6 +33,7 @@ export function usePlayerLookup(enabled: boolean, dataSource: AdminPlayerDataSou
     try {
       if (intent.kind === "lookup") {
         const next = await dataSource.lookupByUserId(intent.id);
+        if (next.userId !== intent.id) throw new Error("Player lookup response did not match the requested User ID.");
         if (current === requestId.current) {
           setSummary(next);
           setLoadedAt(new Date());
@@ -40,6 +41,7 @@ export function usePlayerLookup(enabled: boolean, dataSource: AdminPlayerDataSou
         return next;
       }
       const next = await dataSource.getByPlayerId(intent.id);
+      if (next.playerId !== intent.id) throw new Error("Player detail response did not match the requested Player ID.");
       if (current === requestId.current) {
         setDetail(next);
         setLoadedAt(new Date());

--- a/features/admin/player/usePlayerLookup.ts
+++ b/features/admin/player/usePlayerLookup.ts
@@ -7,7 +7,7 @@ import type { AdminPlayerDataSource } from "../api/player.source";
 import type { AdminPlayerInfo, AdminPlayerSummary } from "./model";
 
 type Intent = { kind: "lookup"; id: number } | { kind: "detail"; id: number };
-type PlayerLoadError = { status: number | null; message: string };
+type PlayerLoadError = { status: number | null; message: string; kind: Intent["kind"] };
 
 export function usePlayerLookup(enabled: boolean, dataSource: AdminPlayerDataSource) {
   const [summary, setSummary] = useState<AdminPlayerSummary | null>(null);
@@ -53,7 +53,7 @@ export function usePlayerLookup(enabled: boolean, dataSource: AdminPlayerDataSou
           setDetail(null);
           setLoadedAt(null);
         }
-        setError({ status, message: caught instanceof Error ? caught.message : "Unable to load Player." });
+        setError({ status, message: caught instanceof Error ? caught.message : "Unable to load Player.", kind: intent.kind });
       }
       return undefined;
     } finally {

--- a/features/admin/player/usePlayerLookup.ts
+++ b/features/admin/player/usePlayerLookup.ts
@@ -1,0 +1,88 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { ApiError } from "@/shared/api/client";
+import type { AdminPlayerDataSource } from "../api/player.source";
+import type { AdminPlayerInfo, AdminPlayerSummary } from "./model";
+
+type Intent = { kind: "lookup"; id: number } | { kind: "detail"; id: number };
+type PlayerLoadError = { status: number | null; message: string };
+
+export function usePlayerLookup(enabled: boolean, dataSource: AdminPlayerDataSource) {
+  const [summary, setSummary] = useState<AdminPlayerSummary | null>(null);
+  const [detail, setDetail] = useState<AdminPlayerInfo | null>(null);
+  const [loading, setLoading] = useState<Intent["kind"] | null>(null);
+  const [error, setError] = useState<PlayerLoadError | null>(null);
+  const [loadedAt, setLoadedAt] = useState<Date | null>(null);
+  const requestId = useRef(0);
+  const lastIntent = useRef<Intent | null>(null);
+
+  const run = useCallback(async (intent: Intent) => {
+    const current = ++requestId.current;
+    lastIntent.current = intent;
+    setLoading(intent.kind);
+    setError(null);
+    if (intent.kind === "lookup") {
+      setSummary(null);
+      setDetail(null);
+      setLoadedAt(null);
+    } else {
+      setDetail(null);
+    }
+    try {
+      if (intent.kind === "lookup") {
+        const next = await dataSource.lookupByUserId(intent.id);
+        if (current === requestId.current) {
+          setSummary(next);
+          setLoadedAt(new Date());
+        }
+        return next;
+      }
+      const next = await dataSource.getByPlayerId(intent.id);
+      if (current === requestId.current) {
+        setDetail(next);
+        setLoadedAt(new Date());
+      }
+      return next;
+    } catch (caught) {
+      if (current === requestId.current) {
+        const status = caught instanceof ApiError ? caught.status : null;
+        if (status === 401 || status === 403) {
+          setSummary(null);
+          setDetail(null);
+          setLoadedAt(null);
+        }
+        setError({ status, message: caught instanceof Error ? caught.message : "Unable to load Player." });
+      }
+      return undefined;
+    } finally {
+      if (current === requestId.current) setLoading(null);
+    }
+  }, [dataSource]);
+
+  useEffect(() => {
+    if (!enabled) {
+      requestId.current += 1;
+      lastIntent.current = null;
+      setSummary(null);
+      setDetail(null);
+      setLoading(null);
+      setError(null);
+      setLoadedAt(null);
+    }
+    return () => { requestId.current += 1; };
+  }, [enabled]);
+
+  return {
+    summary,
+    detail,
+    loading,
+    error,
+    loadedAt,
+    lookupByUserId: (userId: number) => run({ kind: "lookup", id: userId }),
+    openDetail: (playerId: number) => run({ kind: "detail", id: playerId }),
+    retry: () => lastIntent.current ? run(lastIntent.current) : Promise.resolve(undefined),
+    closeDetail: () => { setDetail(null); setError(null); },
+  };
+}

--- a/features/admin/shell/AdminShell.test.tsx
+++ b/features/admin/shell/AdminShell.test.tsx
@@ -6,41 +6,45 @@ import { AdminShell } from "./AdminShell";
 const apiSource = { mode: "api", badge: "API", label: "/admin/v1", eventLabel: "/admin/v1/audit-events" } as const;
 const mockSource = { mode: "mock", badge: "MOCK DATA", label: "Local Admin Mock", eventLabel: "Local Admin Mock" } as const;
 
-describe("Admin Phase A1 shell", () => {
-  it("keeps the locked navigation visible with only Admin Audit supported", () => {
-    render(<AdminShell operator="operator@lag" audit={<div>Canonical Audit Screen</div>} source={apiSource} />);
+describe("Admin Phase A2 shell", () => {
+  it("keeps Player Lookup active while Admin Audit remains supported", () => {
+    render(<AdminShell operator="operator@lag" player={<div>Player Screen</div>} audit={<div>Audit Screen</div>} source={apiSource} />);
 
     expect(screen.getByRole("navigation", { name: "Admin operations" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "System, SUPPORTED" })).toHaveAttribute("aria-current", "page");
+    expect(screen.getByRole("button", { name: "Players, SUPPORTED" })).toHaveAttribute("aria-current", "page");
+    expect(screen.getByText("Player Lookup")).toBeInTheDocument();
+    expect(screen.getByText("Player Screen")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "System, SUPPORTED" }));
     expect(screen.getByText("Admin Audit")).toBeInTheDocument();
-    expect(screen.getByText("Canonical Audit Screen")).toBeInTheDocument();
+    expect(screen.getByText("Audit Screen")).toBeInTheDocument();
     expect(screen.queryByText("OrbNav")).not.toBeInTheDocument();
   });
 
-  it("shows explicit non-A1 capability boundaries without unsupported commands", () => {
-    render(<AdminShell operator="operator@lag" audit={<div>Canonical Audit Screen</div>} source={apiSource} />);
+  it("keeps unrelated capability boundaries without unsupported commands", () => {
+    render(<AdminShell operator="operator@lag" player={<div>Player Screen</div>} audit={<div>Audit Screen</div>} source={apiSource} />);
 
     fireEvent.click(screen.getByRole("button", { name: "Dashboard, DEFERRED" }));
     expect(screen.getByRole("heading", { name: "Dashboard" })).toBeInTheDocument();
     expect(screen.getByText("BACKEND_READ_MODEL_REQUIRED")).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: "Players, GATED" }));
-    expect(screen.getByText("Player administration is not enabled in Phase A1.")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Economy, GATED" }));
+    expect(screen.getByText("Economy commands are not enabled in the current Admin slice.")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /grant|revoke|adjust|delete|override|deliver/i })).not.toBeInTheDocument();
   });
 
   it.each([
     [apiSource, "API", "/admin/v1", "Session", "Authority enforced by server"],
     [mockSource, "MOCK DATA", "Local Admin Mock", "Mock session", "Server Admin authority not evaluated"],
-  ] as const)("shows the %s source without changing A1 shell anatomy", (source, badge, label, session, authority) => {
-    render(<AdminShell operator="operator@lag" audit={<div>Audit Screen</div>} source={source} />);
+  ] as const)("shows the %s source without changing the Admin shell anatomy", (source, badge, label, session, authority) => {
+    render(<AdminShell operator="operator@lag" player={<div>Player Screen</div>} audit={<div>Audit Screen</div>} source={source} />);
 
     expect(screen.getByText(badge)).toBeInTheDocument();
     expect(screen.getByText(label)).toBeInTheDocument();
     expect(screen.getByText(session)).toBeInTheDocument();
     expect(screen.getByText(authority)).toBeInTheDocument();
     if (source.mode === "mock") expect(screen.queryByText("Authority enforced by server")).not.toBeInTheDocument();
-    expect(screen.getByText("Audit Screen")).toBeInTheDocument();
+    expect(screen.getByText("Player Screen")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /grant|revoke|adjust|delete|override|deliver/i })).not.toBeInTheDocument();
   });
 });

--- a/features/admin/shell/AdminShell.tsx
+++ b/features/admin/shell/AdminShell.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 
-import type { AdminDataSourceDescriptor } from "../api/audit.source";
+import type { AdminDataSourceDescriptor } from "../api/source";
 import { ADMIN_AREAS } from "../model";
 import type { AdminAreaId, AdminCapabilityState } from "../model";
 import styles from "../admin.module.css";
@@ -12,8 +12,8 @@ function CapabilityBadge({ state, compact = false }: { state: AdminCapabilitySta
   return <span className={styles.badge} data-state={state} data-compact={compact || undefined}>{marker} {state}</span>;
 }
 
-export function AdminShell({ operator, audit, source }: { operator: string; audit: React.ReactNode; source: AdminDataSourceDescriptor }) {
-  const [activeArea, setActiveArea] = useState<AdminAreaId>("system");
+export function AdminShell({ operator, audit, player, source }: { operator: string; audit: React.ReactNode; player: React.ReactNode; source: AdminDataSourceDescriptor }) {
+  const [activeArea, setActiveArea] = useState<AdminAreaId>("players");
   const active = ADMIN_AREAS.find((area) => area.id === activeArea)!;
 
   return (
@@ -42,10 +42,10 @@ export function AdminShell({ operator, audit, source }: { operator: string; audi
                 <span className={styles.navLabel}>{area.label}</span>
                 {area.id !== "system" ? <span className={styles.navBadge}><CapabilityBadge state={area.state} compact /></span> : null}
               </button>
-              {area.id === "system" && activeArea === "system" ? (
-                <div className={styles.subnav} aria-label="System capabilities">
-                  <span>Admin Audit</span>
-                  <CapabilityBadge state="SUPPORTED" compact />
+              {(area.id === "system" || area.id === "players") && activeArea === area.id ? (
+                <div className={styles.subnav} aria-label={`${area.label} capabilities`}>
+                  <span>{area.id === "system" ? "Admin Audit" : "Player Lookup"}</span>
+                  <CapabilityBadge state={area.id === "system" ? "SUPPORTED" : "READ_ONLY"} compact />
                 </div>
               ) : null}
             </div>
@@ -58,17 +58,17 @@ export function AdminShell({ operator, audit, source }: { operator: string; audi
       </aside>
 
       <main className={styles.workspace}>
-        {activeArea === "system" ? audit : (
+        {activeArea === "system" ? audit : activeArea === "players" ? player : (
           <section className={styles.capabilityPanel} aria-labelledby="admin-capability-title">
             <div className={styles.capabilityHeader}>
               <div>
-                <p className={styles.eyebrow}>Phase A1 capability boundary</p>
+                <p className={styles.eyebrow}>Admin capability boundary</p>
                 <h1 id="admin-capability-title">{active.label}</h1>
               </div>
               <CapabilityBadge state={active.state} />
             </div>
             <p>{active.reason}</p>
-            <p className={styles.safeNote}>No data or command API is connected for this area in Phase A1.</p>
+            <p className={styles.safeNote}>No data or command API is connected for this area in the current approved slice.</p>
           </section>
         )}
       </main>


### PR DESCRIPTION
## Purpose

Add the next Admin Phase A read-only workflow after the canonical shell and Audit Explorer: Player Lookup with quick detail backed only by proven current Admin reads.

Closes #78

## Delivered

- read-only Player Lookup
- read-only Player quick detail
- canonical Player Admin API adapters
- matching local Mock Player data source
- explicit loading / not-found / error / retry / 401 / 403 states
- supported Players navigation state for the A2 read-only slice
- Warm Beige-first Player Lookup visuals with Astral parity

## Canonical Reads

The real source uses only:

```text
GET /admin/v1/players?userId={userId}
GET /admin/v1/players/{playerId}
```

No unsupported broad search or `/api/v1/admin/**` compatibility path is introduced.

## Data Sources

Player Lookup preserves the explicit Admin source contract:

```text
NEXT_PUBLIC_ADMIN_DATA_SOURCE=api|mock
```

Both sources expose the same screen/use-case contract.

API errors do not automatically fall back to Mock.

## Capability Boundary

This PR does not enable Player mutations.

The following remain gated:

- EXP/stat/HP/MP correction
- rename
- title/achievement/certification/hobby grant/revoke
- Inventory/Mailbox direct delivery
- Wallet adjustment
- Quest override

Private LifeLog, Person, and Direct Chat content remain unavailable.

## Visual Contract

The implementation follows the approved Admin Player Lookup references for:

- Warm Beige desktop
- Warm Beige tablet
- Astral desktop
- component/state treatment

Screenshots are used only as visual authority, not as backend capability authority.

## Validation

Validation is focused on Player API/Mock sources, lookup/detail states, shell integration, and one final production build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a read-only Player Lookup screen in the admin area using exact User ID searches.
  * Added player summaries, detailed profiles, statistics, status effects, and responsive layouts.
  * Added API and local mock data options with clear source indicators.
  * Added loading, retry, authentication, permission, and not-found states.
  * Updated admin navigation to make Player Lookup the default supported area.

* **Bug Fixes**
  * Improved handling of invalid IDs and stale lookup results.
  * Prevented unauthorized or forbidden responses from displaying cached player data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->