### PR TITLE
[Admin] Add read-only Quest Runtime Status

### DIFF
--- a/app/admin/page.test.tsx
+++ b/app/admin/page.test.tsx
@@ -15,24 +15,41 @@ const playerSource = vi.hoisted(() => ({
   lookupByUserId: vi.fn(),
   getByPlayerId: vi.fn(),
 }));
+const questSource = vi.hoisted(() => ({
+  descriptor: { mode: "api" as const, badge: "API" as const, label: "/admin/v1", questLabel: "/admin/v1/quests" },
+  getCatalog: vi.fn(),
+  getDefinitions: vi.fn(),
+  getDefinition: vi.fn(),
+  getAcceptances: vi.fn(),
+  getAcceptance: vi.fn(),
+}));
 
 vi.mock("next/navigation", () => ({ useRouter: () => router }));
 vi.mock("@/features/auth/AuthContext", () => ({ useAuth: () => auth }));
 vi.mock("@/features/admin/api/audit.source", () => ({ adminAuditDataSource: source }));
 vi.mock("@/features/admin/api/player.source", () => ({ adminPlayerDataSource: playerSource }));
+vi.mock("@/features/admin/api/quest.source", () => ({ adminQuestDataSource: questSource }));
 
 describe("/admin route", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     source.getEvents.mockResolvedValue({ items: [], nextCursor: null });
+    questSource.getCatalog.mockResolvedValue({ blueprints: [] });
+    questSource.getDefinitions.mockResolvedValue({ definitions: [] });
   });
 
-  it("composes Player Lookup and preserves the supported Audit route", async () => {
+  it("composes Quest Runtime Status and preserves Player Lookup and Audit", async () => {
     render(<AdminPage />);
 
     expect(screen.getByText("operator@lag")).toBeInTheDocument();
     expect(screen.getByText("API")).toBeInTheDocument();
     expect(screen.getByText("/admin/v1")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Quest Runtime Status" })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "No Quest definitions" })).toBeInTheDocument();
+    expect(questSource.getCatalog).toHaveBeenCalledTimes(1);
+    expect(questSource.getDefinitions).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "Players, SUPPORTED" }));
     expect(screen.getByRole("heading", { name: "Player Lookup" })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Ready for exact lookup" })).toBeInTheDocument();
     expect(playerSource.lookupByUserId).not.toHaveBeenCalled();
@@ -49,6 +66,7 @@ describe("/admin route", () => {
     const css = readFileSync("features/admin/admin.module.css", "utf8");
     expect(css).toMatch(/\.auditLayout\s*\{[^}]*grid-template-columns:\s*minmax\(0, 1fr\) minmax\(320px, 390px\)/);
     expect(css).toMatch(/\.playerLayout\s*\{[^}]*grid-template-columns:\s*minmax\(0, 1fr\) minmax\(320px, 390px\)/);
+    expect(css).toMatch(/\.questLayout\s*\{[^}]*grid-template-columns:\s*minmax\(360px, 430px\) minmax\(0, 1fr\)/);
     expect(css).toMatch(/\.tableWrap\s*\{[^}]*overflow:\s*auto/);
   });
 });

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -5,7 +5,9 @@ import { useRouter } from "next/navigation";
 import { AuditExplorer } from "@/features/admin/audit/AuditExplorer";
 import { adminAuditDataSource } from "@/features/admin/api/audit.source";
 import { adminPlayerDataSource } from "@/features/admin/api/player.source";
+import { adminQuestDataSource } from "@/features/admin/api/quest.source";
 import { PlayerLookup } from "@/features/admin/player/PlayerLookup";
+import { QuestRuntimeStatus } from "@/features/admin/quest/QuestRuntimeStatus";
 import { AdminShell } from "@/features/admin/shell/AdminShell";
 import { useAuth } from "@/features/auth/AuthContext";
 
@@ -20,6 +22,7 @@ export default function AdminPage() {
       source={adminAuditDataSource.descriptor}
       audit={<AuditExplorer access={access} onLogin={() => router.push("/login")} dataSource={adminAuditDataSource} />}
       player={<PlayerLookup access={access} onLogin={() => router.push("/login")} dataSource={adminPlayerDataSource} />}
+      quest={<QuestRuntimeStatus access={access} onLogin={() => router.push("/login")} dataSource={adminQuestDataSource} />}
     />
   );
 }

--- a/features/admin/admin.module.css
+++ b/features/admin/admin.module.css
@@ -59,7 +59,7 @@
   --admin-failed: #d86d72;
 }
 
-.root :where(button, input, select):focus-visible {
+.root :where(button, input, select, summary):focus-visible {
   outline: 2px solid var(--admin-focus);
   outline-offset: 2px;
 }
@@ -582,6 +582,7 @@
   text-decoration: underline;
   text-decoration-color: transparent;
   text-underline-offset: 3px;
+  user-select: text;
 }
 
 .idButton:hover {
@@ -870,6 +871,181 @@
   font-size: 11px;
 }
 
+.questLayout {
+  display: grid;
+  grid-template-columns: minmax(360px, 430px) minmax(0, 1fr);
+  align-items: start;
+  gap: 14px;
+}
+
+.questPanel {
+  min-width: 0;
+  padding: 14px;
+  background: var(--admin-panel);
+  border: 1px solid var(--admin-border);
+  border-radius: 10px;
+}
+
+.questPanel h2 {
+  margin: 0;
+  color: var(--admin-text);
+  font-size: 17px;
+}
+
+.questPanelHeader,
+.questAcceptanceHeader {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.questPanelHeader > span {
+  color: var(--admin-muted);
+  font-size: 10px;
+}
+
+.catalogDisclosure {
+  margin-bottom: 10px;
+  padding: 9px 10px;
+  color: var(--admin-text-2);
+  background: var(--admin-workspace);
+  border: 1px solid var(--admin-divider);
+  border-radius: 6px;
+  font-size: 10px;
+}
+
+.catalogDisclosure summary {
+  cursor: pointer;
+  font-weight: 750;
+}
+
+.catalogDisclosure ul {
+  display: grid;
+  gap: 6px;
+  margin: 9px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.catalogDisclosure li {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.catalogDisclosure code {
+  color: var(--admin-id);
+  user-select: text;
+}
+
+.questDefinitionTable {
+  min-width: 400px;
+}
+
+.questWorkspace {
+  display: grid;
+  min-width: 0;
+  gap: 14px;
+}
+
+.questDescription,
+.questSemantics {
+  color: var(--admin-text-2);
+  line-height: 1.5;
+}
+
+.questDescription {
+  margin: 0 0 12px;
+  padding: 10px;
+  background: var(--admin-workspace);
+  border: 1px solid var(--admin-divider);
+  border-radius: 6px;
+  white-space: pre-wrap;
+}
+
+.questDefinitionFields {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  column-gap: 18px;
+}
+
+.questAcceptanceHeader label {
+  display: flex;
+  min-width: 190px;
+  flex-direction: column;
+  gap: 4px;
+  color: var(--admin-text-2);
+  font-size: 10px;
+  font-weight: 700;
+}
+
+.questAcceptanceHeader select {
+  width: 100%;
+  height: 36px;
+  padding: 0 10px;
+  color: var(--admin-text);
+  background: var(--admin-workspace);
+  border: 1px solid var(--admin-border);
+  border-radius: 6px;
+  font: inherit;
+}
+
+.questSemantics {
+  margin: 0 0 12px;
+  padding: 9px 10px;
+  border-left: 2px solid var(--admin-focus);
+  font-size: 10px;
+}
+
+.questAcceptanceLayout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(320px, 390px);
+  align-items: start;
+  gap: 12px;
+}
+
+.questAcceptanceLayout > * {
+  min-width: 0;
+}
+
+.questAcceptanceTable {
+  min-width: 710px;
+}
+
+.questStatus {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  min-height: 23px;
+  padding: 3px 8px;
+  color: var(--admin-focus);
+  background: color-mix(in srgb, var(--admin-focus) 8%, var(--admin-panel));
+  border: 1px solid var(--admin-focus);
+  border-radius: 999px;
+  font-size: 9px;
+  font-weight: 750;
+  white-space: nowrap;
+}
+
+.questStatus[data-status="GOAL_REACHED"] {
+  color: var(--admin-gated);
+  border-color: var(--admin-gated);
+  background: color-mix(in srgb, var(--admin-gated) 8%, var(--admin-panel));
+}
+
+.questStatus[data-status="COMPLETED"] {
+  color: var(--admin-supported);
+  border-color: var(--admin-supported);
+  background: color-mix(in srgb, var(--admin-supported) 8%, var(--admin-panel));
+}
+
+.questStatus[data-status="CANCELED"] {
+  color: var(--admin-failed);
+  border-color: var(--admin-failed);
+  background: color-mix(in srgb, var(--admin-failed) 8%, var(--admin-panel));
+}
+
 @media (max-width: 1179px) {
   .root {
     grid-template:
@@ -907,6 +1083,15 @@
   }
 
   .playerLayout {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .questLayout,
+  .questAcceptanceLayout {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .questDefinitionFields {
     grid-template-columns: minmax(0, 1fr);
   }
 
@@ -997,6 +1182,14 @@
   }
 
   .playerLookupForm button {
+    width: 100%;
+  }
+
+  .questAcceptanceHeader {
+    flex-direction: column;
+  }
+
+  .questAcceptanceHeader label {
     width: 100%;
   }
 

--- a/features/admin/api/quest.mock.test.ts
+++ b/features/admin/api/quest.mock.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import type { AdminQuestAcceptanceStatus } from "../quest/model";
 import {
   getMockAdminQuestAcceptance,
   getMockAdminQuestAcceptances,
@@ -48,7 +49,7 @@ describe("read-only Admin Quest Mock adapter", () => {
     [() => getMockAdminQuestAcceptances(""), "must not be blank"],
     [() => getMockAdminQuestAcceptance(0), "positive integer"],
     [() => getMockAdminQuestAcceptance(-1), "positive integer"],
-    [() => getMockAdminQuestAcceptances("quest:record:first-trace", "DONE" as "COMPLETED"), "canonical Acceptance status"],
+    [() => getMockAdminQuestAcceptances("quest:record:first-trace", "DONE" as unknown as AdminQuestAcceptanceStatus), "canonical Acceptance status"],
   ])("rejects the same invalid input as the API source", async (request, message) => {
     await expect(request()).rejects.toThrow(message);
   });

--- a/features/admin/api/quest.mock.test.ts
+++ b/features/admin/api/quest.mock.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getMockAdminQuestAcceptance,
+  getMockAdminQuestAcceptances,
+  getMockAdminQuestCatalog,
+  getMockAdminQuestDefinition,
+  getMockAdminQuestDefinitions,
+} from "./quest.mock";
+
+describe("read-only Admin Quest Mock adapter", () => {
+  it("returns deterministic DTO-only Blueprint, Definition, and Acceptance fixtures", async () => {
+    const catalog = await getMockAdminQuestCatalog();
+    const definitions = await getMockAdminQuestDefinitions();
+    const definition = await getMockAdminQuestDefinition(definitions.definitions[0].code);
+    const acceptances = await getMockAdminQuestAcceptances(definition.code);
+    const acceptance = await getMockAdminQuestAcceptance(acceptances.acceptances[0].id);
+
+    expect(catalog).toEqual(await getMockAdminQuestCatalog());
+    expect(definitions.definitions).toHaveLength(2);
+    expect(definition.code).toBe("quest:record:first-trace");
+    expect(acceptance).toMatchObject({ id: 9001, questId: 501, playerId: 10218, code: definition.code, status: "IN_PROGRESS" });
+    expect(acceptance).not.toHaveProperty("route");
+    expect(acceptance).not.toHaveProperty("wallet");
+    expect(acceptance).not.toHaveProperty("inventory");
+    expect(acceptance).not.toHaveProperty("lifeLog");
+    expect(acceptance).not.toHaveProperty("person");
+    expect(acceptance).not.toHaveProperty("directChat");
+    expect(acceptance).not.toHaveProperty("rewardRepair");
+  });
+
+  it("supports the proven status filter and an empty Acceptance list", async () => {
+    expect((await getMockAdminQuestAcceptances("quest:record:first-trace", "COMPLETED")).acceptances).toEqual([
+      expect.objectContaining({ id: 9002, status: "COMPLETED" }),
+    ]);
+    expect((await getMockAdminQuestAcceptances("quest:daily:walk")).acceptances).toEqual([]);
+  });
+
+  it("reports not-found without fabricating fallback data", async () => {
+    await expect(getMockAdminQuestDefinition("missing")).rejects.toMatchObject({ status: 404 });
+    await expect(getMockAdminQuestAcceptances("missing")).rejects.toMatchObject({ status: 404 });
+    await expect(getMockAdminQuestAcceptance(9999)).rejects.toMatchObject({ status: 404 });
+  });
+});

--- a/features/admin/api/quest.mock.test.ts
+++ b/features/admin/api/quest.mock.test.ts
@@ -30,15 +30,26 @@ describe("read-only Admin Quest Mock adapter", () => {
   });
 
   it("supports the proven status filter and an empty Acceptance list", async () => {
-    expect((await getMockAdminQuestAcceptances("quest:record:first-trace", "COMPLETED")).acceptances).toEqual([
+    expect((await getMockAdminQuestAcceptances(" quest:record:first-trace ", "COMPLETED")).acceptances).toEqual([
       expect.objectContaining({ id: 9002, status: "COMPLETED" }),
     ]);
     expect((await getMockAdminQuestAcceptances("quest:daily:walk")).acceptances).toEqual([]);
+    expect((await getMockAdminQuestDefinition(" quest:record:first-trace ")).code).toBe("quest:record:first-trace");
   });
 
   it("reports not-found without fabricating fallback data", async () => {
     await expect(getMockAdminQuestDefinition("missing")).rejects.toMatchObject({ status: 404 });
     await expect(getMockAdminQuestAcceptances("missing")).rejects.toMatchObject({ status: 404 });
     await expect(getMockAdminQuestAcceptance(9999)).rejects.toMatchObject({ status: 404 });
+  });
+
+  it.each([
+    [() => getMockAdminQuestDefinition("   "), "must not be blank"],
+    [() => getMockAdminQuestAcceptances(""), "must not be blank"],
+    [() => getMockAdminQuestAcceptance(0), "positive integer"],
+    [() => getMockAdminQuestAcceptance(-1), "positive integer"],
+    [() => getMockAdminQuestAcceptances("quest:record:first-trace", "DONE" as "COMPLETED"), "canonical Acceptance status"],
+  ])("rejects the same invalid input as the API source", async (request, message) => {
+    await expect(request()).rejects.toThrow(message);
   });
 });

--- a/features/admin/api/quest.mock.ts
+++ b/features/admin/api/quest.mock.ts
@@ -1,0 +1,72 @@
+import { ApiError } from "@/shared/api/client";
+import type {
+  AdminQuestAcceptance,
+  AdminQuestAcceptances,
+  AdminQuestAcceptanceStatus,
+  AdminQuestBlueprint,
+  AdminQuestBlueprints,
+  AdminQuestDefinition,
+  AdminQuestDefinitions,
+} from "../quest/model";
+
+const BLUEPRINTS: AdminQuestBlueprint[] = [
+  {
+    code: "quest:record:first-trace", title: "First Trace", category: null, descriptionMd: "Record one LifeLog entry.",
+    targetType: "COUNT", targetValue: 1, repeatRule: "ONCE", completionPolicy: "AUTO", definitionVersion: 2,
+    rewardProfileCode: "RP_EXP_TINY_10", rewardExp: null, rewardStats: null, dueAt: null,
+    semanticCategory: "RECORD", progressSource: "RECORD_CREATED", repeatPolicy: "ONCE", roleTemplateCode: null,
+  },
+  {
+    code: "quest:daily:walk", title: "Daily Walk", category: "DAILY", descriptionMd: "Complete one walk.",
+    targetType: "COUNT", targetValue: 1, repeatRule: "DAILY", completionPolicy: "USER_CONFIRM", definitionVersion: 1,
+    rewardProfileCode: null, rewardExp: 10, rewardStats: {}, dueAt: null,
+    semanticCategory: null, progressSource: null, repeatPolicy: null, roleTemplateCode: null,
+  },
+];
+
+const DEFINITIONS: AdminQuestDefinition[] = BLUEPRINTS.map((blueprint, index) => ({ id: 501 + index, ...blueprint }));
+
+const ACCEPTANCES: AdminQuestAcceptance[] = [
+  {
+    id: 9001, questId: 501, playerId: 10218, code: "quest:record:first-trace", title: "First Trace", category: null,
+    targetType: "COUNT", targetValue: 1, progressValue: 0, status: "IN_PROGRESS", completionPolicy: "AUTO", repeatRule: "ONCE",
+    periodStart: null, periodEnd: null, acceptedAt: "2026-08-24T04:00:00Z", periodKey: null,
+    goalReachedAt: null, completedAt: null, dueAt: null, semanticCategory: "RECORD", progressSource: "RECORD_CREATED",
+    repeatPolicy: "ONCE", roleTemplateCode: null,
+  },
+  {
+    id: 9002, questId: 501, playerId: 10219, code: "quest:record:first-trace", title: "First Trace", category: null,
+    targetType: "COUNT", targetValue: 1, progressValue: 1, status: "COMPLETED", completionPolicy: "AUTO", repeatRule: "ONCE",
+    periodStart: null, periodEnd: null, acceptedAt: "2026-08-23T04:00:00Z", periodKey: null,
+    goalReachedAt: "2026-08-23T04:05:00Z", completedAt: "2026-08-23T04:05:00Z", dueAt: null,
+    semanticCategory: "RECORD", progressSource: "RECORD_CREATED", repeatPolicy: "ONCE", roleTemplateCode: null,
+  },
+];
+
+const notFound = () => new ApiError(404, "QUEST_NOT_FOUND", "Quest data was not found.");
+const copy = <T,>(value: T): T => structuredClone(value);
+
+export async function getMockAdminQuestCatalog(): Promise<AdminQuestBlueprints> {
+  return copy({ blueprints: BLUEPRINTS });
+}
+
+export async function getMockAdminQuestDefinitions(): Promise<AdminQuestDefinitions> {
+  return copy({ definitions: DEFINITIONS });
+}
+
+export async function getMockAdminQuestDefinition(questCode: string): Promise<AdminQuestDefinition> {
+  const definition = DEFINITIONS.find((candidate) => candidate.code === questCode);
+  if (!definition) throw notFound();
+  return copy(definition);
+}
+
+export async function getMockAdminQuestAcceptances(questCode: string, status?: AdminQuestAcceptanceStatus | ""): Promise<AdminQuestAcceptances> {
+  if (!DEFINITIONS.some((definition) => definition.code === questCode)) throw notFound();
+  return copy({ acceptances: ACCEPTANCES.filter((acceptance) => acceptance.code === questCode && (!status || acceptance.status === status)) });
+}
+
+export async function getMockAdminQuestAcceptance(acceptanceId: number): Promise<AdminQuestAcceptance> {
+  const acceptance = ACCEPTANCES.find((candidate) => candidate.id === acceptanceId);
+  if (!acceptance) throw notFound();
+  return copy(acceptance);
+}

--- a/features/admin/api/quest.mock.ts
+++ b/features/admin/api/quest.mock.ts
@@ -8,6 +8,11 @@ import type {
   AdminQuestDefinition,
   AdminQuestDefinitions,
 } from "../quest/model";
+import {
+  normalizeAdminQuestCode,
+  requirePositiveAdminAcceptanceId,
+  validateAdminQuestAcceptanceStatus,
+} from "./quest.query";
 
 const BLUEPRINTS: AdminQuestBlueprint[] = [
   {
@@ -55,18 +60,22 @@ export async function getMockAdminQuestDefinitions(): Promise<AdminQuestDefiniti
 }
 
 export async function getMockAdminQuestDefinition(questCode: string): Promise<AdminQuestDefinition> {
-  const definition = DEFINITIONS.find((candidate) => candidate.code === questCode);
+  const normalizedCode = normalizeAdminQuestCode(questCode);
+  const definition = DEFINITIONS.find((candidate) => candidate.code === normalizedCode);
   if (!definition) throw notFound();
   return copy(definition);
 }
 
 export async function getMockAdminQuestAcceptances(questCode: string, status?: AdminQuestAcceptanceStatus | ""): Promise<AdminQuestAcceptances> {
-  if (!DEFINITIONS.some((definition) => definition.code === questCode)) throw notFound();
-  return copy({ acceptances: ACCEPTANCES.filter((acceptance) => acceptance.code === questCode && (!status || acceptance.status === status)) });
+  const normalizedCode = normalizeAdminQuestCode(questCode);
+  const normalizedStatus = validateAdminQuestAcceptanceStatus(status);
+  if (!DEFINITIONS.some((definition) => definition.code === normalizedCode)) throw notFound();
+  return copy({ acceptances: ACCEPTANCES.filter((acceptance) => acceptance.code === normalizedCode && (!normalizedStatus || acceptance.status === normalizedStatus)) });
 }
 
 export async function getMockAdminQuestAcceptance(acceptanceId: number): Promise<AdminQuestAcceptance> {
-  const acceptance = ACCEPTANCES.find((candidate) => candidate.id === acceptanceId);
+  const normalizedId = requirePositiveAdminAcceptanceId(acceptanceId);
+  const acceptance = ACCEPTANCES.find((candidate) => candidate.id === normalizedId);
   if (!acceptance) throw notFound();
   return copy(acceptance);
 }

--- a/features/admin/api/quest.query.ts
+++ b/features/admin/api/quest.query.ts
@@ -1,0 +1,19 @@
+import { ADMIN_QUEST_ACCEPTANCE_STATUSES } from "../quest/model";
+import type { AdminQuestAcceptanceStatus } from "../quest/model";
+
+export function normalizeAdminQuestCode(questCode: string) {
+  const normalized = questCode.trim();
+  if (!normalized) throw new RangeError("questCode must not be blank.");
+  return normalized;
+}
+
+export function requirePositiveAdminAcceptanceId(acceptanceId: number) {
+  if (!Number.isInteger(acceptanceId) || acceptanceId < 1) throw new RangeError("acceptanceId must be a positive integer.");
+  return acceptanceId;
+}
+
+export function validateAdminQuestAcceptanceStatus(status?: AdminQuestAcceptanceStatus | "") {
+  if (!status) return undefined;
+  if (!ADMIN_QUEST_ACCEPTANCE_STATUSES.includes(status)) throw new RangeError("status must be a canonical Acceptance status.");
+  return status;
+}

--- a/features/admin/api/quest.source.test.ts
+++ b/features/admin/api/quest.source.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getAdminQuestDataSource } from "./quest.source";
+
+const api = vi.hoisted(() => ({ catalog: vi.fn(), definitions: vi.fn(), definition: vi.fn(), acceptances: vi.fn(), acceptance: vi.fn() }));
+const mock = vi.hoisted(() => ({ catalog: vi.fn(), definitions: vi.fn(), definition: vi.fn(), acceptances: vi.fn(), acceptance: vi.fn() }));
+vi.mock("./quest", () => ({
+  getAdminQuestCatalog: api.catalog, getAdminQuestDefinitions: api.definitions, getAdminQuestDefinition: api.definition,
+  getAdminQuestAcceptances: api.acceptances, getAdminQuestAcceptance: api.acceptance,
+}));
+vi.mock("./quest.mock", () => ({
+  getMockAdminQuestCatalog: mock.catalog, getMockAdminQuestDefinitions: mock.definitions, getMockAdminQuestDefinition: mock.definition,
+  getMockAdminQuestAcceptances: mock.acceptances, getMockAdminQuestAcceptance: mock.acceptance,
+}));
+
+describe("Admin Quest data-source selector", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it.each([
+    [undefined, "api"], ["api", "api"], ["mock", "mock"], ["invalid", "api"],
+  ] as const)("resolves %s to %s using the shared Admin mode rule", (value, expected) => {
+    expect(getAdminQuestDataSource(value).descriptor.mode).toBe(expected);
+  });
+
+  it("exposes truthful Quest source labels", () => {
+    expect(getAdminQuestDataSource("api").descriptor).toEqual({ mode: "api", badge: "API", label: "/admin/v1", questLabel: "/admin/v1/quests" });
+    expect(getAdminQuestDataSource("mock").descriptor).toEqual({ mode: "mock", badge: "MOCK DATA", label: "Local Admin Mock", questLabel: "Local Admin Mock" });
+  });
+
+  it("does not fall back to Mock when the API source fails", async () => {
+    api.catalog.mockRejectedValueOnce(new Error("API unavailable"));
+    await expect(getAdminQuestDataSource("api").getCatalog()).rejects.toThrow("API unavailable");
+    expect(mock.catalog).not.toHaveBeenCalled();
+  });
+});

--- a/features/admin/api/quest.source.ts
+++ b/features/admin/api/quest.source.ts
@@ -1,0 +1,57 @@
+import type {
+  AdminQuestAcceptance,
+  AdminQuestAcceptances,
+  AdminQuestAcceptanceStatus,
+  AdminQuestBlueprints,
+  AdminQuestDefinition,
+  AdminQuestDefinitions,
+} from "../quest/model";
+import {
+  getAdminQuestAcceptance,
+  getAdminQuestAcceptances,
+  getAdminQuestCatalog,
+  getAdminQuestDefinition,
+  getAdminQuestDefinitions,
+} from "./quest";
+import {
+  getMockAdminQuestAcceptance,
+  getMockAdminQuestAcceptances,
+  getMockAdminQuestCatalog,
+  getMockAdminQuestDefinition,
+  getMockAdminQuestDefinitions,
+} from "./quest.mock";
+import { resolveAdminDataSourceMode } from "./source";
+import type { AdminDataSourceDescriptor } from "./source";
+
+export type AdminQuestDataSource = {
+  descriptor: AdminDataSourceDescriptor & { questLabel: string };
+  getCatalog: () => Promise<AdminQuestBlueprints>;
+  getDefinitions: () => Promise<AdminQuestDefinitions>;
+  getDefinition: (questCode: string) => Promise<AdminQuestDefinition>;
+  getAcceptances: (questCode: string, status?: AdminQuestAcceptanceStatus | "") => Promise<AdminQuestAcceptances>;
+  getAcceptance: (acceptanceId: number) => Promise<AdminQuestAcceptance>;
+};
+
+const API_SOURCE: AdminQuestDataSource = {
+  descriptor: { mode: "api", badge: "API", label: "/admin/v1", questLabel: "/admin/v1/quests" },
+  getCatalog: getAdminQuestCatalog,
+  getDefinitions: getAdminQuestDefinitions,
+  getDefinition: getAdminQuestDefinition,
+  getAcceptances: getAdminQuestAcceptances,
+  getAcceptance: getAdminQuestAcceptance,
+};
+
+const MOCK_SOURCE: AdminQuestDataSource = {
+  descriptor: { mode: "mock", badge: "MOCK DATA", label: "Local Admin Mock", questLabel: "Local Admin Mock" },
+  getCatalog: getMockAdminQuestCatalog,
+  getDefinitions: getMockAdminQuestDefinitions,
+  getDefinition: getMockAdminQuestDefinition,
+  getAcceptances: getMockAdminQuestAcceptances,
+  getAcceptance: getMockAdminQuestAcceptance,
+};
+
+export function getAdminQuestDataSource(value: unknown): AdminQuestDataSource {
+  return resolveAdminDataSourceMode(value) === "mock" ? MOCK_SOURCE : API_SOURCE;
+}
+
+export const adminQuestDataSource = getAdminQuestDataSource(process.env.NEXT_PUBLIC_ADMIN_DATA_SOURCE);

--- a/features/admin/api/quest.test.ts
+++ b/features/admin/api/quest.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { AdminQuestAcceptanceStatus } from "../quest/model";
 import {
   getAdminQuestAcceptance,
   getAdminQuestAcceptances,
@@ -40,7 +41,7 @@ describe("read-only Admin Quest API adapter", () => {
     [() => getAdminQuestAcceptances(""), "must not be blank"],
     [() => getAdminQuestAcceptance(0), "positive integer"],
     [() => getAdminQuestAcceptance(1.5), "positive integer"],
-    [() => getAdminQuestAcceptances("quest:record:first-trace", "DONE" as "COMPLETED"), "canonical Acceptance status"],
+    [() => getAdminQuestAcceptances("quest:record:first-trace", "DONE" as unknown as AdminQuestAcceptanceStatus), "canonical Acceptance status"],
   ])("rejects invalid input through its Promise contract", async (request, message) => {
     const result = request();
 

--- a/features/admin/api/quest.test.ts
+++ b/features/admin/api/quest.test.ts
@@ -21,9 +21,9 @@ describe("read-only Admin Quest API adapter", () => {
   it("uses the exact five GET endpoint forms with safe path and query encoding", async () => {
     await getAdminQuestCatalog();
     await getAdminQuestDefinitions();
-    await getAdminQuestDefinition("quest/with space");
-    await getAdminQuestAcceptances("quest/with space");
-    await getAdminQuestAcceptances("quest/with space", "GOAL_REACHED");
+    await getAdminQuestDefinition(" quest/with space ");
+    await getAdminQuestAcceptances(" quest/with space ");
+    await getAdminQuestAcceptances(" quest/with space ", "GOAL_REACHED");
     await getAdminQuestAcceptance(9001);
 
     expect(client.apiGet).toHaveBeenNthCalledWith(1, "/admin/v1/quests/catalog");
@@ -35,11 +35,17 @@ describe("read-only Admin Quest API adapter", () => {
     expect(client.apiGet.mock.calls.flat().join(" ")).not.toContain("/api/v1/admin/");
   });
 
-  it("rejects blank Quest codes and invalid Acceptance IDs before a request", () => {
-    expect(() => getAdminQuestDefinition("   ")).toThrow("must not be blank");
-    expect(() => getAdminQuestAcceptances("")).toThrow("must not be blank");
-    expect(() => getAdminQuestAcceptance(0)).toThrow("positive integer");
-    expect(() => getAdminQuestAcceptance(1.5)).toThrow("positive integer");
+  it.each([
+    [() => getAdminQuestDefinition("   "), "must not be blank"],
+    [() => getAdminQuestAcceptances(""), "must not be blank"],
+    [() => getAdminQuestAcceptance(0), "positive integer"],
+    [() => getAdminQuestAcceptance(1.5), "positive integer"],
+    [() => getAdminQuestAcceptances("quest:record:first-trace", "DONE" as "COMPLETED"), "canonical Acceptance status"],
+  ])("rejects invalid input through its Promise contract", async (request, message) => {
+    const result = request();
+
+    expect(result).toBeInstanceOf(Promise);
+    await expect(result).rejects.toThrow(message);
     expect(client.apiGet).not.toHaveBeenCalled();
   });
 

--- a/features/admin/api/quest.test.ts
+++ b/features/admin/api/quest.test.ts
@@ -1,0 +1,50 @@
+import { readFileSync } from "node:fs";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  getAdminQuestAcceptance,
+  getAdminQuestAcceptances,
+  getAdminQuestCatalog,
+  getAdminQuestDefinition,
+  getAdminQuestDefinitions,
+} from "./quest";
+
+const client = vi.hoisted(() => ({ apiGet: vi.fn() }));
+vi.mock("@/shared/api/client", () => client);
+
+describe("read-only Admin Quest API adapter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    client.apiGet.mockResolvedValue({});
+  });
+
+  it("uses the exact five GET endpoint forms with safe path and query encoding", async () => {
+    await getAdminQuestCatalog();
+    await getAdminQuestDefinitions();
+    await getAdminQuestDefinition("quest/with space");
+    await getAdminQuestAcceptances("quest/with space");
+    await getAdminQuestAcceptances("quest/with space", "GOAL_REACHED");
+    await getAdminQuestAcceptance(9001);
+
+    expect(client.apiGet).toHaveBeenNthCalledWith(1, "/admin/v1/quests/catalog");
+    expect(client.apiGet).toHaveBeenNthCalledWith(2, "/admin/v1/quests/definitions");
+    expect(client.apiGet).toHaveBeenNthCalledWith(3, "/admin/v1/quests/definitions/quest%2Fwith%20space");
+    expect(client.apiGet).toHaveBeenNthCalledWith(4, "/admin/v1/quests/quest%2Fwith%20space/acceptances");
+    expect(client.apiGet).toHaveBeenNthCalledWith(5, "/admin/v1/quests/quest%2Fwith%20space/acceptances?status=GOAL_REACHED");
+    expect(client.apiGet).toHaveBeenNthCalledWith(6, "/admin/v1/quests/acceptances/9001");
+    expect(client.apiGet.mock.calls.flat().join(" ")).not.toContain("/api/v1/admin/");
+  });
+
+  it("rejects blank Quest codes and invalid Acceptance IDs before a request", () => {
+    expect(() => getAdminQuestDefinition("   ")).toThrow("must not be blank");
+    expect(() => getAdminQuestAcceptances("")).toThrow("must not be blank");
+    expect(() => getAdminQuestAcceptance(0)).toThrow("positive integer");
+    expect(() => getAdminQuestAcceptance(1.5)).toThrow("positive integer");
+    expect(client.apiGet).not.toHaveBeenCalled();
+  });
+
+  it("contains no mutation transport", () => {
+    const source = readFileSync("features/admin/api/quest.ts", "utf8");
+    expect(source).not.toMatch(/apiPatch|apiPost|apiPut|apiDelete|\/progress|\/status/);
+  });
+});

--- a/features/admin/api/quest.ts
+++ b/features/admin/api/quest.ts
@@ -7,19 +7,13 @@ import type {
   AdminQuestDefinition,
   AdminQuestDefinitions,
 } from "../quest/model";
+import {
+  normalizeAdminQuestCode,
+  requirePositiveAdminAcceptanceId,
+  validateAdminQuestAcceptanceStatus,
+} from "./quest.query";
 
 export const ADMIN_QUESTS_PATH = "/admin/v1/quests";
-
-function questCodePath(questCode: string) {
-  const code = questCode.trim();
-  if (!code) throw new RangeError("questCode must not be blank.");
-  return encodeURIComponent(code);
-}
-
-function acceptanceIdPath(acceptanceId: number) {
-  if (!Number.isInteger(acceptanceId) || acceptanceId < 1) throw new RangeError("acceptanceId must be a positive integer.");
-  return acceptanceId;
-}
 
 export function getAdminQuestCatalog(): Promise<AdminQuestBlueprints> {
   return apiGet(`${ADMIN_QUESTS_PATH}/catalog`);
@@ -29,15 +23,16 @@ export function getAdminQuestDefinitions(): Promise<AdminQuestDefinitions> {
   return apiGet(`${ADMIN_QUESTS_PATH}/definitions`);
 }
 
-export function getAdminQuestDefinition(questCode: string): Promise<AdminQuestDefinition> {
-  return apiGet(`${ADMIN_QUESTS_PATH}/definitions/${questCodePath(questCode)}`);
+export async function getAdminQuestDefinition(questCode: string): Promise<AdminQuestDefinition> {
+  return apiGet(`${ADMIN_QUESTS_PATH}/definitions/${encodeURIComponent(normalizeAdminQuestCode(questCode))}`);
 }
 
-export function getAdminQuestAcceptances(questCode: string, status?: AdminQuestAcceptanceStatus | ""): Promise<AdminQuestAcceptances> {
-  const path = `${ADMIN_QUESTS_PATH}/${questCodePath(questCode)}/acceptances`;
-  return apiGet(status ? `${path}?${new URLSearchParams({ status })}` : path);
+export async function getAdminQuestAcceptances(questCode: string, status?: AdminQuestAcceptanceStatus | ""): Promise<AdminQuestAcceptances> {
+  const path = `${ADMIN_QUESTS_PATH}/${encodeURIComponent(normalizeAdminQuestCode(questCode))}/acceptances`;
+  const normalizedStatus = validateAdminQuestAcceptanceStatus(status);
+  return apiGet(normalizedStatus ? `${path}?${new URLSearchParams({ status: normalizedStatus })}` : path);
 }
 
-export function getAdminQuestAcceptance(acceptanceId: number): Promise<AdminQuestAcceptance> {
-  return apiGet(`${ADMIN_QUESTS_PATH}/acceptances/${acceptanceIdPath(acceptanceId)}`);
+export async function getAdminQuestAcceptance(acceptanceId: number): Promise<AdminQuestAcceptance> {
+  return apiGet(`${ADMIN_QUESTS_PATH}/acceptances/${requirePositiveAdminAcceptanceId(acceptanceId)}`);
 }

--- a/features/admin/api/quest.ts
+++ b/features/admin/api/quest.ts
@@ -1,0 +1,43 @@
+import { apiGet } from "@/shared/api/client";
+import type {
+  AdminQuestAcceptance,
+  AdminQuestAcceptances,
+  AdminQuestAcceptanceStatus,
+  AdminQuestBlueprints,
+  AdminQuestDefinition,
+  AdminQuestDefinitions,
+} from "../quest/model";
+
+export const ADMIN_QUESTS_PATH = "/admin/v1/quests";
+
+function questCodePath(questCode: string) {
+  const code = questCode.trim();
+  if (!code) throw new RangeError("questCode must not be blank.");
+  return encodeURIComponent(code);
+}
+
+function acceptanceIdPath(acceptanceId: number) {
+  if (!Number.isInteger(acceptanceId) || acceptanceId < 1) throw new RangeError("acceptanceId must be a positive integer.");
+  return acceptanceId;
+}
+
+export function getAdminQuestCatalog(): Promise<AdminQuestBlueprints> {
+  return apiGet(`${ADMIN_QUESTS_PATH}/catalog`);
+}
+
+export function getAdminQuestDefinitions(): Promise<AdminQuestDefinitions> {
+  return apiGet(`${ADMIN_QUESTS_PATH}/definitions`);
+}
+
+export function getAdminQuestDefinition(questCode: string): Promise<AdminQuestDefinition> {
+  return apiGet(`${ADMIN_QUESTS_PATH}/definitions/${questCodePath(questCode)}`);
+}
+
+export function getAdminQuestAcceptances(questCode: string, status?: AdminQuestAcceptanceStatus | ""): Promise<AdminQuestAcceptances> {
+  const path = `${ADMIN_QUESTS_PATH}/${questCodePath(questCode)}/acceptances`;
+  return apiGet(status ? `${path}?${new URLSearchParams({ status })}` : path);
+}
+
+export function getAdminQuestAcceptance(acceptanceId: number): Promise<AdminQuestAcceptance> {
+  return apiGet(`${ADMIN_QUESTS_PATH}/acceptances/${acceptanceIdPath(acceptanceId)}`);
+}

--- a/features/admin/model.ts
+++ b/features/admin/model.ts
@@ -19,7 +19,7 @@ export type AdminArea = {
 export const ADMIN_AREAS: AdminArea[] = [
   { id: "dashboard", label: "Dashboard", shortLabel: "D", state: "DEFERRED", reason: "BACKEND_READ_MODEL_REQUIRED" },
   { id: "players", label: "Players", shortLabel: "P", state: "SUPPORTED", reason: "Exact User ID lookup and read-only Player detail are supported." },
-  { id: "content", label: "Content", shortLabel: "C", state: "DEFERRED", reason: "Content administration is deferred to a later approved slice." },
+  { id: "content", label: "Content", shortLabel: "C", state: "SUPPORTED", reason: "Read-only Quest Runtime Status is supported; other Content capabilities remain deferred." },
   { id: "economy", label: "Economy", shortLabel: "E", state: "GATED", reason: "Economy commands are not enabled in the current Admin slice." },
   { id: "social", label: "Social & Trust", shortLabel: "S", state: "PRIVACY_GATED", reason: "Private social content is outside this Admin slice." },
   { id: "system", label: "System", shortLabel: "Y", state: "SUPPORTED", reason: "Admin Audit remains supported." },

--- a/features/admin/quest/QuestRuntimeStatus.test.tsx
+++ b/features/admin/quest/QuestRuntimeStatus.test.tsx
@@ -1,0 +1,171 @@
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ApiError } from "@/shared/api/client";
+import type { AdminQuestDataSource } from "../api/quest.source";
+import type { AdminQuestAcceptance, AdminQuestBlueprint, AdminQuestDefinition } from "./model";
+import { QuestRuntimeStatus } from "./QuestRuntimeStatus";
+
+const blueprint: AdminQuestBlueprint = {
+  code: "quest:record:first-trace", title: "First Trace", category: null, descriptionMd: "Record one LifeLog entry.",
+  targetType: "COUNT", targetValue: 1, repeatRule: "ONCE", completionPolicy: "AUTO", definitionVersion: 2,
+  rewardProfileCode: "RP_EXP_TINY_10", rewardExp: null, rewardStats: null, dueAt: null,
+  semanticCategory: "RECORD", progressSource: "RECORD_CREATED", repeatPolicy: "ONCE", roleTemplateCode: null,
+};
+const definition: AdminQuestDefinition = { id: 501, ...blueprint };
+const emptyDefinition: AdminQuestDefinition = {
+  id: 502, ...blueprint, code: "quest:daily:walk", title: "Daily Walk", category: "DAILY", definitionVersion: 1,
+};
+const acceptance: AdminQuestAcceptance = {
+  id: 9001, questId: 501, playerId: 10218, code: definition.code, title: definition.title, category: null,
+  targetType: "COUNT", targetValue: 1, progressValue: 0, status: "IN_PROGRESS", completionPolicy: "AUTO", repeatRule: "ONCE",
+  periodStart: null, periodEnd: null, acceptedAt: "2026-08-24T04:00:00Z", periodKey: null, goalReachedAt: null,
+  completedAt: null, dueAt: null, semanticCategory: "RECORD", progressSource: "RECORD_CREATED", repeatPolicy: "ONCE", roleTemplateCode: null,
+};
+const completed: AdminQuestAcceptance = {
+  ...acceptance, id: 9002, playerId: 10219, progressValue: 1, status: "COMPLETED",
+  goalReachedAt: "2026-08-23T04:05:00Z", completedAt: "2026-08-23T04:05:00Z",
+};
+
+function source(): AdminQuestDataSource {
+  return {
+    descriptor: { mode: "api", badge: "API", label: "/admin/v1", questLabel: "/admin/v1/quests" },
+    getCatalog: vi.fn().mockResolvedValue({ blueprints: [blueprint] }),
+    getDefinitions: vi.fn().mockResolvedValue({ definitions: [definition, emptyDefinition] }),
+    getDefinition: vi.fn(async (code: string) => code === emptyDefinition.code ? emptyDefinition : definition),
+    getAcceptances: vi.fn(async (code: string, status = "") => ({
+      acceptances: code === emptyDefinition.code ? [] : [acceptance, completed].filter((item) => !status || item.status === status),
+    })),
+    getAcceptance: vi.fn().mockResolvedValue(acceptance),
+  };
+}
+
+async function selectDefinition(code = definition.code) {
+  fireEvent.click(await screen.findByRole("button", { name: code }));
+  await waitFor(() => expect(document.getElementById("quest-definition-title")).toHaveFocus());
+}
+
+describe("read-only Quest Runtime Status", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => { callback(0); return 1; });
+  });
+
+  it("loads catalog and definitions, then separates explicit Definition and Acceptance loading", async () => {
+    const dataSource = source();
+    let resolveCatalog!: (value: { blueprints: AdminQuestBlueprint[] }) => void;
+    vi.mocked(dataSource.getCatalog).mockReturnValue(new Promise((resolve) => { resolveCatalog = resolve; }));
+    render(<QuestRuntimeStatus access="ready" onLogin={vi.fn()} dataSource={dataSource} />);
+
+    expect(await screen.findByRole("heading", { name: "Loading Quest sources" })).toBeInTheDocument();
+    await act(async () => resolveCatalog({ blueprints: [blueprint] }));
+    expect(await screen.findByRole("button", { name: definition.code })).toBeInTheDocument();
+    expect(dataSource.getDefinition).not.toHaveBeenCalled();
+
+    await selectDefinition();
+    expect(dataSource.getDefinition).toHaveBeenCalledWith(definition.code);
+    expect(dataSource.getAcceptances).toHaveBeenCalledWith(definition.code);
+    expect(screen.getByText("Definition configuration and player Acceptance runtime state remain separate. Quest completion does not automatically advance a QuestRoute.")).toBeInTheDocument();
+    expect(screen.getByText("RP_EXP_TINY_10")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "9001" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /adjust|override|complete|repair|advance|publish|create|update/i })).not.toBeInTheDocument();
+  });
+
+  it("filters by the proven status values and opens an exact Acceptance detail", async () => {
+    const dataSource = source();
+    render(<QuestRuntimeStatus access="ready" onLogin={vi.fn()} dataSource={dataSource} />);
+    await selectDefinition();
+
+    fireEvent.click(screen.getByRole("button", { name: "9001" }));
+    await waitFor(() => expect(document.getElementById("quest-acceptance-title")).toHaveFocus());
+    expect(dataSource.getAcceptance).toHaveBeenCalledWith(9001);
+    expect(within(document.getElementById("quest-acceptance-title")!.closest("aside")!).getByText("2026-08-24T04:00:00Z")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Acceptance status"), { target: { value: "COMPLETED" } });
+    expect(await screen.findByRole("button", { name: "9002" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "9001" })).not.toBeInTheDocument();
+    expect(dataSource.getAcceptances).toHaveBeenLastCalledWith(definition.code, "COMPLETED");
+  });
+
+  it("distinguishes an empty Quest from a status no-match", async () => {
+    const dataSource = source();
+    render(<QuestRuntimeStatus access="ready" onLogin={vi.fn()} dataSource={dataSource} />);
+    await selectDefinition(emptyDefinition.code);
+
+    expect(screen.getByRole("heading", { name: "No Quest Acceptances" })).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText("Acceptance status"), { target: { value: "COMPLETED" } });
+    expect(await screen.findByRole("heading", { name: "No matching Acceptances" })).toBeInTheDocument();
+  });
+
+  it("retries the same source after an index error without switching to Mock", async () => {
+    const dataSource = source();
+    vi.mocked(dataSource.getCatalog).mockRejectedValueOnce(new Error("Network unavailable"));
+    render(<QuestRuntimeStatus access="ready" onLogin={vi.fn()} dataSource={dataSource} />);
+
+    expect(await screen.findByRole("heading", { name: "Unable to load Quest sources" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(await screen.findByRole("button", { name: definition.code })).toBeInTheDocument();
+    expect(dataSource.getCatalog).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([[401, "Authentication required"], [403, "Admin access denied"]] as const)("renders %s without cached Quest data", async (status, title) => {
+    const dataSource = source();
+    vi.mocked(dataSource.getCatalog).mockRejectedValueOnce(new ApiError(status, `HTTP_${status}`, "Denied"));
+    render(<QuestRuntimeStatus access="ready" onLogin={vi.fn()} dataSource={dataSource} />);
+
+    expect(await screen.findByRole("heading", { name: title })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: definition.code })).not.toBeInTheDocument();
+  });
+
+  it("withholds a mismatched Definition and retries the same Quest code", async () => {
+    const dataSource = source();
+    vi.mocked(dataSource.getDefinition)
+      .mockResolvedValueOnce({ ...definition, code: "quest:wrong", title: "Wrong Definition" })
+      .mockResolvedValueOnce(definition);
+    render(<QuestRuntimeStatus access="ready" onLogin={vi.fn()} dataSource={dataSource} />);
+    fireEvent.click(await screen.findByRole("button", { name: definition.code }));
+
+    expect(await screen.findByText("Quest definition response did not match the requested Quest code.")).toBeInTheDocument();
+    expect(screen.queryByText("Wrong Definition")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    await waitFor(() => expect(document.getElementById("quest-definition-title")).toHaveFocus());
+    expect(dataSource.getDefinition).toHaveBeenNthCalledWith(1, definition.code);
+    expect(dataSource.getDefinition).toHaveBeenNthCalledWith(2, definition.code);
+  });
+
+  it("withholds an Acceptance list containing another Quest code", async () => {
+    const dataSource = source();
+    vi.mocked(dataSource.getAcceptances)
+      .mockResolvedValueOnce({ acceptances: [{ ...acceptance, code: "quest:wrong" }] })
+      .mockResolvedValueOnce({ acceptances: [acceptance] });
+    render(<QuestRuntimeStatus access="ready" onLogin={vi.fn()} dataSource={dataSource} />);
+    fireEvent.click(await screen.findByRole("button", { name: definition.code }));
+
+    expect(await screen.findByText("Quest acceptance list contained another Quest code.")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "9001" })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(await screen.findByRole("button", { name: "9001" })).toBeInTheDocument();
+  });
+
+  it("withholds mismatched Acceptance identity and selected Quest identity before rendering", async () => {
+    const dataSource = source();
+    vi.mocked(dataSource.getAcceptance)
+      .mockResolvedValueOnce({ ...acceptance, id: 9999 })
+      .mockResolvedValueOnce({ ...acceptance, code: "quest:wrong" })
+      .mockResolvedValueOnce(acceptance);
+    render(<QuestRuntimeStatus access="ready" onLogin={vi.fn()} dataSource={dataSource} />);
+    await selectDefinition();
+    fireEvent.click(screen.getByRole("button", { name: "9001" }));
+
+    expect(await screen.findByText("Quest acceptance response did not match the requested Acceptance ID.")).toBeInTheDocument();
+    expect(screen.queryByText("9999")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(await screen.findByText("Quest acceptance response did not match the selected Quest code.")).toBeInTheDocument();
+    expect(screen.queryByText("quest:wrong")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    await waitFor(() => expect(document.getElementById("quest-acceptance-title")).toHaveFocus());
+    expect(dataSource.getAcceptance).toHaveBeenNthCalledWith(1, 9001);
+    expect(dataSource.getAcceptance).toHaveBeenNthCalledWith(2, 9001);
+    expect(dataSource.getAcceptance).toHaveBeenNthCalledWith(3, 9001);
+  });
+});

--- a/features/admin/quest/QuestRuntimeStatus.test.tsx
+++ b/features/admin/quest/QuestRuntimeStatus.test.tsx
@@ -147,6 +147,27 @@ describe("read-only Quest Runtime Status", () => {
     expect(await screen.findByRole("button", { name: "9001" })).toBeInTheDocument();
   });
 
+  it("withholds a filtered Acceptance list containing another status and retries the same filter", async () => {
+    const dataSource = source();
+    render(<QuestRuntimeStatus access="ready" onLogin={vi.fn()} dataSource={dataSource} />);
+    await selectDefinition();
+    vi.mocked(dataSource.getAcceptances)
+      .mockResolvedValueOnce({ acceptances: [acceptance] })
+      .mockResolvedValueOnce({ acceptances: [completed] });
+
+    fireEvent.change(screen.getByLabelText("Acceptance status"), { target: { value: "COMPLETED" } });
+
+    expect(await screen.findByRole("heading", { name: "Unable to load Quest Acceptances" })).toBeInTheDocument();
+    expect(screen.getByText("Quest acceptance list contained another Acceptance status.")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "9001" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "9002" })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(await screen.findByRole("button", { name: "9002" })).toBeInTheDocument();
+    expect(dataSource.getAcceptances).toHaveBeenNthCalledWith(2, definition.code, "COMPLETED");
+    expect(dataSource.getAcceptances).toHaveBeenNthCalledWith(3, definition.code, "COMPLETED");
+  });
+
   it("withholds mismatched Acceptance identity and selected Quest identity before rendering", async () => {
     const dataSource = source();
     vi.mocked(dataSource.getAcceptance)

--- a/features/admin/quest/QuestRuntimeStatus.tsx
+++ b/features/admin/quest/QuestRuntimeStatus.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+import { adminQuestDataSource } from "../api/quest.source";
+import type { AdminQuestDataSource } from "../api/quest.source";
+import type { AdminAccess } from "../model";
+import styles from "../admin.module.css";
+import { ADMIN_QUEST_ACCEPTANCE_STATUSES } from "./model";
+import type { AdminQuestAcceptance, AdminQuestAcceptanceStatus, AdminQuestDefinition } from "./model";
+import { useQuestRuntimeStatus } from "./useQuestRuntimeStatus";
+
+function StatePanel({ title, message, action }: { title: string; message: string; action?: React.ReactNode }) {
+  return <section className={styles.statePanel} role="status" aria-live="polite"><h2>{title}</h2><p>{message}</p>{action}</section>;
+}
+
+function shown(value: string | number | Record<string, number> | null) {
+  if (value === null) return "Not set";
+  if (typeof value === "object") return Object.keys(value).length ? JSON.stringify(value) : "None";
+  return value;
+}
+
+function QuestStatusBadge({ status }: { status: AdminQuestAcceptanceStatus }) {
+  return <span className={styles.questStatus} data-status={status}>◎ {status}</span>;
+}
+
+function DefinitionDetail({ definition, headingRef }: { definition: AdminQuestDefinition; headingRef: React.RefObject<HTMLHeadingElement | null> }) {
+  const fields = [
+    ["Definition ID", definition.id], ["Category", shown(definition.category)], ["Target type", definition.targetType],
+    ["Target value", definition.targetValue], ["Repeat rule", definition.repeatRule], ["Completion policy", definition.completionPolicy],
+    ["Definition version", definition.definitionVersion], ["Reward profile code", shown(definition.rewardProfileCode)],
+    ["Reward EXP", shown(definition.rewardExp)], ["Reward stats", shown(definition.rewardStats)], ["Due at", shown(definition.dueAt)],
+    ["Semantic category", shown(definition.semanticCategory)], ["Progress source", shown(definition.progressSource)],
+    ["Repeat policy", shown(definition.repeatPolicy)], ["Role template code", shown(definition.roleTemplateCode)],
+  ] as const;
+
+  return (
+    <section className={styles.questPanel} aria-labelledby="quest-definition-title">
+      <div className={styles.detailHeader}>
+        <div><p className={styles.eyebrow}>Quest Definition</p><h2 id="quest-definition-title" ref={headingRef} tabIndex={-1}>{definition.title}</h2></div>
+        <span className={styles.badge} data-state="READ_ONLY">▣ READ_ONLY</span>
+      </div>
+      <code className={styles.detailId}>{definition.code}</code>
+      <p className={styles.questDescription}>{definition.descriptionMd}</p>
+      <dl className={`${styles.detailList} ${styles.questDefinitionFields}`}>
+        {fields.map(([label, value]) => <div key={label}><dt>{label}</dt><dd className={label.includes("ID") || label.includes("code") ? styles.mono : undefined}>{value}</dd></div>)}
+      </dl>
+    </section>
+  );
+}
+
+function AcceptanceDetail({ acceptance, headingRef, onClose }: { acceptance: AdminQuestAcceptance; headingRef: React.RefObject<HTMLHeadingElement | null>; onClose: () => void }) {
+  const fields = [
+    ["Acceptance ID", acceptance.id], ["Quest ID", acceptance.questId], ["Player ID", acceptance.playerId], ["Quest code", acceptance.code],
+    ["Category", shown(acceptance.category)], ["Target type", acceptance.targetType], ["Target value", acceptance.targetValue],
+    ["Progress value", acceptance.progressValue], ["Completion policy", acceptance.completionPolicy], ["Repeat rule", acceptance.repeatRule],
+    ["Period start", shown(acceptance.periodStart)], ["Period end", shown(acceptance.periodEnd)], ["Accepted at", acceptance.acceptedAt],
+    ["Period key", shown(acceptance.periodKey)], ["Goal reached at", shown(acceptance.goalReachedAt)], ["Completed at", shown(acceptance.completedAt)],
+    ["Due at", shown(acceptance.dueAt)], ["Semantic category", shown(acceptance.semanticCategory)],
+    ["Progress source", shown(acceptance.progressSource)], ["Repeat policy", shown(acceptance.repeatPolicy)],
+    ["Role template code", shown(acceptance.roleTemplateCode)],
+  ] as const;
+
+  return (
+    <aside className={styles.detail} aria-labelledby="quest-acceptance-title">
+      <div className={styles.detailHeader}>
+        <div><p className={styles.eyebrow}>Quest Acceptance</p><h2 id="quest-acceptance-title" ref={headingRef} tabIndex={-1}>{acceptance.title}</h2></div>
+        <button type="button" className={styles.secondaryButton} onClick={onClose}>Close detail</button>
+      </div>
+      <QuestStatusBadge status={acceptance.status} />
+      <dl className={styles.detailList}>
+        {fields.map(([label, value]) => <div key={label}><dt>{label}</dt><dd className={label.includes("ID") || label.includes("code") ? styles.mono : undefined}>{value}</dd></div>)}
+      </dl>
+    </aside>
+  );
+}
+
+export function QuestRuntimeStatus({ access, onLogin, dataSource = adminQuestDataSource }: { access: AdminAccess; onLogin: () => void; dataSource?: AdminQuestDataSource }) {
+  const quest = useQuestRuntimeStatus(access === "ready", dataSource);
+  const definitionHeading = useRef<HTMLHeadingElement | null>(null);
+  const acceptanceHeading = useRef<HTMLHeadingElement | null>(null);
+  const acceptanceTriggers = useRef(new Map<number, HTMLButtonElement>());
+
+  useEffect(() => { if (quest.definition) definitionHeading.current?.focus(); }, [quest.definition]);
+  useEffect(() => { if (quest.acceptance) acceptanceHeading.current?.focus(); }, [quest.acceptance]);
+
+  const closeAcceptance = () => {
+    const id = quest.acceptance?.id;
+    quest.closeAcceptance();
+    if (id) requestAnimationFrame(() => acceptanceTriggers.current.get(id)?.focus());
+  };
+
+  const authRequired = access === "unauthenticated" || quest.error?.status === 401;
+  const forbidden = quest.error?.status === 403;
+  const visibleError = quest.error && !authRequired && !forbidden ? quest.error : null;
+  const indexError = visibleError?.kind === "index" ? visibleError : null;
+  const definitionError = visibleError?.kind === "definition" ? visibleError : null;
+  const acceptancesError = visibleError?.kind === "acceptances" ? visibleError : null;
+  const acceptanceError = visibleError?.kind === "acceptance" ? visibleError : null;
+
+  return (
+    <div className={styles.auditScreen}>
+      <div className={styles.screenHeader}>
+        <div><p className={styles.eyebrow}>Content / Quest Runtime Status</p><h1>Quest Runtime Status</h1><p>Inspect authored Quest definitions and player Acceptance state without changing runtime data.</p></div>
+        <div className={styles.screenActions}>
+          <span className={styles.badge} data-state="READ_ONLY">▣ READ_ONLY</span>
+          <button type="button" className={styles.secondaryButton} onClick={() => void quest.retry()} disabled={access !== "ready" || quest.loading !== null || (!quest.indexLoaded && !quest.error)}>Refresh</button>
+        </div>
+      </div>
+
+      <div className={styles.feedMeta}>
+        <span>Blueprint catalog: {quest.catalog.length} · Definitions: {quest.definitions.length}</span>
+        <span>Source: <code>{dataSource.descriptor.questLabel}</code>{quest.loadedAt ? ` · refreshed ${quest.loadedAt.toLocaleTimeString()}` : ""}</span>
+      </div>
+
+      {access === "loading" ? <StatePanel title="Validating session" message="Checking the authenticated operator session." /> : null}
+      {authRequired ? <StatePanel title="Authentication required" message="Sign in with an authorized operator account, then retry Quest Runtime Status." action={<button type="button" className={styles.primaryButton} onClick={onLogin}>Go to login</button>} /> : null}
+      {forbidden ? <StatePanel title="Admin access denied" message="The server did not authorize this session for Quest Runtime Status. No Quest data is shown." /> : null}
+      {access === "ready" && (quest.loading === "index" || (!quest.indexLoaded && !quest.error)) ? <StatePanel title="Loading Quest sources" message="Loading the Blueprint catalog and authored Quest definitions." /> : null}
+      {access === "ready" && indexError ? <StatePanel title="Unable to load Quest sources" message={indexError.message} action={<button type="button" className={styles.primaryButton} onClick={() => void quest.retry()}>Retry</button>} /> : null}
+      {access === "ready" && quest.indexLoaded && quest.definitions.length === 0 ? <StatePanel title="No Quest definitions" message="The authored Quest definition source is empty." /> : null}
+
+      {access === "ready" && quest.indexLoaded && quest.definitions.length > 0 ? (
+        <div className={styles.questLayout}>
+          <section className={styles.questPanel} aria-labelledby="quest-definitions-title">
+            <div className={styles.questPanelHeader}><div><p className={styles.eyebrow}>Definition source</p><h2 id="quest-definitions-title">Quest definitions</h2></div><span>{quest.definitions.length} records</span></div>
+            <details className={styles.catalogDisclosure}>
+              <summary>Blueprint catalog · {quest.catalog.length}</summary>
+              <ul>{quest.catalog.map((blueprint) => <li key={blueprint.code}><code>{blueprint.code}</code><span>{blueprint.title}</span></li>)}</ul>
+            </details>
+            <div className={styles.tableWrap}>
+              <table className={`${styles.table} ${styles.questDefinitionTable}`}>
+                <caption>Authored Quest definitions</caption>
+                <thead><tr><th>Code</th><th>Title</th><th>Category</th><th>Version</th></tr></thead>
+                <tbody>{quest.definitions.map((definition) => (
+                  <tr key={definition.code} data-selected={quest.selectedCode === definition.code || undefined}>
+                    <td><button type="button" className={styles.idButton} onClick={() => void quest.selectDefinition(definition.code)}>{definition.code}</button></td>
+                    <td>{definition.title}</td><td>{shown(definition.category)}</td><td>{definition.definitionVersion}</td>
+                  </tr>
+                ))}</tbody>
+              </table>
+            </div>
+          </section>
+
+          <div className={styles.questWorkspace}>
+            {quest.loading === "definition" ? <StatePanel title="Loading Quest definition" message={`Loading ${quest.selectedCode}.`} /> : definitionError ? <StatePanel title={definitionError.status === 404 ? "Quest definition not found" : "Unable to load Quest definition"} message={definitionError.message} action={<button type="button" className={styles.primaryButton} onClick={() => void quest.retry()}>Retry</button>} /> : quest.definition ? <DefinitionDetail definition={quest.definition} headingRef={definitionHeading} /> : <section className={styles.detailPlaceholder}><span className={styles.badge} data-state="READ_ONLY">▣ READ_ONLY</span><h2>Select a Quest definition</h2><p>Choose an exact Quest code to load its definition and runtime Acceptances.</p></section>}
+
+            {quest.definition ? (
+              <section className={styles.questPanel} aria-labelledby="quest-acceptances-title">
+                <div className={styles.questAcceptanceHeader}>
+                  <div><p className={styles.eyebrow}>Runtime state</p><h2 id="quest-acceptances-title">Quest Acceptances</h2></div>
+                  <label>Acceptance status<select value={quest.statusFilter} onChange={(event) => void quest.filterAcceptances(event.target.value as AdminQuestAcceptanceStatus | "")} disabled={quest.loading !== null}><option value="">All statuses</option>{ADMIN_QUEST_ACCEPTANCE_STATUSES.map((status) => <option key={status} value={status}>{status}</option>)}</select></label>
+                </div>
+                <p className={styles.questSemantics}>Definition configuration and player Acceptance runtime state remain separate. Quest completion does not automatically advance a QuestRoute.</p>
+                {quest.loading === "acceptances" ? <StatePanel title="Loading Quest Acceptances" message="Applying the exact runtime status filter." /> : acceptancesError ? <StatePanel title="Unable to load Quest Acceptances" message={acceptancesError.message} action={<button type="button" className={styles.primaryButton} onClick={() => void quest.retry()}>Retry</button>} /> : quest.acceptances.length === 0 ? <StatePanel title={quest.statusFilter ? "No matching Acceptances" : "No Quest Acceptances"} message={quest.statusFilter ? `No ${quest.statusFilter} Acceptance exists for this Quest.` : "No player Acceptance exists for this Quest definition."} /> : (
+                  <div className={styles.questAcceptanceLayout}>
+                    <div className={styles.tableWrap}>
+                      <table className={`${styles.table} ${styles.questAcceptanceTable}`}>
+                        <caption>Acceptances for {quest.definition.code}</caption>
+                        <thead><tr><th>ID</th><th>Player ID</th><th>Progress</th><th>Status</th><th>Accepted</th></tr></thead>
+                        <tbody>{quest.acceptances.map((acceptance) => <tr key={acceptance.id} data-selected={quest.acceptance?.id === acceptance.id || undefined}><td><button ref={(node) => { if (node) acceptanceTriggers.current.set(acceptance.id, node); else acceptanceTriggers.current.delete(acceptance.id); }} type="button" className={styles.idButton} onClick={() => void quest.openAcceptance(acceptance.id)}>{acceptance.id}</button></td><td className={styles.mono}>{acceptance.playerId}</td><td>{acceptance.progressValue} / {acceptance.targetValue}</td><td><QuestStatusBadge status={acceptance.status} /></td><td>{acceptance.acceptedAt}</td></tr>)}</tbody>
+                      </table>
+                    </div>
+                    {quest.loading === "acceptance" ? <StatePanel title="Loading Acceptance detail" message="Loading the selected Acceptance ID." /> : acceptanceError ? <StatePanel title={acceptanceError.status === 404 ? "Acceptance not found" : "Unable to load Acceptance detail"} message={acceptanceError.message} action={<button type="button" className={styles.primaryButton} onClick={() => void quest.retry()}>Retry</button>} /> : quest.acceptance ? <AcceptanceDetail acceptance={quest.acceptance} headingRef={acceptanceHeading} onClose={closeAcceptance} /> : <aside className={styles.detailPlaceholder}><span className={styles.badge} data-state="READ_ONLY">▣ READ_ONLY</span><h2>Acceptance detail</h2><p>Open an exact Acceptance ID to inspect its runtime state.</p></aside>}
+                  </div>
+                )}
+              </section>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/features/admin/quest/model.ts
+++ b/features/admin/quest/model.ts
@@ -1,0 +1,58 @@
+type AdminQuestDefinitionFields = {
+  code: string;
+  title: string;
+  category: string | null;
+  descriptionMd: string;
+  targetType: string;
+  targetValue: number;
+  repeatRule: string;
+  completionPolicy: string;
+  definitionVersion: number;
+  rewardProfileCode: string | null;
+  rewardExp: number | null;
+  rewardStats: Record<string, number> | null;
+  dueAt: string | null;
+  semanticCategory: string | null;
+  progressSource: string | null;
+  repeatPolicy: string | null;
+  roleTemplateCode: string | null;
+};
+
+export type AdminQuestBlueprint = AdminQuestDefinitionFields;
+
+export type AdminQuestDefinition = AdminQuestDefinitionFields & {
+  id: number;
+};
+
+export const ADMIN_QUEST_ACCEPTANCE_STATUSES = ["IN_PROGRESS", "GOAL_REACHED", "COMPLETED", "CANCELED"] as const;
+export type AdminQuestAcceptanceStatus = typeof ADMIN_QUEST_ACCEPTANCE_STATUSES[number];
+
+export type AdminQuestAcceptance = {
+  id: number;
+  questId: number;
+  playerId: number;
+  code: string;
+  title: string;
+  category: string | null;
+  targetType: string;
+  targetValue: number;
+  progressValue: number;
+  status: AdminQuestAcceptanceStatus;
+  completionPolicy: string;
+  repeatRule: string;
+  periodStart: string | null;
+  periodEnd: string | null;
+  acceptedAt: string;
+  periodKey: string | null;
+  goalReachedAt: string | null;
+  completedAt: string | null;
+  dueAt: string | null;
+  semanticCategory: string | null;
+  progressSource: string | null;
+  repeatPolicy: string | null;
+  roleTemplateCode: string | null;
+};
+
+export type AdminQuestBlueprints = { blueprints: AdminQuestBlueprint[] };
+export type AdminQuestDefinitions = { definitions: AdminQuestDefinition[] };
+export type AdminQuestAcceptances = { acceptances: AdminQuestAcceptance[] };

--- a/features/admin/quest/useQuestRuntimeStatus.ts
+++ b/features/admin/quest/useQuestRuntimeStatus.ts
@@ -19,9 +19,12 @@ type Intent =
 
 type QuestLoadError = { kind: Intent["kind"]; status: number | null; message: string };
 
-function ensureAcceptanceCodes(acceptances: AdminQuestAcceptance[], questCode: string) {
+function ensureAcceptanceListMatches(acceptances: AdminQuestAcceptance[], questCode: string, status: AdminQuestAcceptanceStatus | "" = "") {
   if (acceptances.some((acceptance) => acceptance.code !== questCode)) {
     throw new Error("Quest acceptance list contained another Quest code.");
+  }
+  if (status && acceptances.some((acceptance) => acceptance.status !== status)) {
+    throw new Error("Quest acceptance list contained another Acceptance status.");
   }
 }
 
@@ -85,7 +88,7 @@ export function useQuestRuntimeStatus(enabled: boolean, dataSource: AdminQuestDa
           dataSource.getAcceptances(intent.questCode),
         ]);
         if (nextDefinition.code !== intent.questCode) throw new Error("Quest definition response did not match the requested Quest code.");
-        ensureAcceptanceCodes(acceptanceResponse.acceptances, intent.questCode);
+        ensureAcceptanceListMatches(acceptanceResponse.acceptances, intent.questCode);
         if (current === requestId.current) {
           setDefinition(nextDefinition);
           setAcceptances(acceptanceResponse.acceptances);
@@ -93,7 +96,7 @@ export function useQuestRuntimeStatus(enabled: boolean, dataSource: AdminQuestDa
         }
       } else if (intent.kind === "acceptances") {
         const response = await dataSource.getAcceptances(intent.questCode, intent.status);
-        ensureAcceptanceCodes(response.acceptances, intent.questCode);
+        ensureAcceptanceListMatches(response.acceptances, intent.questCode, intent.status);
         if (current === requestId.current) {
           setAcceptances(response.acceptances);
           setLoadedAt(new Date());

--- a/features/admin/quest/useQuestRuntimeStatus.ts
+++ b/features/admin/quest/useQuestRuntimeStatus.ts
@@ -1,0 +1,175 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { ApiError } from "@/shared/api/client";
+import type { AdminQuestDataSource } from "../api/quest.source";
+import type {
+  AdminQuestAcceptance,
+  AdminQuestAcceptanceStatus,
+  AdminQuestBlueprint,
+  AdminQuestDefinition,
+} from "./model";
+
+type Intent =
+  | { kind: "index" }
+  | { kind: "definition"; questCode: string }
+  | { kind: "acceptances"; questCode: string; status: AdminQuestAcceptanceStatus | "" }
+  | { kind: "acceptance"; questCode: string; acceptanceId: number };
+
+type QuestLoadError = { kind: Intent["kind"]; status: number | null; message: string };
+
+function ensureAcceptanceCodes(acceptances: AdminQuestAcceptance[], questCode: string) {
+  if (acceptances.some((acceptance) => acceptance.code !== questCode)) {
+    throw new Error("Quest acceptance list contained another Quest code.");
+  }
+}
+
+export function useQuestRuntimeStatus(enabled: boolean, dataSource: AdminQuestDataSource) {
+  const [catalog, setCatalog] = useState<AdminQuestBlueprint[]>([]);
+  const [definitions, setDefinitions] = useState<AdminQuestDefinition[]>([]);
+  const [definition, setDefinition] = useState<AdminQuestDefinition | null>(null);
+  const [acceptances, setAcceptances] = useState<AdminQuestAcceptance[]>([]);
+  const [acceptance, setAcceptance] = useState<AdminQuestAcceptance | null>(null);
+  const [selectedCode, setSelectedCode] = useState<string | null>(null);
+  const [statusFilter, setStatusFilter] = useState<AdminQuestAcceptanceStatus | "">("");
+  const [indexLoaded, setIndexLoaded] = useState(false);
+  const [loading, setLoading] = useState<Intent["kind"] | null>(null);
+  const [error, setError] = useState<QuestLoadError | null>(null);
+  const [loadedAt, setLoadedAt] = useState<Date | null>(null);
+  const requestId = useRef(0);
+  const lastIntent = useRef<Intent | null>(null);
+
+  const run = useCallback(async (intent: Intent) => {
+    const current = ++requestId.current;
+    lastIntent.current = intent;
+    setLoading(intent.kind);
+    setError(null);
+
+    if (intent.kind === "index") {
+      setCatalog([]);
+      setDefinitions([]);
+      setDefinition(null);
+      setAcceptances([]);
+      setAcceptance(null);
+      setSelectedCode(null);
+      setStatusFilter("");
+      setIndexLoaded(false);
+      setLoadedAt(null);
+    } else if (intent.kind === "definition") {
+      setSelectedCode(intent.questCode);
+      setStatusFilter("");
+      setDefinition(null);
+      setAcceptances([]);
+      setAcceptance(null);
+    } else if (intent.kind === "acceptances") {
+      setStatusFilter(intent.status);
+      setAcceptances([]);
+      setAcceptance(null);
+    } else {
+      setAcceptance(null);
+    }
+
+    try {
+      if (intent.kind === "index") {
+        const [catalogResponse, definitionsResponse] = await Promise.all([dataSource.getCatalog(), dataSource.getDefinitions()]);
+        if (current === requestId.current) {
+          setCatalog(catalogResponse.blueprints);
+          setDefinitions(definitionsResponse.definitions);
+          setIndexLoaded(true);
+          setLoadedAt(new Date());
+        }
+      } else if (intent.kind === "definition") {
+        const [nextDefinition, acceptanceResponse] = await Promise.all([
+          dataSource.getDefinition(intent.questCode),
+          dataSource.getAcceptances(intent.questCode),
+        ]);
+        if (nextDefinition.code !== intent.questCode) throw new Error("Quest definition response did not match the requested Quest code.");
+        ensureAcceptanceCodes(acceptanceResponse.acceptances, intent.questCode);
+        if (current === requestId.current) {
+          setDefinition(nextDefinition);
+          setAcceptances(acceptanceResponse.acceptances);
+          setLoadedAt(new Date());
+        }
+      } else if (intent.kind === "acceptances") {
+        const response = await dataSource.getAcceptances(intent.questCode, intent.status);
+        ensureAcceptanceCodes(response.acceptances, intent.questCode);
+        if (current === requestId.current) {
+          setAcceptances(response.acceptances);
+          setLoadedAt(new Date());
+        }
+      } else {
+        const nextAcceptance = await dataSource.getAcceptance(intent.acceptanceId);
+        if (nextAcceptance.id !== intent.acceptanceId) throw new Error("Quest acceptance response did not match the requested Acceptance ID.");
+        if (nextAcceptance.code !== intent.questCode) throw new Error("Quest acceptance response did not match the selected Quest code.");
+        if (current === requestId.current) {
+          setAcceptance(nextAcceptance);
+          setLoadedAt(new Date());
+        }
+      }
+    } catch (caught) {
+      if (current === requestId.current) {
+        const status = caught instanceof ApiError ? caught.status : null;
+        if (status === 401 || status === 403) {
+          setCatalog([]);
+          setDefinitions([]);
+          setDefinition(null);
+          setAcceptances([]);
+          setAcceptance(null);
+          setSelectedCode(null);
+          setIndexLoaded(false);
+          setLoadedAt(null);
+        }
+        setError({ kind: intent.kind, status, message: caught instanceof Error ? caught.message : "Unable to load Quest runtime status." });
+      }
+    } finally {
+      if (current === requestId.current) setLoading(null);
+    }
+  }, [dataSource]);
+
+  useEffect(() => {
+    if (enabled) void run({ kind: "index" });
+    else {
+      requestId.current += 1;
+      lastIntent.current = null;
+      setCatalog([]);
+      setDefinitions([]);
+      setDefinition(null);
+      setAcceptances([]);
+      setAcceptance(null);
+      setSelectedCode(null);
+      setStatusFilter("");
+      setIndexLoaded(false);
+      setLoading(null);
+      setError(null);
+      setLoadedAt(null);
+    }
+    return () => { requestId.current += 1; };
+  }, [enabled, run]);
+
+  return {
+    catalog,
+    definitions,
+    definition,
+    acceptances,
+    acceptance,
+    selectedCode,
+    statusFilter,
+    indexLoaded,
+    loading,
+    error,
+    loadedAt,
+    selectDefinition: (questCode: string) => run({ kind: "definition", questCode }),
+    filterAcceptances: (status: AdminQuestAcceptanceStatus | "") => selectedCode
+      ? run({ kind: "acceptances", questCode: selectedCode, status })
+      : Promise.resolve(),
+    openAcceptance: (acceptanceId: number) => selectedCode
+      ? run({ kind: "acceptance", questCode: selectedCode, acceptanceId })
+      : Promise.resolve(),
+    retry: () => lastIntent.current ? run(lastIntent.current) : Promise.resolve(),
+    closeAcceptance: () => {
+      setAcceptance(null);
+      setError((current) => current?.kind === "acceptance" ? null : current);
+    },
+  };
+}

--- a/features/admin/shell/AdminShell.test.tsx
+++ b/features/admin/shell/AdminShell.test.tsx
@@ -6,12 +6,16 @@ import { AdminShell } from "./AdminShell";
 const apiSource = { mode: "api", badge: "API", label: "/admin/v1", eventLabel: "/admin/v1/audit-events" } as const;
 const mockSource = { mode: "mock", badge: "MOCK DATA", label: "Local Admin Mock", eventLabel: "Local Admin Mock" } as const;
 
-describe("Admin Phase A2 shell", () => {
-  it("keeps Player Lookup active while Admin Audit remains supported", () => {
-    render(<AdminShell operator="operator@lag" player={<div>Player Screen</div>} audit={<div>Audit Screen</div>} source={apiSource} />);
+describe("Admin Phase A3 shell", () => {
+  it("exposes only Quest Runtime Status under Content while Player and Audit remain supported", () => {
+    render(<AdminShell operator="operator@lag" quest={<div>Quest Screen</div>} player={<div>Player Screen</div>} audit={<div>Audit Screen</div>} source={apiSource} />);
 
     expect(screen.getByRole("navigation", { name: "Admin operations" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Players, SUPPORTED" })).toHaveAttribute("aria-current", "page");
+    expect(screen.getByRole("button", { name: "Content, SUPPORTED" })).toHaveAttribute("aria-current", "page");
+    expect(screen.getByText("Quest Runtime Status")).toBeInTheDocument();
+    expect(screen.getByText("Quest Screen")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Players, SUPPORTED" }));
     expect(screen.getByText("Player Lookup")).toBeInTheDocument();
     expect(screen.getByText("Player Screen")).toBeInTheDocument();
 
@@ -22,7 +26,7 @@ describe("Admin Phase A2 shell", () => {
   });
 
   it("keeps unrelated capability boundaries without unsupported commands", () => {
-    render(<AdminShell operator="operator@lag" player={<div>Player Screen</div>} audit={<div>Audit Screen</div>} source={apiSource} />);
+    render(<AdminShell operator="operator@lag" quest={<div>Quest Screen</div>} player={<div>Player Screen</div>} audit={<div>Audit Screen</div>} source={apiSource} />);
 
     fireEvent.click(screen.getByRole("button", { name: "Dashboard, DEFERRED" }));
     expect(screen.getByRole("heading", { name: "Dashboard" })).toBeInTheDocument();
@@ -37,14 +41,14 @@ describe("Admin Phase A2 shell", () => {
     [apiSource, "API", "/admin/v1", "Session", "Authority enforced by server"],
     [mockSource, "MOCK DATA", "Local Admin Mock", "Mock session", "Server Admin authority not evaluated"],
   ] as const)("shows the %s source without changing the Admin shell anatomy", (source, badge, label, session, authority) => {
-    render(<AdminShell operator="operator@lag" player={<div>Player Screen</div>} audit={<div>Audit Screen</div>} source={source} />);
+    render(<AdminShell operator="operator@lag" quest={<div>Quest Screen</div>} player={<div>Player Screen</div>} audit={<div>Audit Screen</div>} source={source} />);
 
     expect(screen.getByText(badge)).toBeInTheDocument();
     expect(screen.getByText(label)).toBeInTheDocument();
     expect(screen.getByText(session)).toBeInTheDocument();
     expect(screen.getByText(authority)).toBeInTheDocument();
     if (source.mode === "mock") expect(screen.queryByText("Authority enforced by server")).not.toBeInTheDocument();
-    expect(screen.getByText("Player Screen")).toBeInTheDocument();
+    expect(screen.getByText("Quest Screen")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /grant|revoke|adjust|delete|override|deliver/i })).not.toBeInTheDocument();
   });
 });

--- a/features/admin/shell/AdminShell.tsx
+++ b/features/admin/shell/AdminShell.tsx
@@ -12,8 +12,8 @@ function CapabilityBadge({ state, compact = false }: { state: AdminCapabilitySta
   return <span className={styles.badge} data-state={state} data-compact={compact || undefined}>{marker} {state}</span>;
 }
 
-export function AdminShell({ operator, audit, player, source }: { operator: string; audit: React.ReactNode; player: React.ReactNode; source: AdminDataSourceDescriptor }) {
-  const [activeArea, setActiveArea] = useState<AdminAreaId>("players");
+export function AdminShell({ operator, audit, player, quest, source }: { operator: string; audit: React.ReactNode; player: React.ReactNode; quest: React.ReactNode; source: AdminDataSourceDescriptor }) {
+  const [activeArea, setActiveArea] = useState<AdminAreaId>("content");
   const active = ADMIN_AREAS.find((area) => area.id === activeArea)!;
 
   return (
@@ -42,9 +42,9 @@ export function AdminShell({ operator, audit, player, source }: { operator: stri
                 <span className={styles.navLabel}>{area.label}</span>
                 {area.id !== "system" ? <span className={styles.navBadge}><CapabilityBadge state={area.state} compact /></span> : null}
               </button>
-              {(area.id === "system" || area.id === "players") && activeArea === area.id ? (
+              {(area.id === "system" || area.id === "players" || area.id === "content") && activeArea === area.id ? (
                 <div className={styles.subnav} aria-label={`${area.label} capabilities`}>
-                  <span>{area.id === "system" ? "Admin Audit" : "Player Lookup"}</span>
+                  <span>{area.id === "system" ? "Admin Audit" : area.id === "players" ? "Player Lookup" : "Quest Runtime Status"}</span>
                   <CapabilityBadge state={area.id === "system" ? "SUPPORTED" : "READ_ONLY"} compact />
                 </div>
               ) : null}
@@ -58,7 +58,7 @@ export function AdminShell({ operator, audit, player, source }: { operator: stri
       </aside>
 
       <main className={styles.workspace}>
-        {activeArea === "system" ? audit : activeArea === "players" ? player : (
+        {activeArea === "system" ? audit : activeArea === "players" ? player : activeArea === "content" ? quest : (
           <section className={styles.capabilityPanel} aria-labelledby="admin-capability-title">
             <div className={styles.capabilityHeader}>
               <div>


### PR DESCRIPTION
## Purpose

Add the next Admin Phase A read-only workflow: Quest Runtime Status backed only by proven canonical Admin Quest reads.

Closes #80

## Delivered

- read-only Quest catalog/definition inspection
- read-only Quest acceptance status inspection
- canonical Quest Admin API adapters
- matching local Mock Quest data source
- Definition / Acceptance model separation
- exact response-identity protection
- loading / empty / error / retry / 401 / 403 states
- Content navigation support only for the Quest Runtime Status slice
- Warm Beige-first Admin Quest visual implementation

## Canonical Reads

The real source uses only:

```text
GET /admin/v1/quests/catalog
GET /admin/v1/quests/definitions
GET /admin/v1/quests/definitions/{questCode}
GET /admin/v1/quests/{questCode}/acceptances?status={status}
GET /admin/v1/quests/acceptances/{acceptanceId}
```

No `/api/v1/admin/**` compatibility path is introduced.

## Domain Semantics

The screen keeps:

```text
Quest Definition != Quest Acceptance
QuestRoute != Quest folder
Quest completion != automatic Route advance
```

No Route progression is derived from runtime Quest completion.

## Data Sources

The screen preserves:

```text
NEXT_PUBLIC_ADMIN_DATA_SOURCE=api|mock
```

API and Mock share one read-only Quest data-source contract.

API failures never automatically fall back to Mock.

## Capability Boundary

This PR does not enable:

- progress adjustment
- status override
- reward repair
- Route advance
- QuestRoute publish/write
- Quest definition create/update UI

## Validation

Validation is focused on canonical Quest reads, API/Mock parity, exact response identity, runtime states, shell integration, and one final production build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a read-only **Quest Runtime Status** section to the admin area.
  - Browse quest definitions and inspect player acceptance details.
  - Filter acceptances by status and refresh or retry data loading.
  - Added loading, empty, error, authentication, and authorization states.
  - Quest data can be loaded from the configured service or local demo data.
- **Style**
  - Added responsive layouts, status badges, detail panels, and improved keyboard focus behavior for quest administration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->