### PR TITLE
[Admin] Add Quest Acceptance override review workflow

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -23,7 +23,7 @@ export default function AdminPage() {
       source={adminAuditDataSource.descriptor}
       audit={<AuditExplorer access={access} onLogin={() => router.push("/login")} dataSource={adminAuditDataSource} />}
       player={<PlayerLookup access={access} onLogin={() => router.push("/login")} dataSource={adminPlayerDataSource} />}
-      quest={(openAudit) => <QuestRuntimeStatus access={access} onLogin={() => router.push("/login")} onOpenAudit={openAudit} dataSource={adminQuestDataSource} commandSource={adminQuestCommandSource} />}
+      quest={(openAudit) => <QuestRuntimeStatus access={access} onLogin={() => router.push("/login")} onOpenAudit={openAudit} dataSource={adminQuestDataSource} commandSource={adminQuestCommandSource} auditSource={adminAuditDataSource} />}
     />
   );
 }

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -6,6 +6,7 @@ import { AuditExplorer } from "@/features/admin/audit/AuditExplorer";
 import { adminAuditDataSource } from "@/features/admin/api/audit.source";
 import { adminPlayerDataSource } from "@/features/admin/api/player.source";
 import { adminQuestDataSource } from "@/features/admin/api/quest.source";
+import { adminQuestCommandSource } from "@/features/admin/api/quest.command";
 import { PlayerLookup } from "@/features/admin/player/PlayerLookup";
 import { QuestRuntimeStatus } from "@/features/admin/quest/QuestRuntimeStatus";
 import { AdminShell } from "@/features/admin/shell/AdminShell";
@@ -22,7 +23,7 @@ export default function AdminPage() {
       source={adminAuditDataSource.descriptor}
       audit={<AuditExplorer access={access} onLogin={() => router.push("/login")} dataSource={adminAuditDataSource} />}
       player={<PlayerLookup access={access} onLogin={() => router.push("/login")} dataSource={adminPlayerDataSource} />}
-      quest={<QuestRuntimeStatus access={access} onLogin={() => router.push("/login")} dataSource={adminQuestDataSource} />}
+      quest={(openAudit) => <QuestRuntimeStatus access={access} onLogin={() => router.push("/login")} onOpenAudit={openAudit} dataSource={adminQuestDataSource} commandSource={adminQuestCommandSource} />}
     />
   );
 }

--- a/features/admin/admin.module.css
+++ b/features/admin/admin.module.css
@@ -1046,6 +1046,196 @@
   background: color-mix(in srgb, var(--admin-failed) 8%, var(--admin-panel));
 }
 
+.questOverrideForm,
+.questOverrideReview,
+.questOverrideState,
+.questOverrideUnavailable {
+  display: grid;
+  gap: 10px;
+  margin-top: 16px;
+  padding: 12px;
+  color: var(--admin-text-2);
+  background: color-mix(in srgb, var(--admin-workspace) 82%, var(--admin-panel));
+  border: 1px solid var(--admin-border);
+  border-radius: 8px;
+}
+
+.questOverrideForm h3,
+.questOverrideReview h3,
+.questOverrideState h3,
+.questOverrideUnavailable h3 {
+  margin: 0;
+  color: var(--admin-text);
+  font-size: 14px;
+}
+
+.questOverrideForm p,
+.questOverrideReview p,
+.questOverrideState p,
+.questOverrideUnavailable p {
+  margin: 0;
+  line-height: 1.45;
+}
+
+.questOverrideForm label,
+.questLevel3Warning label {
+  display: grid;
+  gap: 5px;
+  color: var(--admin-text-2);
+  font-size: 10px;
+  font-weight: 750;
+}
+
+.questOverrideForm input,
+.questOverrideForm select,
+.questLevel3Warning input[type="text"],
+.questLevel3Warning input:not([type]) {
+  width: 100%;
+  min-width: 0;
+  padding: 8px 10px;
+  color: var(--admin-text);
+  background: var(--admin-panel);
+  border: 1px solid var(--admin-border);
+  border-radius: 6px;
+  font: inherit;
+}
+
+.questOverrideForm input,
+.questOverrideForm select,
+.questLevel3Warning input:not([type]) {
+  min-height: 36px;
+}
+
+.questRiskPreview,
+.questLevel2Note {
+  padding: 8px 9px;
+  border-left: 2px solid var(--admin-focus);
+  font-size: 10px;
+}
+
+.questOverrideReview {
+  border-color: var(--admin-focus);
+}
+
+.questOverrideReview[data-risk="L3"] {
+  border-color: var(--admin-failed);
+}
+
+.questOverrideReview[data-risk="L3"] .primaryButton {
+  color: #fff;
+  background: var(--admin-failed);
+  border-color: var(--admin-failed);
+}
+
+.questOverrideReviewHeader {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.questOverrideReviewHeader > span {
+  display: grid;
+  width: 38px;
+  height: 38px;
+  flex: 0 0 38px;
+  place-items: center;
+  color: var(--admin-panel);
+  background: var(--admin-focus);
+  clip-path: polygon(30% 0, 70% 0, 100% 30%, 100% 70%, 70% 100%, 30% 100%, 0 70%, 0 30%);
+  font-weight: 850;
+}
+
+.questOverrideReview[data-risk="L3"] .questOverrideReviewHeader > span {
+  background: var(--admin-failed);
+}
+
+.questOverrideSummary,
+.questOperationReceipt {
+  display: grid;
+  gap: 0;
+  margin: 0;
+  border: 1px solid var(--admin-divider);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.questOverrideSummary > div,
+.questOperationReceipt > div {
+  display: grid;
+  grid-template-columns: 105px minmax(0, 1fr);
+  gap: 8px;
+  padding: 8px;
+  border-bottom: 1px solid var(--admin-divider);
+}
+
+.questOverrideSummary > div:last-child,
+.questOperationReceipt > div:last-child {
+  border-bottom: 0;
+}
+
+.questOverrideSummary dt,
+.questOperationReceipt dt {
+  color: var(--admin-muted);
+  font-size: 9px;
+  font-weight: 750;
+  text-transform: uppercase;
+}
+
+.questOverrideSummary dd,
+.questOperationReceipt dd {
+  min-width: 0;
+  margin: 0;
+  color: var(--admin-text);
+  overflow-wrap: anywhere;
+}
+
+.questOverrideSummary code,
+.questOperationReceipt code {
+  color: var(--admin-id);
+  user-select: text;
+}
+
+.questLevel3Warning {
+  display: grid;
+  gap: 8px;
+  padding: 10px;
+  color: var(--admin-text-2);
+  background: color-mix(in srgb, var(--admin-failed) 7%, var(--admin-panel));
+  border-left: 3px solid var(--admin-failed);
+}
+
+.questConfirmCheck {
+  grid-template-columns: auto minmax(0, 1fr) !important;
+  align-items: start;
+}
+
+.questConfirmCheck input {
+  width: 16px;
+  min-height: 16px;
+  margin: 1px 0 0;
+}
+
+.questOverrideActions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.questOverrideError {
+  color: var(--admin-failed);
+  font-size: 10px;
+  font-weight: 700;
+}
+
+.questOverrideState[data-state="success"] {
+  border-color: var(--admin-supported);
+}
+
+.questOverrideState[data-state="unknown"],
+.questOverrideState[data-state="conflict"] {
+  border-color: var(--admin-gated);
+}
+
 @media (max-width: 1179px) {
   .root {
     grid-template:
@@ -1190,6 +1380,15 @@
   }
 
   .questAcceptanceHeader label {
+    width: 100%;
+  }
+
+  .questOverrideActions {
+    flex-direction: column-reverse;
+  }
+
+  .questOverrideActions button,
+  .questOverrideForm > button {
     width: 100%;
   }
 

--- a/features/admin/admin.module.css
+++ b/features/admin/admin.module.css
@@ -1078,7 +1078,7 @@
 }
 
 .questOverrideForm label,
-.questLevel3Warning label {
+.questLevel3Confirmation label {
   display: grid;
   gap: 5px;
   color: var(--admin-text-2);
@@ -1088,8 +1088,7 @@
 
 .questOverrideForm input,
 .questOverrideForm select,
-.questLevel3Warning input[type="text"],
-.questLevel3Warning input:not([type]) {
+.questLevel3Confirmation input:not([type]) {
   width: 100%;
   min-width: 0;
   padding: 8px 10px;
@@ -1102,7 +1101,7 @@
 
 .questOverrideForm input,
 .questOverrideForm select,
-.questLevel3Warning input:not([type]) {
+.questLevel3Confirmation input:not([type]) {
   min-height: 36px;
 }
 
@@ -1115,16 +1114,6 @@
 
 .questOverrideReview {
   border-color: var(--admin-focus);
-}
-
-.questOverrideReview[data-risk="L3"] {
-  border-color: var(--admin-failed);
-}
-
-.questOverrideReview[data-risk="L3"] .primaryButton {
-  color: #fff;
-  background: var(--admin-failed);
-  border-color: var(--admin-failed);
 }
 
 .questOverrideReviewHeader {
@@ -1143,10 +1132,6 @@
   background: var(--admin-focus);
   clip-path: polygon(30% 0, 70% 0, 100% 30%, 100% 70%, 70% 100%, 30% 100%, 0 70%, 0 30%);
   font-weight: 850;
-}
-
-.questOverrideReview[data-risk="L3"] .questOverrideReviewHeader > span {
-  background: var(--admin-failed);
 }
 
 .questOverrideSummary,
@@ -1195,11 +1180,131 @@
   user-select: text;
 }
 
-.questLevel3Warning {
-  display: grid;
-  gap: 8px;
-  padding: 10px;
+.questLevel3Dialog {
+  width: min(900px, calc(100vw - 48px));
+  max-width: 900px;
+  max-height: calc(100svh - 48px);
+  margin: auto;
+  padding: 24px;
   color: var(--admin-text-2);
+  background: var(--admin-panel);
+  border: 1px solid var(--admin-failed);
+  border-radius: 12px;
+  overflow: auto;
+}
+
+.questLevel3Dialog::backdrop {
+  background: color-mix(in srgb, var(--admin-text) 48%, transparent);
+  backdrop-filter: blur(2px);
+}
+
+.questLevel3Dialog .primaryButton {
+  color: #fff;
+  background: var(--admin-failed);
+  border-color: var(--admin-failed);
+}
+
+.questLevel3Header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 24px;
+}
+
+.questLevel3Header > span {
+  display: grid;
+  width: 42px;
+  height: 42px;
+  flex: 0 0 42px;
+  place-items: center;
+  color: #fff;
+  background: var(--admin-failed);
+  clip-path: polygon(30% 0, 70% 0, 100% 30%, 100% 70%, 70% 100%, 30% 100%, 0 70%, 0 30%);
+  font-weight: 850;
+}
+
+.questLevel3Header h2 {
+  margin: 0;
+  color: var(--admin-text);
+  font-size: 22px;
+}
+
+.questLevel3Section {
+  display: grid;
+  gap: 10px;
+  margin-bottom: 20px;
+}
+
+.questLevel3SectionHeader {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  padding-bottom: 7px;
+  border-bottom: 1px solid var(--admin-divider);
+}
+
+.questLevel3SectionHeader h3 {
+  margin: 0;
+  color: var(--admin-text);
+  font-size: 14px;
+}
+
+.questLevel3SectionHeader span {
+  color: var(--admin-muted);
+  font-size: 9px;
+}
+
+.questLevel3Identity,
+.questLevel3Safeguards {
+  display: grid;
+  gap: 0;
+  margin: 0;
+}
+
+.questLevel3Identity > div,
+.questLevel3Safeguards > div {
+  display: grid;
+  grid-template-columns: 180px minmax(0, 1fr);
+  gap: 12px;
+  padding: 8px 0;
+}
+
+.questLevel3Identity dt,
+.questLevel3Safeguards dt {
+  color: var(--admin-muted);
+  font-size: 10px;
+  font-weight: 750;
+}
+
+.questLevel3Identity dd,
+.questLevel3Safeguards dd {
+  min-width: 0;
+  margin: 0;
+  color: var(--admin-text);
+  overflow-wrap: anywhere;
+}
+
+.questLevel3Identity code {
+  color: var(--admin-id);
+  user-select: text;
+}
+
+.questLevel3Reason {
+  margin: 0;
+  padding: 11px 12px;
+  color: var(--admin-text);
+  background: var(--admin-workspace);
+  border: 1px solid var(--admin-border);
+  border-radius: 6px;
+  overflow-wrap: anywhere;
+}
+
+.questLevel3Confirmation {
+  display: grid;
+  gap: 10px;
+  margin-bottom: 16px;
+  padding: 12px;
   background: color-mix(in srgb, var(--admin-failed) 7%, var(--admin-panel));
   border-left: 3px solid var(--admin-failed);
 }
@@ -1221,6 +1326,13 @@
   gap: 8px;
 }
 
+.questLevel3FocusNote {
+  margin: 8px 0 0;
+  color: var(--admin-muted);
+  font-size: 9px;
+  text-align: right;
+}
+
 .questOverrideError {
   color: var(--admin-failed);
   font-size: 10px;
@@ -1237,6 +1349,14 @@
 }
 
 @media (max-width: 1179px) {
+  .questLevel3Dialog {
+    width: calc(100vw - 32px);
+    max-width: none;
+    height: calc(100svh - 32px);
+    max-height: none;
+    padding: 20px;
+  }
+
   .root {
     grid-template:
       "topbar topbar" 57px
@@ -1390,6 +1510,12 @@
   .questOverrideActions button,
   .questOverrideForm > button {
     width: 100%;
+  }
+
+  .questLevel3Identity > div,
+  .questLevel3Safeguards > div {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 4px;
   }
 
   .filterActions {

--- a/features/admin/api/quest.command.test.ts
+++ b/features/admin/api/quest.command.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import * as client from "@/shared/api/client";
 import {
+  type AdminQuestStatusCommand,
   adjustAdminQuestAcceptanceProgress,
   changeAdminQuestAcceptanceStatus,
   getAdminQuestCommandSource,
@@ -38,7 +39,7 @@ describe("Admin Quest command adapter", () => {
   });
 
   it("rejects legacy and unsafe values before transport", () => {
-    expect(() => changeAdminQuestAcceptanceStatus(9001, { status: "DONE" as "COMPLETED", reason: "Legacy" }, { idempotencyKey: "key" })).toThrow("allowed Acceptance command target");
+    expect(() => changeAdminQuestAcceptanceStatus(9001, { status: "DONE" as unknown as AdminQuestStatusCommand, reason: "Legacy" }, { idempotencyKey: "key" })).toThrow("allowed Acceptance command target");
     expect(() => adjustAdminQuestAcceptanceProgress(9001, { delta: 0.5, reason: "Fraction" }, { idempotencyKey: "key" })).toThrow("non-negative integer");
     expect(() => validateAdminQuestOverrideReason("")).toThrow("visible, single-line");
     expect(() => validateAdminQuestOverrideReason("line one\nline two")).toThrow("visible, single-line");

--- a/features/admin/api/quest.command.test.ts
+++ b/features/admin/api/quest.command.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import * as client from "@/shared/api/client";
+import {
+  adjustAdminQuestAcceptanceProgress,
+  changeAdminQuestAcceptanceStatus,
+  getAdminQuestCommandSource,
+  validateAdminQuestOverrideReason,
+} from "./quest.command";
+
+vi.mock("@/shared/api/client", () => ({ apiPatch: vi.fn() }));
+
+describe("Admin Quest command adapter", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("sends the exact progress and status contracts without automatic retry", async () => {
+    vi.mocked(client.apiPatch).mockResolvedValue({});
+
+    await adjustAdminQuestAcceptanceProgress(9001, { delta: 2, reason: "Support case 42" }, {
+      idempotencyKey: "quest-override:key-1",
+      correlationId: "quest-operation:correlation-1",
+    });
+    await changeAdminQuestAcceptanceStatus(9001, { status: "COMPLETED", reason: "Verified target state" }, {
+      idempotencyKey: "quest-override:key-2",
+    });
+
+    expect(client.apiPatch).toHaveBeenNthCalledWith(1,
+      "/admin/v1/quests/acceptances/9001/progress",
+      { delta: 2, reason: "Support case 42" },
+      { headers: { "Idempotency-Key": "quest-override:key-1", "X-Correlation-Id": "quest-operation:correlation-1" }, retry: false },
+    );
+    expect(client.apiPatch).toHaveBeenNthCalledWith(2,
+      "/admin/v1/quests/acceptances/9001/status",
+      { status: "COMPLETED", reason: "Verified target state" },
+      { headers: { "Idempotency-Key": "quest-override:key-2" }, retry: false },
+    );
+    expect(client.apiPatch).not.toHaveBeenCalledWith(expect.stringContaining("/api/v1/admin/"), expect.anything(), expect.anything());
+  });
+
+  it("rejects legacy and unsafe values before transport", () => {
+    expect(() => changeAdminQuestAcceptanceStatus(9001, { status: "DONE" as "COMPLETED", reason: "Legacy" }, { idempotencyKey: "key" })).toThrow("allowed Acceptance command target");
+    expect(() => adjustAdminQuestAcceptanceProgress(9001, { delta: 0.5, reason: "Fraction" }, { idempotencyKey: "key" })).toThrow("non-negative integer");
+    expect(() => validateAdminQuestOverrideReason("")).toThrow("visible, single-line");
+    expect(() => validateAdminQuestOverrideReason("line one\nline two")).toThrow("visible, single-line");
+    expect(() => validateAdminQuestOverrideReason("\u200b")).toThrow("visible, single-line");
+    expect(client.apiPatch).not.toHaveBeenCalled();
+  });
+
+  it("keeps Mock reads available without exposing a fake command", () => {
+    expect(getAdminQuestCommandSource("mock")).toEqual({ available: false });
+    expect(getAdminQuestCommandSource("api")).toMatchObject({ available: true });
+    expect(getAdminQuestCommandSource("invalid")).toMatchObject({ available: true });
+  });
+});

--- a/features/admin/api/quest.command.ts
+++ b/features/admin/api/quest.command.ts
@@ -1,0 +1,96 @@
+import { apiPatch } from "@/shared/api/client";
+import type { AdminQuestAcceptance, AdminQuestAcceptanceStatus } from "../quest/model";
+import { requirePositiveAdminAcceptanceId } from "./quest.query";
+import { resolveAdminDataSourceMode } from "./source";
+
+const SAFE_HEADER_VALUE = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/;
+const UNSAFE_REASON_CHARACTER = /[\p{Cc}\p{Cf}\p{Zl}\p{Zp}]/u;
+const VISIBLE_REASON_CHARACTER = /[^\p{Cf}\p{Zs}]/u;
+
+export const ADMIN_QUEST_STATUS_COMMANDS = ["GOAL_REACHED", "COMPLETED", "CANCELED"] as const;
+export type AdminQuestStatusCommand = Extract<AdminQuestAcceptanceStatus, typeof ADMIN_QUEST_STATUS_COMMANDS[number]>;
+
+export type AdminQuestCommandMetadata = {
+  idempotencyKey: string;
+  correlationId?: string;
+};
+
+export type AdminQuestProgressCommand = {
+  delta: number;
+  reason: string;
+};
+
+export type AdminQuestStatusCommandBody = {
+  status: AdminQuestStatusCommand;
+  reason: string;
+};
+
+function validateHeaderValue(value: string, name: string, maxLength: number) {
+  if (value.length > maxLength || !SAFE_HEADER_VALUE.test(value)) {
+    throw new RangeError(`${name} must use the backend-safe identifier format.`);
+  }
+  return value;
+}
+
+export function validateAdminQuestOverrideReason(reason: string) {
+  if (reason.length < 1 || reason.length > 512 || UNSAFE_REASON_CHARACTER.test(reason) || !VISIBLE_REASON_CHARACTER.test(reason)) {
+    throw new RangeError("Reason must be 1–512 visible, single-line characters without control or formatting characters.");
+  }
+  return reason.trim();
+}
+
+function commandOptions({ idempotencyKey, correlationId }: AdminQuestCommandMetadata) {
+  const headers: Record<string, string> = {
+    "Idempotency-Key": validateHeaderValue(idempotencyKey, "Idempotency-Key", 128),
+  };
+  if (correlationId) headers["X-Correlation-Id"] = validateHeaderValue(correlationId, "X-Correlation-Id", 100);
+  return { headers, retry: false } as const;
+}
+
+export function adjustAdminQuestAcceptanceProgress(
+  acceptanceId: number,
+  body: AdminQuestProgressCommand,
+  metadata: AdminQuestCommandMetadata,
+): Promise<AdminQuestAcceptance> {
+  if (!Number.isInteger(body.delta) || body.delta < 0) throw new RangeError("Progress delta must be a non-negative integer.");
+  return apiPatch(
+    `/admin/v1/quests/acceptances/${requirePositiveAdminAcceptanceId(acceptanceId)}/progress`,
+    { delta: body.delta, reason: validateAdminQuestOverrideReason(body.reason) },
+    commandOptions(metadata),
+  );
+}
+
+export function changeAdminQuestAcceptanceStatus(
+  acceptanceId: number,
+  body: AdminQuestStatusCommandBody,
+  metadata: AdminQuestCommandMetadata,
+): Promise<AdminQuestAcceptance> {
+  if (!ADMIN_QUEST_STATUS_COMMANDS.includes(body.status)) throw new RangeError("Status must be an allowed Acceptance command target.");
+  return apiPatch(
+    `/admin/v1/quests/acceptances/${requirePositiveAdminAcceptanceId(acceptanceId)}/status`,
+    { status: body.status, reason: validateAdminQuestOverrideReason(body.reason) },
+    commandOptions(metadata),
+  );
+}
+
+export type AdminQuestCommandSource =
+  | {
+    available: true;
+    adjustProgress: typeof adjustAdminQuestAcceptanceProgress;
+    changeStatus: typeof changeAdminQuestAcceptanceStatus;
+  }
+  | { available: false };
+
+const API_COMMAND_SOURCE: AdminQuestCommandSource = {
+  available: true,
+  adjustProgress: adjustAdminQuestAcceptanceProgress,
+  changeStatus: changeAdminQuestAcceptanceStatus,
+};
+
+const UNAVAILABLE_COMMAND_SOURCE: AdminQuestCommandSource = { available: false };
+
+export function getAdminQuestCommandSource(value: unknown): AdminQuestCommandSource {
+  return resolveAdminDataSourceMode(value) === "mock" ? UNAVAILABLE_COMMAND_SOURCE : API_COMMAND_SOURCE;
+}
+
+export const adminQuestCommandSource = getAdminQuestCommandSource(process.env.NEXT_PUBLIC_ADMIN_DATA_SOURCE);

--- a/features/admin/api/quest.query.ts
+++ b/features/admin/api/quest.query.ts
@@ -1,5 +1,5 @@
 import { ADMIN_QUEST_ACCEPTANCE_STATUSES } from "../quest/model";
-import type { AdminQuestAcceptanceStatus } from "../quest/model";
+import type { AdminQuestAcceptance, AdminQuestAcceptanceStatus } from "../quest/model";
 
 export function normalizeAdminQuestCode(questCode: string) {
   const normalized = questCode.trim();
@@ -16,4 +16,14 @@ export function validateAdminQuestAcceptanceStatus(status?: AdminQuestAcceptance
   if (!status) return undefined;
   if (!ADMIN_QUEST_ACCEPTANCE_STATUSES.includes(status)) throw new RangeError("status must be a canonical Acceptance status.");
   return status;
+}
+
+export function assertAdminQuestAcceptanceIdentity(
+  acceptance: AdminQuestAcceptance,
+  acceptanceId: number,
+  questCode: string,
+) {
+  if (acceptance.id !== acceptanceId) throw new Error("Quest acceptance response did not match the requested Acceptance ID.");
+  if (acceptance.code !== questCode) throw new Error("Quest acceptance response did not match the selected Quest code.");
+  return acceptance;
 }

--- a/features/admin/quest/QuestAcceptanceOverride.test.tsx
+++ b/features/admin/quest/QuestAcceptanceOverride.test.tsx
@@ -1,0 +1,118 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AdminQuestCommandSource } from "../api/quest.command";
+import type { AdminQuestDataSource } from "../api/quest.source";
+import type { AdminQuestAcceptance } from "./model";
+import { QuestAcceptanceOverride } from "./QuestAcceptanceOverride";
+
+const acceptance: AdminQuestAcceptance = {
+  id: 9001, questId: 501, playerId: 10218, code: "quest:record:first-trace", title: "First Trace", category: null,
+  targetType: "COUNT", targetValue: 3, progressValue: 1, status: "IN_PROGRESS", completionPolicy: "MANUAL", repeatRule: "ONCE",
+  periodStart: null, periodEnd: null, acceptedAt: "2026-08-24T04:00:00Z", periodKey: null, goalReachedAt: null,
+  completedAt: null, dueAt: null, semanticCategory: "RECORD", progressSource: "RECORD_CREATED", repeatPolicy: "ONCE", roleTemplateCode: null,
+};
+
+function sources() {
+  const commandSource = { available: true, adjustProgress: vi.fn(), changeStatus: vi.fn() } satisfies AdminQuestCommandSource;
+  const readSource = {
+    descriptor: { mode: "api", badge: "API", label: "/admin/v1", questLabel: "/admin/v1/quests" },
+    getAcceptance: vi.fn(),
+  } as unknown as AdminQuestDataSource;
+  return { commandSource, readSource };
+}
+
+describe("Quest Acceptance override UI", () => {
+  beforeEach(() => {
+    let sequence = 0;
+    vi.stubGlobal("crypto", { randomUUID: vi.fn(() => `00000000-0000-4000-8000-${String(++sequence).padStart(12, "0")}`) });
+    vi.stubGlobal("matchMedia", vi.fn());
+    Object.defineProperty(window, "matchMedia", { configurable: true, value: undefined });
+  });
+
+  it("does not optimistically update, then shows a copyable reconciled receipt and Audit navigation", async () => {
+    const { commandSource, readSource } = sources();
+    let resolveCommand!: (value: AdminQuestAcceptance) => void;
+    commandSource.adjustProgress.mockReturnValue(new Promise((resolve) => { resolveCommand = resolve; }));
+    readSource.getAcceptance = vi.fn().mockResolvedValue({ ...acceptance, progressValue: 2 });
+    const onCanonicalAcceptance = vi.fn();
+    const onOpenAudit = vi.fn();
+    render(<QuestAcceptanceOverride acceptance={acceptance} access="ready" readSource={readSource} commandSource={commandSource} onCanonicalAcceptance={onCanonicalAcceptance} onOpenAudit={onOpenAudit} />);
+
+    fireEvent.change(screen.getByLabelText("Progress delta"), { target: { value: "1" } });
+    fireEvent.change(screen.getByLabelText("Reason *"), { target: { value: "Verified support case" } });
+    fireEvent.click(screen.getByRole("button", { name: "Review operation" }));
+    expect(screen.getByRole("heading", { name: "Confirm Acceptance operation" })).toHaveFocus();
+    expect(screen.getByText("Level 2 review")).toBeInTheDocument();
+
+    const confirm = screen.getByRole("button", { name: "Confirm Level 2 operation" });
+    fireEvent.click(confirm);
+    fireEvent.click(confirm);
+    expect(commandSource.adjustProgress).toHaveBeenCalledTimes(1);
+    expect(onCanonicalAcceptance).not.toHaveBeenCalled();
+    resolveCommand(acceptance);
+
+    expect(await screen.findByRole("heading", { name: "Operation completed" })).toBeInTheDocument();
+    expect(onCanonicalAcceptance).toHaveBeenCalledWith({ ...acceptance, progressValue: 2 });
+    expect(screen.getByText(/quest-operation:/).tagName).toBe("CODE");
+    fireEvent.click(screen.getByRole("button", { name: "Open Audit Explorer" }));
+    expect(onOpenAudit).toHaveBeenCalledTimes(1);
+  });
+
+  it("blocks Level 3 confirmation on mobile", async () => {
+    const { commandSource, readSource } = sources();
+    const listeners = new Set<() => void>();
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      value: vi.fn(() => ({
+        matches: true,
+        media: "(max-width: 759px)",
+        onchange: null,
+        addEventListener: (_name: string, listener: () => void) => listeners.add(listener),
+        removeEventListener: (_name: string, listener: () => void) => listeners.delete(listener),
+        addListener: vi.fn(), removeListener: vi.fn(), dispatchEvent: vi.fn(),
+      })),
+    });
+    render(<QuestAcceptanceOverride acceptance={acceptance} access="ready" readSource={readSource} commandSource={commandSource} onCanonicalAcceptance={vi.fn()} />);
+    await waitFor(() => expect(window.matchMedia).toHaveBeenCalled());
+
+    fireEvent.change(screen.getByLabelText("Progress delta"), { target: { value: "2" } });
+    fireEvent.change(screen.getByLabelText("Reason *"), { target: { value: "Verified target evidence" } });
+    fireEvent.click(screen.getByRole("button", { name: "Review operation" }));
+
+    expect(screen.getByText("Level 3 review")).toBeInTheDocument();
+    expect(screen.getByRole("alert")).toHaveTextContent("Level 3 confirmation is unavailable on mobile");
+    expect(screen.getByRole("button", { name: "Confirm Level 3 operation" })).toBeDisabled();
+    expect(commandSource.adjustProgress).not.toHaveBeenCalled();
+  });
+
+  it("requires target re-verification and a second Level 3 confirmation", () => {
+    const { commandSource, readSource } = sources();
+    render(<QuestAcceptanceOverride acceptance={acceptance} access="ready" readSource={readSource} commandSource={commandSource} onCanonicalAcceptance={vi.fn()} />);
+    fireEvent.change(screen.getByLabelText("Progress delta"), { target: { value: "2" } });
+    fireEvent.change(screen.getByLabelText("Reason *"), { target: { value: "Verified target evidence" } });
+    fireEvent.click(screen.getByRole("button", { name: "Review operation" }));
+
+    const confirm = screen.getByRole("button", { name: "Confirm Level 3 operation" });
+    expect(confirm).toBeDisabled();
+    fireEvent.change(screen.getByLabelText("Re-enter Acceptance ID"), { target: { value: "9001" } });
+    expect(confirm).toBeDisabled();
+    fireEvent.click(screen.getByRole("checkbox"));
+    expect(confirm).toBeEnabled();
+    expect(confirm).not.toHaveFocus();
+  });
+
+  it("derives controls from the current canonical status", () => {
+    const { commandSource, readSource } = sources();
+    const { rerender } = render(<QuestAcceptanceOverride acceptance={{ ...acceptance, status: "GOAL_REACHED" }} access="ready" readSource={readSource} commandSource={commandSource} onCanonicalAcceptance={vi.fn()} />);
+
+    expect(screen.queryByLabelText("Progress delta")).not.toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "COMPLETED" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "CANCELED" })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: "IN_PROGRESS" })).not.toBeInTheDocument();
+
+    rerender(<QuestAcceptanceOverride acceptance={{ ...acceptance, status: "COMPLETED" }} access="ready" readSource={readSource} commandSource={commandSource} onCanonicalAcceptance={vi.fn()} />);
+    expect(screen.getByRole("heading", { name: "No available operation" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Review operation" })).not.toBeInTheDocument();
+  });
+});

--- a/features/admin/quest/QuestAcceptanceOverride.test.tsx
+++ b/features/admin/quest/QuestAcceptanceOverride.test.tsx
@@ -1,6 +1,9 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { readFileSync } from "node:fs";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { ApiError } from "@/shared/api/client";
+import type { AdminAuditDataSource } from "../api/audit.source";
 import type { AdminQuestCommandSource } from "../api/quest.command";
 import type { AdminQuestDataSource } from "../api/quest.source";
 import type { AdminQuestAcceptance } from "./model";
@@ -19,7 +22,11 @@ function sources() {
     descriptor: { mode: "api", badge: "API", label: "/admin/v1", questLabel: "/admin/v1/quests" },
     getAcceptance: vi.fn(),
   } as unknown as AdminQuestDataSource;
-  return { commandSource, readSource };
+  const auditSource = {
+    descriptor: { mode: "api", badge: "API", label: "/admin/v1", eventLabel: "/admin/v1/audit-events" },
+    getEvents: vi.fn().mockResolvedValue({ items: [], nextCursor: null }),
+  } satisfies AdminAuditDataSource;
+  return { commandSource, readSource, auditSource };
 }
 
 describe("Quest Acceptance override UI", () => {
@@ -31,13 +38,13 @@ describe("Quest Acceptance override UI", () => {
   });
 
   it("does not optimistically update, then shows a copyable reconciled receipt and Audit navigation", async () => {
-    const { commandSource, readSource } = sources();
+    const { commandSource, readSource, auditSource } = sources();
     let resolveCommand!: (value: AdminQuestAcceptance) => void;
     commandSource.adjustProgress.mockReturnValue(new Promise((resolve) => { resolveCommand = resolve; }));
     readSource.getAcceptance = vi.fn().mockResolvedValue({ ...acceptance, progressValue: 2 });
     const onCanonicalAcceptance = vi.fn();
     const onOpenAudit = vi.fn();
-    render(<QuestAcceptanceOverride acceptance={acceptance} access="ready" readSource={readSource} commandSource={commandSource} onCanonicalAcceptance={onCanonicalAcceptance} onOpenAudit={onOpenAudit} />);
+    render(<QuestAcceptanceOverride acceptance={acceptance} access="ready" readSource={readSource} auditSource={auditSource} commandSource={commandSource} onCanonicalAcceptance={onCanonicalAcceptance} onOpenAudit={onOpenAudit} />);
 
     fireEvent.change(screen.getByLabelText("Progress delta"), { target: { value: "1" } });
     fireEvent.change(screen.getByLabelText("Reason *"), { target: { value: "Verified support case" } });
@@ -60,7 +67,7 @@ describe("Quest Acceptance override UI", () => {
   });
 
   it("blocks Level 3 confirmation on mobile", async () => {
-    const { commandSource, readSource } = sources();
+    const { commandSource, readSource, auditSource } = sources();
     const listeners = new Set<() => void>();
     Object.defineProperty(window, "matchMedia", {
       configurable: true,
@@ -73,26 +80,35 @@ describe("Quest Acceptance override UI", () => {
         addListener: vi.fn(), removeListener: vi.fn(), dispatchEvent: vi.fn(),
       })),
     });
-    render(<QuestAcceptanceOverride acceptance={acceptance} access="ready" readSource={readSource} commandSource={commandSource} onCanonicalAcceptance={vi.fn()} />);
+    render(<QuestAcceptanceOverride acceptance={acceptance} access="ready" readSource={readSource} auditSource={auditSource} commandSource={commandSource} onCanonicalAcceptance={vi.fn()} />);
     await waitFor(() => expect(window.matchMedia).toHaveBeenCalled());
 
     fireEvent.change(screen.getByLabelText("Progress delta"), { target: { value: "2" } });
     fireEvent.change(screen.getByLabelText("Reason *"), { target: { value: "Verified target evidence" } });
     fireEvent.click(screen.getByRole("button", { name: "Review operation" }));
 
-    expect(screen.getByText("Level 3 review")).toBeInTheDocument();
-    expect(screen.getByRole("alert")).toHaveTextContent("Level 3 confirmation is unavailable on mobile");
-    expect(screen.getByRole("button", { name: "Confirm Level 3 operation" })).toBeDisabled();
+    expect(screen.getByRole("heading", { name: "Level 3 unavailable on mobile" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Confirm Level 3 operation" })).not.toBeInTheDocument();
     expect(commandSource.adjustProgress).not.toHaveBeenCalled();
   });
 
-  it("requires target re-verification and a second Level 3 confirmation", () => {
-    const { commandSource, readSource } = sources();
-    render(<QuestAcceptanceOverride acceptance={acceptance} access="ready" readSource={readSource} commandSource={commandSource} onCanonicalAcceptance={vi.fn()} />);
+  it("uses a dedicated desktop L3 surface with the approved safety hierarchy", () => {
+    const { commandSource, readSource, auditSource } = sources();
+    render(<aside data-testid="quick-detail"><QuestAcceptanceOverride acceptance={acceptance} access="ready" readSource={readSource} auditSource={auditSource} commandSource={commandSource} onCanonicalAcceptance={vi.fn()} /></aside>);
     fireEvent.change(screen.getByLabelText("Progress delta"), { target: { value: "2" } });
     fireEvent.change(screen.getByLabelText("Reason *"), { target: { value: "Verified target evidence" } });
     fireEvent.click(screen.getByRole("button", { name: "Review operation" }));
 
+    const dialog = screen.getByRole("dialog");
+    expect(screen.getByTestId("quick-detail")).not.toContainElement(dialog);
+    expect(screen.getByRole("heading", { name: "Review target and consequences before confirmation" })).toHaveFocus();
+    expect(screen.getByRole("heading", { name: "Target identity" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Dependency / blast-radius review" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Mandatory reason" })).toBeInTheDocument();
+    expect(screen.getByText(/additive, non-negative progress only/i)).toBeInTheDocument();
+    expect(screen.getByText(/409 or unknown results require reconciliation/i)).toBeInTheDocument();
+    expect(screen.getByText(/Durable Admin Audit evidence must match/i)).toBeInTheDocument();
+    expect(screen.getByText("Verified target evidence")).toBeInTheDocument();
     const confirm = screen.getByRole("button", { name: "Confirm Level 3 operation" });
     expect(confirm).toBeDisabled();
     fireEvent.change(screen.getByLabelText("Re-enter Acceptance ID"), { target: { value: "9001" } });
@@ -102,16 +118,101 @@ describe("Quest Acceptance override UI", () => {
     expect(confirm).not.toHaveFocus();
   });
 
+  it("resets L3 confirmation after cancel for the same and a different intent", () => {
+    const { commandSource, readSource, auditSource } = sources();
+    render(<QuestAcceptanceOverride acceptance={acceptance} access="ready" readSource={readSource} auditSource={auditSource} commandSource={commandSource} onCanonicalAcceptance={vi.fn()} />);
+    fireEvent.change(screen.getByLabelText("Progress delta"), { target: { value: "2" } });
+    fireEvent.change(screen.getByLabelText("Reason *"), { target: { value: "First review" } });
+    fireEvent.click(screen.getByRole("button", { name: "Review operation" }));
+    fireEvent.change(screen.getByLabelText("Re-enter Acceptance ID"), { target: { value: "9001" } });
+    fireEvent.click(screen.getByRole("checkbox"));
+    expect(screen.getByRole("button", { name: "Confirm Level 3 operation" })).toBeEnabled();
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Review operation" }));
+    expect(screen.getByLabelText("Re-enter Acceptance ID")).toHaveValue("");
+    expect(screen.getByRole("checkbox")).not.toBeChecked();
+    expect(screen.getByRole("button", { name: "Confirm Level 3 operation" })).toBeDisabled();
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    fireEvent.change(screen.getByLabelText("Operation"), { target: { value: "status" } });
+    fireEvent.change(screen.getByLabelText("Target status"), { target: { value: "CANCELED" } });
+    fireEvent.change(screen.getByLabelText("Reason *"), { target: { value: "Different review" } });
+    fireEvent.click(screen.getByRole("button", { name: "Review operation" }));
+    expect(screen.getByLabelText("Re-enter Acceptance ID")).toHaveValue("");
+    expect(screen.getByRole("checkbox")).not.toBeChecked();
+    expect(screen.getByRole("button", { name: "Confirm Level 3 operation" })).toBeDisabled();
+  });
+
+  it("resets L3 confirmation when a rejected submit returns to REVIEWING", async () => {
+    const { commandSource, readSource, auditSource } = sources();
+    commandSource.adjustProgress.mockRejectedValue(new ApiError(422, "INVALID_COMMAND", "Server rejected the operation"));
+    render(<QuestAcceptanceOverride acceptance={acceptance} access="ready" readSource={readSource} auditSource={auditSource} commandSource={commandSource} onCanonicalAcceptance={vi.fn()} />);
+    fireEvent.change(screen.getByLabelText("Progress delta"), { target: { value: "2" } });
+    fireEvent.change(screen.getByLabelText("Reason *"), { target: { value: "Rejected review" } });
+    fireEvent.click(screen.getByRole("button", { name: "Review operation" }));
+    fireEvent.change(screen.getByLabelText("Re-enter Acceptance ID"), { target: { value: "9001" } });
+    fireEvent.click(screen.getByRole("checkbox"));
+    fireEvent.click(screen.getByRole("button", { name: "Confirm Level 3 operation" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Server rejected the operation");
+    expect(screen.getByLabelText("Re-enter Acceptance ID")).toHaveValue("");
+    expect(screen.getByRole("checkbox")).not.toBeChecked();
+    expect(screen.getByRole("button", { name: "Confirm Level 3 operation" })).toBeDisabled();
+  });
+
+  it("uses a full-page L3 surface at tablet width", () => {
+    const css = readFileSync("features/admin/admin.module.css", "utf8");
+    expect(css).toMatch(/@media \(max-width: 1179px\)[\s\S]*?\.questLevel3Dialog\s*\{[^}]*width:\s*calc\(100vw - 32px\)[^}]*height:\s*calc\(100svh - 32px\)/);
+  });
+
+  it("shows ambiguous operation identity without exposing Retry", async () => {
+    const { commandSource, readSource, auditSource } = sources();
+    commandSource.adjustProgress.mockRejectedValue(new Error("Connection lost"));
+    readSource.getAcceptance = vi.fn().mockResolvedValue({ ...acceptance, progressValue: 2 });
+    const onOpenAudit = vi.fn();
+    render(<QuestAcceptanceOverride acceptance={acceptance} access="ready" readSource={readSource} auditSource={auditSource} commandSource={commandSource} onCanonicalAcceptance={vi.fn()} onOpenAudit={onOpenAudit} />);
+    fireEvent.change(screen.getByLabelText("Progress delta"), { target: { value: "1" } });
+    fireEvent.change(screen.getByLabelText("Reason *"), { target: { value: "Ambiguous result" } });
+    fireEvent.click(screen.getByRole("button", { name: "Review operation" }));
+    fireEvent.click(screen.getByRole("button", { name: "Confirm Level 2 operation" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Reconcile current state" }));
+
+    expect(await screen.findByRole("heading", { name: "Current state matches, but this operation is not proven" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /retry/i })).not.toBeInTheDocument();
+    expect(screen.getByText(/quest-operation:/).tagName).toBe("CODE");
+    fireEvent.click(screen.getByRole("button", { name: "Open Audit Explorer" }));
+    expect(onOpenAudit).toHaveBeenCalledTimes(1);
+  });
+
+  it("labels retryable reconciliation and manually retries with the same key", async () => {
+    const { commandSource, readSource, auditSource } = sources();
+    commandSource.adjustProgress.mockRejectedValue(new Error("Connection lost"));
+    readSource.getAcceptance = vi.fn().mockResolvedValue(acceptance);
+    render(<QuestAcceptanceOverride acceptance={acceptance} access="ready" readSource={readSource} auditSource={auditSource} commandSource={commandSource} onCanonicalAcceptance={vi.fn()} />);
+    fireEvent.change(screen.getByLabelText("Progress delta"), { target: { value: "1" } });
+    fireEvent.change(screen.getByLabelText("Reason *"), { target: { value: "Retryable result" } });
+    fireEvent.click(screen.getByRole("button", { name: "Review operation" }));
+    fireEvent.click(screen.getByRole("button", { name: "Confirm Level 2 operation" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Reconcile current state" }));
+
+    expect(await screen.findByRole("heading", { name: "Operation was not reflected" })).toBeInTheDocument();
+    const firstMetadata = commandSource.adjustProgress.mock.calls[0][2];
+    fireEvent.click(screen.getByRole("button", { name: "Retry same operation" }));
+    await waitFor(() => expect(commandSource.adjustProgress).toHaveBeenCalledTimes(2));
+    expect(commandSource.adjustProgress.mock.calls[1][2]).toEqual(firstMetadata);
+  });
+
   it("derives controls from the current canonical status", () => {
-    const { commandSource, readSource } = sources();
-    const { rerender } = render(<QuestAcceptanceOverride acceptance={{ ...acceptance, status: "GOAL_REACHED" }} access="ready" readSource={readSource} commandSource={commandSource} onCanonicalAcceptance={vi.fn()} />);
+    const { commandSource, readSource, auditSource } = sources();
+    const { rerender } = render(<QuestAcceptanceOverride acceptance={{ ...acceptance, status: "GOAL_REACHED" }} access="ready" readSource={readSource} auditSource={auditSource} commandSource={commandSource} onCanonicalAcceptance={vi.fn()} />);
 
     expect(screen.queryByLabelText("Progress delta")).not.toBeInTheDocument();
     expect(screen.getByRole("option", { name: "COMPLETED" })).toBeInTheDocument();
     expect(screen.getByRole("option", { name: "CANCELED" })).toBeInTheDocument();
     expect(screen.queryByRole("option", { name: "IN_PROGRESS" })).not.toBeInTheDocument();
 
-    rerender(<QuestAcceptanceOverride acceptance={{ ...acceptance, status: "COMPLETED" }} access="ready" readSource={readSource} commandSource={commandSource} onCanonicalAcceptance={vi.fn()} />);
+    rerender(<QuestAcceptanceOverride acceptance={{ ...acceptance, status: "COMPLETED" }} access="ready" readSource={readSource} auditSource={auditSource} commandSource={commandSource} onCanonicalAcceptance={vi.fn()} />);
     expect(screen.getByRole("heading", { name: "No available operation" })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Review operation" })).not.toBeInTheDocument();
   });

--- a/features/admin/quest/QuestAcceptanceOverride.tsx
+++ b/features/admin/quest/QuestAcceptanceOverride.tsx
@@ -1,7 +1,10 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 
+import { adminAuditDataSource } from "../api/audit.source";
+import type { AdminAuditDataSource } from "../api/audit.source";
 import { adminQuestCommandSource } from "../api/quest.command";
 import type { AdminQuestCommandSource, AdminQuestStatusCommand } from "../api/quest.command";
 import type { AdminQuestDataSource } from "../api/quest.source";
@@ -13,11 +16,12 @@ import {
   allowedAdminQuestStatusTargets,
   useQuestAcceptanceOverride,
 } from "./useQuestAcceptanceOverride";
+import type { QuestOverrideIntent, QuestOverridePhase } from "./useQuestAcceptanceOverride";
 
 function useIsMobile() {
-  const [mobile, setMobile] = useState(false);
+  const [mobile, setMobile] = useState<boolean | null>(null);
   useEffect(() => {
-    if (typeof window.matchMedia !== "function") return;
+    if (typeof window.matchMedia !== "function") { setMobile(false); return; }
     const query = window.matchMedia("(max-width: 759px)");
     const update = () => setMobile(query.matches);
     update();
@@ -31,10 +35,111 @@ function operationLabel(intent: NonNullable<ReturnType<typeof useQuestAcceptance
   return intent.kind === "progress" ? `Add ${intent.delta} progress` : `Change status to ${intent.status}`;
 }
 
+function QuestLevel3Review({
+  intent,
+  phase,
+  error,
+  onCancel,
+  onSubmit,
+}: {
+  intent: QuestOverrideIntent;
+  phase: QuestOverridePhase;
+  error: { status: number | null; message: string } | null;
+  onCancel: () => void;
+  onSubmit: () => void;
+}) {
+  const dialogRef = useRef<HTMLDialogElement | null>(null);
+  const headingRef = useRef<HTMLHeadingElement | null>(null);
+  const [verifiedId, setVerifiedId] = useState("");
+  const [confirmed, setConfirmed] = useState(false);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    if (typeof dialog.showModal === "function") dialog.showModal();
+    else dialog.setAttribute("open", "");
+    headingRef.current?.focus();
+    return () => {
+      if (dialog.open && typeof dialog.close === "function") dialog.close();
+    };
+  }, []);
+
+  if (typeof document === "undefined") return null;
+  const busy = phase !== "REVIEWING";
+  const requested = intent.kind === "progress"
+    ? `Add ${intent.delta}; projected progress ${intent.originalProgress + intent.delta} / ${intent.targetValue}`
+    : `Change status to ${intent.status}`;
+  const dependency = intent.kind === "progress"
+    ? "Reaching or crossing the target can trigger the existing Quest goal/completion policy."
+    : "This terminal status change affects the selected Acceptance.";
+  const reversibility = intent.kind === "progress"
+    ? "This slice exposes additive, non-negative progress only; it does not expose a progress reduction command."
+    : "This slice exposes no reverse command from COMPLETED or CANCELED.";
+
+  return createPortal(
+    <dialog
+      ref={dialogRef}
+      className={styles.questLevel3Dialog}
+      aria-labelledby="quest-level3-title"
+      onCancel={(event) => { event.preventDefault(); if (!busy) onCancel(); }}
+    >
+      <div className={styles.questLevel3Header}>
+        <span aria-hidden="true">3</span>
+        <div><p className={styles.eyebrow}>Level 3 · high-impact review</p><h2 id="quest-level3-title" ref={headingRef} tabIndex={-1}>Review target and consequences before confirmation</h2></div>
+      </div>
+
+      <section className={styles.questLevel3Section} aria-labelledby="quest-level3-target">
+        <div className={styles.questLevel3SectionHeader}><h3 id="quest-level3-target">Target identity</h3><span>Re-verify before execution</span></div>
+        <dl className={styles.questLevel3Identity}>
+          <div><dt>Acceptance ID</dt><dd><code>{intent.acceptanceId}</code></dd></div>
+          <div><dt>Player ID</dt><dd><code>{intent.playerId}</code></dd></div>
+          <div><dt>Quest code</dt><dd><code>{intent.questCode}</code></dd></div>
+          <div><dt>Current state</dt><dd>{intent.originalStatus} · {intent.originalProgress} / {intent.targetValue}</dd></div>
+          <div><dt>Requested state</dt><dd>{requested}</dd></div>
+        </dl>
+      </section>
+
+      <section className={styles.questLevel3Section} aria-labelledby="quest-level3-impact">
+        <div className={styles.questLevel3SectionHeader}><h3 id="quest-level3-impact">Dependency / blast-radius review</h3><span>Only proven command effects</span></div>
+        <dl className={styles.questLevel3Safeguards}>
+          <div><dt>◇ Dependencies</dt><dd>{dependency} QuestRoute is not automatically advanced, and reward repair is not performed.</dd></div>
+          <div><dt>△ Reversibility</dt><dd>{reversibility}</dd></div>
+          <div><dt>▧ Stale safety</dt><dd>Server/domain state is authoritative. There is no optimistic mutation; 409 or unknown results require reconciliation before any retry.</dd></div>
+          <div><dt>◎ Audit expectation</dt><dd>Durable Admin Audit evidence must match this correlation and idempotency identity.</dd></div>
+        </dl>
+      </section>
+
+      <section className={styles.questLevel3Section} aria-labelledby="quest-level3-reason">
+        <div className={styles.questLevel3SectionHeader}><h3 id="quest-level3-reason">Mandatory reason</h3></div>
+        <p className={styles.questLevel3Reason}>{intent.reason}</p>
+        <dl className={styles.questOperationReceipt}>
+          <div><dt>Correlation ID</dt><dd><code>{intent.correlationId}</code></dd></div>
+          <div><dt>Idempotency key</dt><dd><code>{intent.idempotencyKey}</code></dd></div>
+        </dl>
+      </section>
+
+      <div className={styles.questLevel3Confirmation}>
+        <label>Re-enter Acceptance ID<input value={verifiedId} onChange={(event) => setVerifiedId(event.target.value)} inputMode="numeric" autoComplete="off" disabled={busy} /></label>
+        <label className={styles.questConfirmCheck}><input type="checkbox" checked={confirmed} onChange={(event) => setConfirmed(event.target.checked)} disabled={busy} /> I verified the target and understand the terminal or downstream effects.</label>
+      </div>
+      {error ? <p className={styles.questOverrideError} role="alert">{error.message}</p> : null}
+      <div className={styles.questOverrideActions}>
+        <button type="button" className={styles.secondaryButton} onClick={onCancel} disabled={busy}>Cancel</button>
+        <button type="button" className={styles.primaryButton} onClick={onSubmit} disabled={busy || verifiedId !== String(intent.acceptanceId) || !confirmed}>
+          {phase === "SUBMITTING" ? "Submitting…" : phase === "SUCCEEDED_RECONCILING" ? "Reconciling…" : "Confirm Level 3 operation"}
+        </button>
+      </div>
+      <p className={styles.questLevel3FocusNote}>The confirm action is never initial focus.</p>
+    </dialog>,
+    document.body,
+  );
+}
+
 export function QuestAcceptanceOverride({
   acceptance,
   access,
   readSource,
+  auditSource = adminAuditDataSource,
   commandSource = adminQuestCommandSource,
   onCanonicalAcceptance,
   onOpenAudit,
@@ -42,6 +147,7 @@ export function QuestAcceptanceOverride({
   acceptance: AdminQuestAcceptance;
   access: AdminAccess;
   readSource: AdminQuestDataSource;
+  auditSource?: AdminAuditDataSource;
   commandSource?: AdminQuestCommandSource;
   onCanonicalAcceptance: (acceptance: AdminQuestAcceptance) => void;
   onOpenAudit?: () => void;
@@ -52,8 +158,6 @@ export function QuestAcceptanceOverride({
   const [status, setStatus] = useState<AdminQuestStatusCommand | "">(statusTargets[0] ?? "");
   const [reason, setReason] = useState("");
   const [validation, setValidation] = useState<string | null>(null);
-  const [verifiedId, setVerifiedId] = useState("");
-  const [confirmed, setConfirmed] = useState(false);
   const reviewHeading = useRef<HTMLHeadingElement | null>(null);
   const mobile = useIsMobile();
   const override = useQuestAcceptanceOverride({
@@ -61,6 +165,7 @@ export function QuestAcceptanceOverride({
     enabled: access === "ready",
     commandSource,
     readSource,
+    auditSource,
     onCanonicalAcceptance,
   });
 
@@ -70,15 +175,13 @@ export function QuestAcceptanceOverride({
     setStatus(allowedAdminQuestStatusTargets(acceptance.status)[0] ?? "");
     setReason("");
     setValidation(null);
-    setVerifiedId("");
-    setConfirmed(false);
   }, [acceptance.id, acceptance.status]);
 
   useEffect(() => {
     if (override.phase === "REVIEWING") reviewHeading.current?.focus();
-  }, [override.phase]);
+  }, [override.phase, override.reviewVersion]);
 
-  if (!commandSource.available) {
+  if (!commandSource.available || auditSource.descriptor.mode !== "api") {
     return (
       <section className={styles.questOverrideUnavailable} aria-labelledby="quest-override-title">
         <p className={styles.eyebrow}>Acceptance operation</p>
@@ -97,7 +200,7 @@ export function QuestAcceptanceOverride({
       <section className={styles.questOverrideState} data-state="success" aria-labelledby="quest-operation-complete">
         <p className={styles.eyebrow}>Canonical state reconciled</p>
         <h3 id="quest-operation-complete">Operation completed</h3>
-        <p>The exact Acceptance was reloaded after the server accepted the command.</p>
+        <p>The exact Acceptance was reloaded, and this operation was proven by its direct response or matching Audit evidence.</p>
         <dl className={styles.questOperationReceipt}>
           <div><dt>Correlation ID</dt><dd><code>{override.receipt.correlationId}</code></dd></div>
           <div><dt>Idempotency key</dt><dd><code>{override.receipt.idempotencyKey}</code></dd></div>
@@ -121,7 +224,7 @@ export function QuestAcceptanceOverride({
     );
   }
 
-  if (override.phase === "RECONCILED" && override.intent) {
+  if (override.phase === "RECONCILED_RETRYABLE" && override.intent) {
     return (
       <section className={styles.questOverrideState}>
         <p className={styles.eyebrow}>Reconciled · unchanged intent</p>
@@ -136,25 +239,47 @@ export function QuestAcceptanceOverride({
     );
   }
 
+  if (override.phase === "RECONCILED_UNVERIFIED" && override.intent) {
+    return (
+      <section className={styles.questOverrideState} data-state="unknown" role="alert">
+        <p className={styles.eyebrow}>Ambiguous · unverified</p>
+        <h3>Current state matches, but this operation is not proven</h3>
+        <p>No exact success Audit matched this operation. Another action may have produced the current state, so this intent cannot be marked successful or retried.</p>
+        <dl className={styles.questOperationReceipt}>
+          <div><dt>Correlation ID</dt><dd><code>{override.intent.correlationId}</code></dd></div>
+          <div><dt>Idempotency key</dt><dd><code>{override.intent.idempotencyKey}</code></dd></div>
+        </dl>
+        <div className={styles.questOverrideActions}>
+          {onOpenAudit ? <button type="button" className={styles.secondaryButton} onClick={onOpenAudit}>Open Audit Explorer</button> : null}
+          <button type="button" className={styles.primaryButton} onClick={override.newIntent}>Close investigation</button>
+        </div>
+      </section>
+    );
+  }
+
   if ((override.phase === "CONFLICT_RECONCILING" || override.phase === "CONFLICT_RECONCILED") && override.intent) {
     return (
       <section className={styles.questOverrideState} data-state="conflict" role="alert">
         <p className={styles.eyebrow}>409 conflict</p>
         <h3>{override.phase === "CONFLICT_RECONCILING" ? "Reconciling current state" : "Current state reconciled"}</h3>
-        <p>{override.phase === "CONFLICT_RECONCILING" ? "The command is not being retried." : "Review the reloaded Acceptance before creating a new operation."}</p>
-        {override.phase === "CONFLICT_RECONCILED" ? <button type="button" className={styles.primaryButton} onClick={override.newIntent}>Review current Acceptance</button> : null}
+        <p>{override.phase === "CONFLICT_RECONCILING" ? "The command is not being retried." : "No exact success Audit matched this operation. Review the reloaded Acceptance before creating a new intent."}</p>
+        {override.phase === "CONFLICT_RECONCILED" ? <div className={styles.questOverrideActions}>{onOpenAudit ? <button type="button" className={styles.secondaryButton} onClick={onOpenAudit}>Open Audit Explorer</button> : null}<button type="button" className={styles.primaryButton} onClick={override.newIntent}>Review current Acceptance</button></div> : null}
       </section>
     );
   }
 
   if (override.intent && ["REVIEWING", "SUBMITTING", "SUCCEEDED_RECONCILING"].includes(override.phase)) {
     const intent = override.intent;
-    const level3Unavailable = intent.risk === "L3" && mobile;
-    const level3Confirmed = intent.risk === "L2" || (verifiedId === String(intent.acceptanceId) && confirmed);
+    if (intent.risk === "L3") {
+      if (mobile !== false) {
+        return <section className={styles.questOverrideUnavailable} role="status"><p className={styles.eyebrow}>Level 3 review</p><h3>{mobile ? "Level 3 unavailable on mobile" : "Preparing safe review"}</h3><p>{mobile ? "Use a desktop or tablet viewport for this high-impact operation." : "Checking the responsive safety profile."}</p><button type="button" className={styles.secondaryButton} onClick={override.cancelReview}>Cancel review</button></section>;
+      }
+      return <QuestLevel3Review key={override.reviewVersion} intent={intent} phase={override.phase} error={override.error} onCancel={override.cancelReview} onSubmit={() => void override.submit()} />;
+    }
     return (
       <section className={styles.questOverrideReview} data-risk={intent.risk} aria-labelledby="quest-override-review-title">
         <div className={styles.questOverrideReviewHeader}>
-          <span aria-hidden="true">{intent.risk === "L3" ? "3" : "2"}</span>
+          <span aria-hidden="true">2</span>
           <div><p className={styles.eyebrow}>Level {intent.risk.slice(1)} review</p><h3 id="quest-override-review-title" ref={reviewHeading} tabIndex={-1}>Confirm Acceptance operation</h3></div>
         </div>
         <dl className={styles.questOverrideSummary}>
@@ -165,22 +290,11 @@ export function QuestAcceptanceOverride({
           <div><dt>Reason</dt><dd>{intent.reason}</dd></div>
           <div><dt>Audit</dt><dd>Successful commands append an Admin Audit event with the correlation ID.</dd></div>
         </dl>
-        {intent.risk === "L3" ? (
-          <div className={styles.questLevel3Warning}>
-            <strong>High-impact operation</strong>
-            <p>This can reach a target or enter a terminal state. It does not advance a QuestRoute or repair rewards.</p>
-            {level3Unavailable ? <p role="alert">Level 3 confirmation is unavailable on mobile. Use a desktop or tablet viewport.</p> : (
-              <>
-                <label>Re-enter Acceptance ID<input value={verifiedId} onChange={(event) => setVerifiedId(event.target.value)} inputMode="numeric" autoComplete="off" /></label>
-                <label className={styles.questConfirmCheck}><input type="checkbox" checked={confirmed} onChange={(event) => setConfirmed(event.target.checked)} /> I verified the target and understand the terminal or downstream effects.</label>
-              </>
-            )}
-          </div>
-        ) : <p className={styles.questLevel2Note}>This operation remains scoped to the selected Acceptance and will be verified by an exact reload.</p>}
+        <p className={styles.questLevel2Note}>This operation remains scoped to the selected Acceptance and will be verified by an exact reload.</p>
         {override.error ? <p className={styles.questOverrideError} role="alert">{override.error.message}</p> : null}
         <div className={styles.questOverrideActions}>
           <button type="button" className={styles.secondaryButton} onClick={override.cancelReview} disabled={override.phase !== "REVIEWING"}>Cancel</button>
-          <button type="button" className={styles.primaryButton} onClick={() => void override.submit()} disabled={override.phase !== "REVIEWING" || level3Unavailable || !level3Confirmed}>
+          <button type="button" className={styles.primaryButton} onClick={() => void override.submit()} disabled={override.phase !== "REVIEWING"}>
             {override.phase === "SUBMITTING" ? "Submitting…" : override.phase === "SUCCEEDED_RECONCILING" ? "Reconciling…" : `Confirm Level ${intent.risk.slice(1)} operation`}
           </button>
         </div>

--- a/features/admin/quest/QuestAcceptanceOverride.tsx
+++ b/features/admin/quest/QuestAcceptanceOverride.tsx
@@ -1,0 +1,231 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import { adminQuestCommandSource } from "../api/quest.command";
+import type { AdminQuestCommandSource, AdminQuestStatusCommand } from "../api/quest.command";
+import type { AdminQuestDataSource } from "../api/quest.source";
+import type { AdminAccess } from "../model";
+import styles from "../admin.module.css";
+import type { AdminQuestAcceptance } from "./model";
+import {
+  adminQuestOverrideRisk,
+  allowedAdminQuestStatusTargets,
+  useQuestAcceptanceOverride,
+} from "./useQuestAcceptanceOverride";
+
+function useIsMobile() {
+  const [mobile, setMobile] = useState(false);
+  useEffect(() => {
+    if (typeof window.matchMedia !== "function") return;
+    const query = window.matchMedia("(max-width: 759px)");
+    const update = () => setMobile(query.matches);
+    update();
+    query.addEventListener("change", update);
+    return () => query.removeEventListener("change", update);
+  }, []);
+  return mobile;
+}
+
+function operationLabel(intent: NonNullable<ReturnType<typeof useQuestAcceptanceOverride>["intent"]>) {
+  return intent.kind === "progress" ? `Add ${intent.delta} progress` : `Change status to ${intent.status}`;
+}
+
+export function QuestAcceptanceOverride({
+  acceptance,
+  access,
+  readSource,
+  commandSource = adminQuestCommandSource,
+  onCanonicalAcceptance,
+  onOpenAudit,
+}: {
+  acceptance: AdminQuestAcceptance;
+  access: AdminAccess;
+  readSource: AdminQuestDataSource;
+  commandSource?: AdminQuestCommandSource;
+  onCanonicalAcceptance: (acceptance: AdminQuestAcceptance) => void;
+  onOpenAudit?: () => void;
+}) {
+  const statusTargets = allowedAdminQuestStatusTargets(acceptance.status);
+  const [kind, setKind] = useState<"progress" | "status">(acceptance.status === "IN_PROGRESS" ? "progress" : "status");
+  const [delta, setDelta] = useState("0");
+  const [status, setStatus] = useState<AdminQuestStatusCommand | "">(statusTargets[0] ?? "");
+  const [reason, setReason] = useState("");
+  const [validation, setValidation] = useState<string | null>(null);
+  const [verifiedId, setVerifiedId] = useState("");
+  const [confirmed, setConfirmed] = useState(false);
+  const reviewHeading = useRef<HTMLHeadingElement | null>(null);
+  const mobile = useIsMobile();
+  const override = useQuestAcceptanceOverride({
+    acceptance,
+    enabled: access === "ready",
+    commandSource,
+    readSource,
+    onCanonicalAcceptance,
+  });
+
+  useEffect(() => {
+    setKind(acceptance.status === "IN_PROGRESS" ? "progress" : "status");
+    setDelta("0");
+    setStatus(allowedAdminQuestStatusTargets(acceptance.status)[0] ?? "");
+    setReason("");
+    setValidation(null);
+    setVerifiedId("");
+    setConfirmed(false);
+  }, [acceptance.id, acceptance.status]);
+
+  useEffect(() => {
+    if (override.phase === "REVIEWING") reviewHeading.current?.focus();
+  }, [override.phase]);
+
+  if (!commandSource.available) {
+    return (
+      <section className={styles.questOverrideUnavailable} aria-labelledby="quest-override-title">
+        <p className={styles.eyebrow}>Acceptance operation</p>
+        <h3 id="quest-override-title">Operational command unavailable</h3>
+        <p>Real API mode is required. Mock mode remains read-only and does not simulate a successful high-risk operation.</p>
+      </section>
+    );
+  }
+
+  if (override.error?.status === 401 || override.error?.status === 403) {
+    return <section className={styles.questOverrideState} role="alert"><h3>{override.error.status === 401 ? "Authentication required" : "Admin access denied"}</h3><p>{override.error.message}</p></section>;
+  }
+
+  if (override.phase === "SUCCEEDED" && override.receipt) {
+    return (
+      <section className={styles.questOverrideState} data-state="success" aria-labelledby="quest-operation-complete">
+        <p className={styles.eyebrow}>Canonical state reconciled</p>
+        <h3 id="quest-operation-complete">Operation completed</h3>
+        <p>The exact Acceptance was reloaded after the server accepted the command.</p>
+        <dl className={styles.questOperationReceipt}>
+          <div><dt>Correlation ID</dt><dd><code>{override.receipt.correlationId}</code></dd></div>
+          <div><dt>Idempotency key</dt><dd><code>{override.receipt.idempotencyKey}</code></dd></div>
+        </dl>
+        <div className={styles.questOverrideActions}>
+          {onOpenAudit ? <button type="button" className={styles.secondaryButton} onClick={onOpenAudit}>Open Audit Explorer</button> : null}
+          <button type="button" className={styles.primaryButton} onClick={override.newIntent}>Start another operation</button>
+        </div>
+      </section>
+    );
+  }
+
+  if (override.phase === "UNKNOWN_RESULT" || override.phase === "RECONCILING") {
+    return (
+      <section className={styles.questOverrideState} data-state="unknown" role="alert">
+        <p className={styles.eyebrow}>Unknown result</p>
+        <h3>{override.phase === "RECONCILING" ? "Reconciling exact Acceptance" : "Do not retry yet"}</h3>
+        <p>{override.phase === "RECONCILING" ? "Loading the authoritative Acceptance state." : `${override.error?.message ?? "The command result is unknown."} Reconcile before deciding whether to retry.`}</p>
+        <button type="button" className={styles.primaryButton} onClick={() => void override.reconcile()} disabled={override.phase === "RECONCILING"}>Reconcile current state</button>
+      </section>
+    );
+  }
+
+  if (override.phase === "RECONCILED" && override.intent) {
+    return (
+      <section className={styles.questOverrideState}>
+        <p className={styles.eyebrow}>Reconciled · unchanged intent</p>
+        <h3>Operation was not reflected</h3>
+        <p>The authoritative Acceptance does not show the requested outcome. A manual retry will reuse the same idempotency key.</p>
+        <code className={styles.detailId}>{override.intent.idempotencyKey}</code>
+        <div className={styles.questOverrideActions}>
+          <button type="button" className={styles.secondaryButton} onClick={override.newIntent}>Cancel operation</button>
+          <button type="button" className={styles.primaryButton} onClick={() => void override.submit()}>Retry same operation</button>
+        </div>
+      </section>
+    );
+  }
+
+  if ((override.phase === "CONFLICT_RECONCILING" || override.phase === "CONFLICT_RECONCILED") && override.intent) {
+    return (
+      <section className={styles.questOverrideState} data-state="conflict" role="alert">
+        <p className={styles.eyebrow}>409 conflict</p>
+        <h3>{override.phase === "CONFLICT_RECONCILING" ? "Reconciling current state" : "Current state reconciled"}</h3>
+        <p>{override.phase === "CONFLICT_RECONCILING" ? "The command is not being retried." : "Review the reloaded Acceptance before creating a new operation."}</p>
+        {override.phase === "CONFLICT_RECONCILED" ? <button type="button" className={styles.primaryButton} onClick={override.newIntent}>Review current Acceptance</button> : null}
+      </section>
+    );
+  }
+
+  if (override.intent && ["REVIEWING", "SUBMITTING", "SUCCEEDED_RECONCILING"].includes(override.phase)) {
+    const intent = override.intent;
+    const level3Unavailable = intent.risk === "L3" && mobile;
+    const level3Confirmed = intent.risk === "L2" || (verifiedId === String(intent.acceptanceId) && confirmed);
+    return (
+      <section className={styles.questOverrideReview} data-risk={intent.risk} aria-labelledby="quest-override-review-title">
+        <div className={styles.questOverrideReviewHeader}>
+          <span aria-hidden="true">{intent.risk === "L3" ? "3" : "2"}</span>
+          <div><p className={styles.eyebrow}>Level {intent.risk.slice(1)} review</p><h3 id="quest-override-review-title" ref={reviewHeading} tabIndex={-1}>Confirm Acceptance operation</h3></div>
+        </div>
+        <dl className={styles.questOverrideSummary}>
+          <div><dt>Acceptance</dt><dd><code>{intent.acceptanceId}</code> · {intent.questCode}</dd></div>
+          <div><dt>Player ID</dt><dd><code>{intent.playerId}</code></dd></div>
+          <div><dt>Current state</dt><dd>{intent.originalStatus} · {intent.originalProgress} / {intent.targetValue}</dd></div>
+          <div><dt>Requested change</dt><dd>{operationLabel(intent)}</dd></div>
+          <div><dt>Reason</dt><dd>{intent.reason}</dd></div>
+          <div><dt>Audit</dt><dd>Successful commands append an Admin Audit event with the correlation ID.</dd></div>
+        </dl>
+        {intent.risk === "L3" ? (
+          <div className={styles.questLevel3Warning}>
+            <strong>High-impact operation</strong>
+            <p>This can reach a target or enter a terminal state. It does not advance a QuestRoute or repair rewards.</p>
+            {level3Unavailable ? <p role="alert">Level 3 confirmation is unavailable on mobile. Use a desktop or tablet viewport.</p> : (
+              <>
+                <label>Re-enter Acceptance ID<input value={verifiedId} onChange={(event) => setVerifiedId(event.target.value)} inputMode="numeric" autoComplete="off" /></label>
+                <label className={styles.questConfirmCheck}><input type="checkbox" checked={confirmed} onChange={(event) => setConfirmed(event.target.checked)} /> I verified the target and understand the terminal or downstream effects.</label>
+              </>
+            )}
+          </div>
+        ) : <p className={styles.questLevel2Note}>This operation remains scoped to the selected Acceptance and will be verified by an exact reload.</p>}
+        {override.error ? <p className={styles.questOverrideError} role="alert">{override.error.message}</p> : null}
+        <div className={styles.questOverrideActions}>
+          <button type="button" className={styles.secondaryButton} onClick={override.cancelReview} disabled={override.phase !== "REVIEWING"}>Cancel</button>
+          <button type="button" className={styles.primaryButton} onClick={() => void override.submit()} disabled={override.phase !== "REVIEWING" || level3Unavailable || !level3Confirmed}>
+            {override.phase === "SUBMITTING" ? "Submitting…" : override.phase === "SUCCEEDED_RECONCILING" ? "Reconciling…" : `Confirm Level ${intent.risk.slice(1)} operation`}
+          </button>
+        </div>
+      </section>
+    );
+  }
+
+  const canAdjustProgress = acceptance.status === "IN_PROGRESS";
+  const hasActions = canAdjustProgress || statusTargets.length > 0;
+
+  if (!hasActions) {
+    return <section className={styles.questOverrideUnavailable}><p className={styles.eyebrow}>Acceptance operation</p><h3>No available operation</h3><p>This terminal Acceptance remains available for read-only inspection.</p></section>;
+  }
+
+  const review = () => {
+    setValidation(null);
+    try {
+      if (kind === "progress") {
+        if (!delta.trim()) throw new RangeError("Progress delta is required.");
+        override.beginReview({ kind, delta: Number(delta), reason });
+      } else if (status) {
+        override.beginReview({ kind, status, reason });
+      } else {
+        throw new RangeError("Choose an allowed target status.");
+      }
+    } catch (caught) {
+      setValidation(caught instanceof Error ? caught.message : "Review the command values.");
+    }
+  };
+
+  const draftRisk = kind === "progress"
+    ? adminQuestOverrideRisk(acceptance, { kind, delta: Number(delta), reason })
+    : status ? adminQuestOverrideRisk(acceptance, { kind, status, reason }) : "L2";
+
+  return (
+    <section className={styles.questOverrideForm} aria-labelledby="quest-override-title">
+      <div><p className={styles.eyebrow}>Acceptance operation</p><h3 id="quest-override-title">Prepare controlled override</h3></div>
+      {canAdjustProgress && statusTargets.length ? <label>Operation<select value={kind} onChange={(event) => setKind(event.target.value as "progress" | "status")}><option value="progress">Adjust progress</option><option value="status">Change status</option></select></label> : null}
+      {kind === "progress" && canAdjustProgress ? <label>Progress delta<input type="number" min={0} step={1} value={delta} onChange={(event) => setDelta(event.target.value)} /></label> : (
+        <label>Target status<select value={status} onChange={(event) => setStatus(event.target.value as AdminQuestStatusCommand)}>{statusTargets.map((target) => <option key={target} value={target}>{target}</option>)}</select></label>
+      )}
+      <label>Reason *<input type="text" maxLength={512} value={reason} onChange={(event) => setReason(event.target.value)} placeholder="Required operational reason" /></label>
+      <p className={styles.questRiskPreview}>Review level: <strong>{draftRisk}</strong>{draftRisk === "L3" ? " · desktop or tablet confirmation required" : ""}</p>
+      {validation ? <p className={styles.questOverrideError} role="alert">{validation}</p> : null}
+      <button type="button" className={styles.primaryButton} onClick={review}>Review operation</button>
+    </section>
+  );
+}

--- a/features/admin/quest/QuestRuntimeStatus.test.tsx
+++ b/features/admin/quest/QuestRuntimeStatus.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ApiError } from "@/shared/api/client";
 import type { AdminQuestDataSource } from "../api/quest.source";
+import type { AdminQuestCommandSource } from "../api/quest.command";
 import type { AdminQuestAcceptance, AdminQuestBlueprint, AdminQuestDefinition } from "./model";
 import { QuestRuntimeStatus } from "./QuestRuntimeStatus";
 
@@ -26,6 +27,7 @@ const completed: AdminQuestAcceptance = {
   ...acceptance, id: 9002, playerId: 10219, progressValue: 1, status: "COMPLETED",
   goalReachedAt: "2026-08-23T04:05:00Z", completedAt: "2026-08-23T04:05:00Z",
 };
+const unavailableCommands: AdminQuestCommandSource = { available: false };
 
 function source(): AdminQuestDataSource {
   return {
@@ -45,6 +47,10 @@ async function selectDefinition(code = definition.code) {
   await waitFor(() => expect(document.getElementById("quest-definition-title")).toHaveFocus());
 }
 
+function renderQuest(dataSource: AdminQuestDataSource) {
+  return render(<QuestRuntimeStatus access="ready" onLogin={vi.fn()} dataSource={dataSource} commandSource={unavailableCommands} />);
+}
+
 describe("read-only Quest Runtime Status", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -55,7 +61,7 @@ describe("read-only Quest Runtime Status", () => {
     const dataSource = source();
     let resolveCatalog!: (value: { blueprints: AdminQuestBlueprint[] }) => void;
     vi.mocked(dataSource.getCatalog).mockReturnValue(new Promise((resolve) => { resolveCatalog = resolve; }));
-    render(<QuestRuntimeStatus access="ready" onLogin={vi.fn()} dataSource={dataSource} />);
+    renderQuest(dataSource);
 
     expect(await screen.findByRole("heading", { name: "Loading Quest sources" })).toBeInTheDocument();
     await act(async () => resolveCatalog({ blueprints: [blueprint] }));
@@ -73,13 +79,15 @@ describe("read-only Quest Runtime Status", () => {
 
   it("filters by the proven status values and opens an exact Acceptance detail", async () => {
     const dataSource = source();
-    render(<QuestRuntimeStatus access="ready" onLogin={vi.fn()} dataSource={dataSource} />);
+    renderQuest(dataSource);
     await selectDefinition();
 
     fireEvent.click(screen.getByRole("button", { name: "9001" }));
     await waitFor(() => expect(document.getElementById("quest-acceptance-title")).toHaveFocus());
     expect(dataSource.getAcceptance).toHaveBeenCalledWith(9001);
     expect(within(document.getElementById("quest-acceptance-title")!.closest("aside")!).getByText("2026-08-24T04:00:00Z")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Operational command unavailable" })).toBeInTheDocument();
+    expect(screen.getByText(/Mock mode remains read-only/)).toBeInTheDocument();
 
     fireEvent.change(screen.getByLabelText("Acceptance status"), { target: { value: "COMPLETED" } });
     expect(await screen.findByRole("button", { name: "9002" })).toBeInTheDocument();
@@ -87,9 +95,23 @@ describe("read-only Quest Runtime Status", () => {
     expect(dataSource.getAcceptances).toHaveBeenLastCalledWith(definition.code, "COMPLETED");
   });
 
+  it("never exposes a mutation when the active read source is Mock", async () => {
+    const dataSource = source();
+    dataSource.descriptor = { mode: "mock", badge: "MOCK DATA", label: "Local Admin Mock", questLabel: "Local Admin Mock" };
+    const commandSource = { available: true, adjustProgress: vi.fn(), changeStatus: vi.fn() } satisfies AdminQuestCommandSource;
+    render(<QuestRuntimeStatus access="ready" onLogin={vi.fn()} dataSource={dataSource} commandSource={commandSource} />);
+    await selectDefinition();
+    fireEvent.click(screen.getByRole("button", { name: "9001" }));
+
+    expect(await screen.findByRole("heading", { name: "Operational command unavailable" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Review operation" })).not.toBeInTheDocument();
+    expect(commandSource.adjustProgress).not.toHaveBeenCalled();
+    expect(commandSource.changeStatus).not.toHaveBeenCalled();
+  });
+
   it("distinguishes an empty Quest from a status no-match", async () => {
     const dataSource = source();
-    render(<QuestRuntimeStatus access="ready" onLogin={vi.fn()} dataSource={dataSource} />);
+    renderQuest(dataSource);
     await selectDefinition(emptyDefinition.code);
 
     expect(screen.getByRole("heading", { name: "No Quest Acceptances" })).toBeInTheDocument();
@@ -100,7 +122,7 @@ describe("read-only Quest Runtime Status", () => {
   it("retries the same source after an index error without switching to Mock", async () => {
     const dataSource = source();
     vi.mocked(dataSource.getCatalog).mockRejectedValueOnce(new Error("Network unavailable"));
-    render(<QuestRuntimeStatus access="ready" onLogin={vi.fn()} dataSource={dataSource} />);
+    renderQuest(dataSource);
 
     expect(await screen.findByRole("heading", { name: "Unable to load Quest sources" })).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Retry" }));
@@ -111,7 +133,7 @@ describe("read-only Quest Runtime Status", () => {
   it.each([[401, "Authentication required"], [403, "Admin access denied"]] as const)("renders %s without cached Quest data", async (status, title) => {
     const dataSource = source();
     vi.mocked(dataSource.getCatalog).mockRejectedValueOnce(new ApiError(status, `HTTP_${status}`, "Denied"));
-    render(<QuestRuntimeStatus access="ready" onLogin={vi.fn()} dataSource={dataSource} />);
+    renderQuest(dataSource);
 
     expect(await screen.findByRole("heading", { name: title })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: definition.code })).not.toBeInTheDocument();
@@ -122,7 +144,7 @@ describe("read-only Quest Runtime Status", () => {
     vi.mocked(dataSource.getDefinition)
       .mockResolvedValueOnce({ ...definition, code: "quest:wrong", title: "Wrong Definition" })
       .mockResolvedValueOnce(definition);
-    render(<QuestRuntimeStatus access="ready" onLogin={vi.fn()} dataSource={dataSource} />);
+    renderQuest(dataSource);
     fireEvent.click(await screen.findByRole("button", { name: definition.code }));
 
     expect(await screen.findByText("Quest definition response did not match the requested Quest code.")).toBeInTheDocument();
@@ -138,7 +160,7 @@ describe("read-only Quest Runtime Status", () => {
     vi.mocked(dataSource.getAcceptances)
       .mockResolvedValueOnce({ acceptances: [{ ...acceptance, code: "quest:wrong" }] })
       .mockResolvedValueOnce({ acceptances: [acceptance] });
-    render(<QuestRuntimeStatus access="ready" onLogin={vi.fn()} dataSource={dataSource} />);
+    renderQuest(dataSource);
     fireEvent.click(await screen.findByRole("button", { name: definition.code }));
 
     expect(await screen.findByText("Quest acceptance list contained another Quest code.")).toBeInTheDocument();
@@ -149,7 +171,7 @@ describe("read-only Quest Runtime Status", () => {
 
   it("withholds a filtered Acceptance list containing another status and retries the same filter", async () => {
     const dataSource = source();
-    render(<QuestRuntimeStatus access="ready" onLogin={vi.fn()} dataSource={dataSource} />);
+    renderQuest(dataSource);
     await selectDefinition();
     vi.mocked(dataSource.getAcceptances)
       .mockResolvedValueOnce({ acceptances: [acceptance] })
@@ -174,7 +196,7 @@ describe("read-only Quest Runtime Status", () => {
       .mockResolvedValueOnce({ ...acceptance, id: 9999 })
       .mockResolvedValueOnce({ ...acceptance, code: "quest:wrong" })
       .mockResolvedValueOnce(acceptance);
-    render(<QuestRuntimeStatus access="ready" onLogin={vi.fn()} dataSource={dataSource} />);
+    renderQuest(dataSource);
     await selectDefinition();
     fireEvent.click(screen.getByRole("button", { name: "9001" }));
 

--- a/features/admin/quest/QuestRuntimeStatus.tsx
+++ b/features/admin/quest/QuestRuntimeStatus.tsx
@@ -4,11 +4,16 @@ import { useEffect, useRef } from "react";
 
 import { adminQuestDataSource } from "../api/quest.source";
 import type { AdminQuestDataSource } from "../api/quest.source";
+import { adminQuestCommandSource } from "../api/quest.command";
+import type { AdminQuestCommandSource } from "../api/quest.command";
 import type { AdminAccess } from "../model";
 import styles from "../admin.module.css";
 import { ADMIN_QUEST_ACCEPTANCE_STATUSES } from "./model";
 import type { AdminQuestAcceptance, AdminQuestAcceptanceStatus, AdminQuestDefinition } from "./model";
+import { QuestAcceptanceOverride } from "./QuestAcceptanceOverride";
 import { useQuestRuntimeStatus } from "./useQuestRuntimeStatus";
+
+const UNAVAILABLE_COMMAND_SOURCE: AdminQuestCommandSource = { available: false };
 
 function StatePanel({ title, message, action }: { title: string; message: string; action?: React.ReactNode }) {
   return <section className={styles.statePanel} role="status" aria-live="polite"><h2>{title}</h2><p>{message}</p>{action}</section>;
@@ -49,7 +54,7 @@ function DefinitionDetail({ definition, headingRef }: { definition: AdminQuestDe
   );
 }
 
-function AcceptanceDetail({ acceptance, headingRef, onClose }: { acceptance: AdminQuestAcceptance; headingRef: React.RefObject<HTMLHeadingElement | null>; onClose: () => void }) {
+function AcceptanceDetail({ acceptance, headingRef, onClose, children }: { acceptance: AdminQuestAcceptance; headingRef: React.RefObject<HTMLHeadingElement | null>; onClose: () => void; children: React.ReactNode }) {
   const fields = [
     ["Acceptance ID", acceptance.id], ["Quest ID", acceptance.questId], ["Player ID", acceptance.playerId], ["Quest code", acceptance.code],
     ["Category", shown(acceptance.category)], ["Target type", acceptance.targetType], ["Target value", acceptance.targetValue],
@@ -71,11 +76,24 @@ function AcceptanceDetail({ acceptance, headingRef, onClose }: { acceptance: Adm
       <dl className={styles.detailList}>
         {fields.map(([label, value]) => <div key={label}><dt>{label}</dt><dd className={label.includes("ID") || label.includes("code") ? styles.mono : undefined}>{value}</dd></div>)}
       </dl>
+      {children}
     </aside>
   );
 }
 
-export function QuestRuntimeStatus({ access, onLogin, dataSource = adminQuestDataSource }: { access: AdminAccess; onLogin: () => void; dataSource?: AdminQuestDataSource }) {
+export function QuestRuntimeStatus({
+  access,
+  onLogin,
+  onOpenAudit,
+  dataSource = adminQuestDataSource,
+  commandSource = adminQuestCommandSource,
+}: {
+  access: AdminAccess;
+  onLogin: () => void;
+  onOpenAudit?: () => void;
+  dataSource?: AdminQuestDataSource;
+  commandSource?: AdminQuestCommandSource;
+}) {
   const quest = useQuestRuntimeStatus(access === "ready", dataSource);
   const definitionHeading = useRef<HTMLHeadingElement | null>(null);
   const acceptanceHeading = useRef<HTMLHeadingElement | null>(null);
@@ -101,9 +119,9 @@ export function QuestRuntimeStatus({ access, onLogin, dataSource = adminQuestDat
   return (
     <div className={styles.auditScreen}>
       <div className={styles.screenHeader}>
-        <div><p className={styles.eyebrow}>Content / Quest Runtime Status</p><h1>Quest Runtime Status</h1><p>Inspect authored Quest definitions and player Acceptance state without changing runtime data.</p></div>
+        <div><p className={styles.eyebrow}>Content / Quest Runtime Status</p><h1>Quest Runtime Status</h1><p>Inspect Quest definitions and Acceptance state, then run the approved controlled Acceptance operations.</p></div>
         <div className={styles.screenActions}>
-          <span className={styles.badge} data-state="READ_ONLY">▣ READ_ONLY</span>
+          <span className={styles.badge} data-state="SUPPORTED">✓ CONTROLLED</span>
           <button type="button" className={styles.secondaryButton} onClick={() => void quest.retry()} disabled={access !== "ready" || quest.loading !== null || (!quest.indexLoaded && !quest.error)}>Refresh</button>
         </div>
       </div>
@@ -152,8 +170,8 @@ export function QuestRuntimeStatus({ access, onLogin, dataSource = adminQuestDat
                   <label>Acceptance status<select value={quest.statusFilter} onChange={(event) => void quest.filterAcceptances(event.target.value as AdminQuestAcceptanceStatus | "")} disabled={quest.loading !== null}><option value="">All statuses</option>{ADMIN_QUEST_ACCEPTANCE_STATUSES.map((status) => <option key={status} value={status}>{status}</option>)}</select></label>
                 </div>
                 <p className={styles.questSemantics}>Definition configuration and player Acceptance runtime state remain separate. Quest completion does not automatically advance a QuestRoute.</p>
-                {quest.loading === "acceptances" ? <StatePanel title="Loading Quest Acceptances" message="Applying the exact runtime status filter." /> : acceptancesError ? <StatePanel title="Unable to load Quest Acceptances" message={acceptancesError.message} action={<button type="button" className={styles.primaryButton} onClick={() => void quest.retry()}>Retry</button>} /> : quest.acceptances.length === 0 ? <StatePanel title={quest.statusFilter ? "No matching Acceptances" : "No Quest Acceptances"} message={quest.statusFilter ? `No ${quest.statusFilter} Acceptance exists for this Quest.` : "No player Acceptance exists for this Quest definition."} /> : (
-                  <div className={styles.questAcceptanceLayout}>
+                <div className={styles.questAcceptanceLayout}>
+                  {quest.loading === "acceptances" ? <StatePanel title="Loading Quest Acceptances" message="Applying the exact runtime status filter." /> : acceptancesError ? <StatePanel title="Unable to load Quest Acceptances" message={acceptancesError.message} action={<button type="button" className={styles.primaryButton} onClick={() => void quest.retry()}>Retry</button>} /> : quest.acceptances.length === 0 ? <StatePanel title={quest.statusFilter ? "No matching Acceptances" : "No Quest Acceptances"} message={quest.statusFilter ? `No ${quest.statusFilter} Acceptance exists for this Quest.` : "No player Acceptance exists for this Quest definition."} /> : (
                     <div className={styles.tableWrap}>
                       <table className={`${styles.table} ${styles.questAcceptanceTable}`}>
                         <caption>Acceptances for {quest.definition.code}</caption>
@@ -161,9 +179,20 @@ export function QuestRuntimeStatus({ access, onLogin, dataSource = adminQuestDat
                         <tbody>{quest.acceptances.map((acceptance) => <tr key={acceptance.id} data-selected={quest.acceptance?.id === acceptance.id || undefined}><td><button ref={(node) => { if (node) acceptanceTriggers.current.set(acceptance.id, node); else acceptanceTriggers.current.delete(acceptance.id); }} type="button" className={styles.idButton} onClick={() => void quest.openAcceptance(acceptance.id)}>{acceptance.id}</button></td><td className={styles.mono}>{acceptance.playerId}</td><td>{acceptance.progressValue} / {acceptance.targetValue}</td><td><QuestStatusBadge status={acceptance.status} /></td><td>{acceptance.acceptedAt}</td></tr>)}</tbody>
                       </table>
                     </div>
-                    {quest.loading === "acceptance" ? <StatePanel title="Loading Acceptance detail" message="Loading the selected Acceptance ID." /> : acceptanceError ? <StatePanel title={acceptanceError.status === 404 ? "Acceptance not found" : "Unable to load Acceptance detail"} message={acceptanceError.message} action={<button type="button" className={styles.primaryButton} onClick={() => void quest.retry()}>Retry</button>} /> : quest.acceptance ? <AcceptanceDetail acceptance={quest.acceptance} headingRef={acceptanceHeading} onClose={closeAcceptance} /> : <aside className={styles.detailPlaceholder}><span className={styles.badge} data-state="READ_ONLY">▣ READ_ONLY</span><h2>Acceptance detail</h2><p>Open an exact Acceptance ID to inspect its runtime state.</p></aside>}
-                  </div>
-                )}
+                  )}
+                  {quest.loading === "acceptance" ? <StatePanel title="Loading Acceptance detail" message="Loading the selected Acceptance ID." /> : acceptanceError ? <StatePanel title={acceptanceError.status === 404 ? "Acceptance not found" : "Unable to load Acceptance detail"} message={acceptanceError.message} action={<button type="button" className={styles.primaryButton} onClick={() => void quest.retry()}>Retry</button>} /> : quest.acceptance ? (
+                    <AcceptanceDetail acceptance={quest.acceptance} headingRef={acceptanceHeading} onClose={closeAcceptance}>
+                      <QuestAcceptanceOverride
+                        acceptance={quest.acceptance}
+                        access={access}
+                        readSource={dataSource}
+                        commandSource={dataSource.descriptor.mode === "api" ? commandSource : UNAVAILABLE_COMMAND_SOURCE}
+                        onCanonicalAcceptance={quest.applyCanonicalAcceptance}
+                        onOpenAudit={onOpenAudit}
+                      />
+                    </AcceptanceDetail>
+                  ) : <aside className={styles.detailPlaceholder}><span className={styles.badge} data-state="READ_ONLY">▣ READ_ONLY</span><h2>Acceptance detail</h2><p>Open an exact Acceptance ID to inspect its runtime state.</p></aside>}
+                </div>
               </section>
             ) : null}
           </div>

--- a/features/admin/quest/QuestRuntimeStatus.tsx
+++ b/features/admin/quest/QuestRuntimeStatus.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect, useRef } from "react";
 
+import { adminAuditDataSource } from "../api/audit.source";
+import type { AdminAuditDataSource } from "../api/audit.source";
 import { adminQuestDataSource } from "../api/quest.source";
 import type { AdminQuestDataSource } from "../api/quest.source";
 import { adminQuestCommandSource } from "../api/quest.command";
@@ -87,12 +89,14 @@ export function QuestRuntimeStatus({
   onOpenAudit,
   dataSource = adminQuestDataSource,
   commandSource = adminQuestCommandSource,
+  auditSource = adminAuditDataSource,
 }: {
   access: AdminAccess;
   onLogin: () => void;
   onOpenAudit?: () => void;
   dataSource?: AdminQuestDataSource;
   commandSource?: AdminQuestCommandSource;
+  auditSource?: AdminAuditDataSource;
 }) {
   const quest = useQuestRuntimeStatus(access === "ready", dataSource);
   const definitionHeading = useRef<HTMLHeadingElement | null>(null);
@@ -186,7 +190,8 @@ export function QuestRuntimeStatus({
                         acceptance={quest.acceptance}
                         access={access}
                         readSource={dataSource}
-                        commandSource={dataSource.descriptor.mode === "api" ? commandSource : UNAVAILABLE_COMMAND_SOURCE}
+                        auditSource={auditSource}
+                        commandSource={dataSource.descriptor.mode === "api" && auditSource.descriptor.mode === "api" ? commandSource : UNAVAILABLE_COMMAND_SOURCE}
                         onCanonicalAcceptance={quest.applyCanonicalAcceptance}
                         onOpenAudit={onOpenAudit}
                       />

--- a/features/admin/quest/useQuestAcceptanceOverride.test.tsx
+++ b/features/admin/quest/useQuestAcceptanceOverride.test.tsx
@@ -1,0 +1,129 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ApiError } from "@/shared/api/client";
+import type { AdminQuestCommandSource } from "../api/quest.command";
+import type { AdminQuestDataSource } from "../api/quest.source";
+import type { AdminQuestAcceptance } from "./model";
+import {
+  adminQuestOverrideRisk,
+  allowedAdminQuestStatusTargets,
+  useQuestAcceptanceOverride,
+} from "./useQuestAcceptanceOverride";
+
+const acceptance: AdminQuestAcceptance = {
+  id: 9001, questId: 501, playerId: 10218, code: "quest:record:first-trace", title: "First Trace", category: null,
+  targetType: "COUNT", targetValue: 3, progressValue: 1, status: "IN_PROGRESS", completionPolicy: "MANUAL", repeatRule: "ONCE",
+  periodStart: null, periodEnd: null, acceptedAt: "2026-08-24T04:00:00Z", periodKey: null, goalReachedAt: null,
+  completedAt: null, dueAt: null, semanticCategory: "RECORD", progressSource: "RECORD_CREATED", repeatPolicy: "ONCE", roleTemplateCode: null,
+};
+
+function sources() {
+  const commandSource = {
+    available: true,
+    adjustProgress: vi.fn(),
+    changeStatus: vi.fn(),
+  } satisfies AdminQuestCommandSource;
+  const readSource = {
+    descriptor: { mode: "api", badge: "API", label: "/admin/v1", questLabel: "/admin/v1/quests" },
+    getAcceptance: vi.fn(),
+  } as unknown as AdminQuestDataSource;
+  return { commandSource, readSource };
+}
+
+describe("Quest Acceptance override workflow", () => {
+  beforeEach(() => {
+    let sequence = 0;
+    vi.stubGlobal("crypto", { randomUUID: vi.fn(() => `00000000-0000-4000-8000-${String(++sequence).padStart(12, "0")}`) });
+  });
+
+  it("keeps an unresolved key through failed reload, reconcile, and manual retry", async () => {
+    const { commandSource, readSource } = sources();
+    commandSource.adjustProgress.mockResolvedValue(acceptance);
+    vi.mocked(readSource.getAcceptance)
+      .mockRejectedValueOnce(new Error("Reload unavailable"))
+      .mockResolvedValueOnce(acceptance)
+      .mockResolvedValueOnce({ ...acceptance, progressValue: 2 });
+    const onCanonicalAcceptance = vi.fn();
+    const { result } = renderHook(() => useQuestAcceptanceOverride({ acceptance, enabled: true, commandSource, readSource, onCanonicalAcceptance }));
+
+    act(() => { result.current.beginReview({ kind: "progress", delta: 1, reason: "Verified support request" }); });
+    const firstKey = result.current.intent?.idempotencyKey;
+    await act(async () => { await result.current.submit(); });
+    expect(result.current.phase).toBe("UNKNOWN_RESULT");
+    expect(result.current.intent?.idempotencyKey).toBe(firstKey);
+
+    await act(async () => { await result.current.reconcile(); });
+    expect(result.current.phase).toBe("RECONCILED");
+    await act(async () => { await result.current.submit(); });
+    await waitFor(() => expect(result.current.phase).toBe("SUCCEEDED"));
+
+    expect(commandSource.adjustProgress).toHaveBeenCalledTimes(2);
+    const firstMetadata = commandSource.adjustProgress.mock.calls[0][2];
+    const retryMetadata = commandSource.adjustProgress.mock.calls[1][2];
+    expect(retryMetadata).toEqual(firstMetadata);
+    expect(onCanonicalAcceptance).toHaveBeenLastCalledWith({ ...acceptance, progressValue: 2 });
+
+    act(() => { result.current.newIntent(); });
+    act(() => { result.current.beginReview({ kind: "progress", delta: 1, reason: "Verified support request" }); });
+    expect(result.current.intent?.idempotencyKey).not.toBe(firstKey);
+  });
+
+  it("reconciles a 409 without blind retry and clears resolved intent metadata", async () => {
+    const { commandSource, readSource } = sources();
+    commandSource.changeStatus.mockRejectedValue(new ApiError(409, "CONFLICT", "Already applied"));
+    vi.mocked(readSource.getAcceptance).mockResolvedValue({ ...acceptance, status: "GOAL_REACHED" });
+    const onCanonicalAcceptance = vi.fn();
+    const { result } = renderHook(() => useQuestAcceptanceOverride({ acceptance, enabled: true, commandSource, readSource, onCanonicalAcceptance }));
+
+    act(() => { result.current.beginReview({ kind: "status", status: "GOAL_REACHED", reason: "Verified goal evidence" }); });
+    await act(async () => { await result.current.submit(); });
+
+    expect(result.current.phase).toBe("CONFLICT_RECONCILED");
+    expect(commandSource.changeStatus).toHaveBeenCalledTimes(1);
+    expect(readSource.getAcceptance).toHaveBeenCalledWith(9001);
+    expect(onCanonicalAcceptance).toHaveBeenCalledWith({ ...acceptance, status: "GOAL_REACHED" });
+  });
+
+  it("creates a new key only when operator intent changes", () => {
+    const { commandSource, readSource } = sources();
+    const { result } = renderHook(() => useQuestAcceptanceOverride({ acceptance, enabled: true, commandSource, readSource, onCanonicalAcceptance: vi.fn() }));
+
+    act(() => { result.current.beginReview({ kind: "progress", delta: 1, reason: "Same reason" }); });
+    const initialKey = result.current.intent?.idempotencyKey;
+    act(() => { result.current.cancelReview(); });
+    act(() => { result.current.beginReview({ kind: "progress", delta: 1, reason: "Same reason" }); });
+    expect(result.current.intent?.idempotencyKey).toBe(initialKey);
+
+    act(() => { result.current.cancelReview(); });
+    act(() => { result.current.beginReview({ kind: "progress", delta: 2, reason: "Changed intent" }); });
+    expect(result.current.intent?.idempotencyKey).not.toBe(initialKey);
+  });
+
+  it("clears pending command metadata on authorization failure", async () => {
+    const { commandSource, readSource } = sources();
+    commandSource.adjustProgress.mockRejectedValue(new ApiError(403, "FORBIDDEN", "Admin access denied"));
+    const { result } = renderHook(() => useQuestAcceptanceOverride({ acceptance, enabled: true, commandSource, readSource, onCanonicalAcceptance: vi.fn() }));
+
+    act(() => { result.current.beginReview({ kind: "progress", delta: 1, reason: "Verified support request" }); });
+    expect(result.current.intent).not.toBeNull();
+    await act(async () => { await result.current.submit(); });
+
+    expect(result.current.phase).toBe("IDLE");
+    expect(result.current.intent).toBeNull();
+    expect(result.current.receipt).toBeNull();
+    expect(result.current.error?.status).toBe(403);
+  });
+
+  it("applies exact risk and transition rules", () => {
+    expect(adminQuestOverrideRisk(acceptance, { kind: "progress", delta: 1, reason: "Below" })).toBe("L2");
+    expect(adminQuestOverrideRisk(acceptance, { kind: "progress", delta: 2, reason: "Reaches" })).toBe("L3");
+    expect(adminQuestOverrideRisk(acceptance, { kind: "status", status: "GOAL_REACHED", reason: "Goal" })).toBe("L2");
+    expect(adminQuestOverrideRisk(acceptance, { kind: "status", status: "COMPLETED", reason: "Complete" })).toBe("L3");
+    expect(adminQuestOverrideRisk(acceptance, { kind: "status", status: "CANCELED", reason: "Cancel" })).toBe("L3");
+    expect(allowedAdminQuestStatusTargets("IN_PROGRESS")).toEqual(["GOAL_REACHED", "CANCELED"]);
+    expect(allowedAdminQuestStatusTargets("GOAL_REACHED")).toEqual(["COMPLETED", "CANCELED"]);
+    expect(allowedAdminQuestStatusTargets("COMPLETED")).toEqual([]);
+    expect(allowedAdminQuestStatusTargets("CANCELED")).toEqual([]);
+  });
+});

--- a/features/admin/quest/useQuestAcceptanceOverride.test.tsx
+++ b/features/admin/quest/useQuestAcceptanceOverride.test.tsx
@@ -2,8 +2,10 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ApiError } from "@/shared/api/client";
+import type { AdminAuditDataSource } from "../api/audit.source";
 import type { AdminQuestCommandSource } from "../api/quest.command";
 import type { AdminQuestDataSource } from "../api/quest.source";
+import type { AdminAuditEvent } from "../model";
 import type { AdminQuestAcceptance } from "./model";
 import {
   adminQuestOverrideRisk,
@@ -28,7 +30,30 @@ function sources() {
     descriptor: { mode: "api", badge: "API", label: "/admin/v1", questLabel: "/admin/v1/quests" },
     getAcceptance: vi.fn(),
   } as unknown as AdminQuestDataSource;
-  return { commandSource, readSource };
+  const auditSource = {
+    descriptor: { mode: "api", badge: "API", label: "/admin/v1", eventLabel: "/admin/v1/audit-events" },
+    getEvents: vi.fn().mockResolvedValue({ items: [], nextCursor: null }),
+  } satisfies AdminAuditDataSource;
+  return { commandSource, readSource, auditSource };
+}
+
+function successAudit(
+  intent: NonNullable<ReturnType<typeof useQuestAcceptanceOverride>["intent"]>,
+  overrides: Partial<AdminAuditEvent> = {},
+): AdminAuditEvent {
+  return {
+    id: 1,
+    actorUserId: 12,
+    action: intent.kind === "progress" ? "QUEST_ACCEPTANCE_PROGRESS_ADJUST" : "QUEST_ACCEPTANCE_STATUS_CHANGE",
+    targetType: "QUEST_ACCEPTANCE",
+    targetId: String(intent.acceptanceId),
+    reason: intent.reason,
+    result: "SUCCESS",
+    correlationId: intent.correlationId,
+    idempotencyKey: intent.idempotencyKey,
+    occurredAt: "2026-08-26T01:00:00Z",
+    ...overrides,
+  };
 }
 
 describe("Quest Acceptance override workflow", () => {
@@ -38,14 +63,14 @@ describe("Quest Acceptance override workflow", () => {
   });
 
   it("keeps an unresolved key through failed reload, reconcile, and manual retry", async () => {
-    const { commandSource, readSource } = sources();
+    const { commandSource, readSource, auditSource } = sources();
     commandSource.adjustProgress.mockResolvedValue(acceptance);
     vi.mocked(readSource.getAcceptance)
       .mockRejectedValueOnce(new Error("Reload unavailable"))
       .mockResolvedValueOnce(acceptance)
       .mockResolvedValueOnce({ ...acceptance, progressValue: 2 });
     const onCanonicalAcceptance = vi.fn();
-    const { result } = renderHook(() => useQuestAcceptanceOverride({ acceptance, enabled: true, commandSource, readSource, onCanonicalAcceptance }));
+    const { result } = renderHook(() => useQuestAcceptanceOverride({ acceptance, enabled: true, commandSource, readSource, auditSource, onCanonicalAcceptance }));
 
     act(() => { result.current.beginReview({ kind: "progress", delta: 1, reason: "Verified support request" }); });
     const firstKey = result.current.intent?.idempotencyKey;
@@ -54,7 +79,7 @@ describe("Quest Acceptance override workflow", () => {
     expect(result.current.intent?.idempotencyKey).toBe(firstKey);
 
     await act(async () => { await result.current.reconcile(); });
-    expect(result.current.phase).toBe("RECONCILED");
+    expect(result.current.phase).toBe("RECONCILED_RETRYABLE");
     await act(async () => { await result.current.submit(); });
     await waitFor(() => expect(result.current.phase).toBe("SUCCEEDED"));
 
@@ -69,12 +94,107 @@ describe("Quest Acceptance override workflow", () => {
     expect(result.current.intent?.idempotencyKey).not.toBe(firstKey);
   });
 
-  it("reconciles a 409 without blind retry and clears resolved intent metadata", async () => {
-    const { commandSource, readSource } = sources();
+  it("does not attribute an outcome-looking canonical state without exact Audit evidence", async () => {
+    const { commandSource, readSource, auditSource } = sources();
+    commandSource.adjustProgress.mockRejectedValue(new Error("Connection lost"));
+    vi.mocked(readSource.getAcceptance).mockResolvedValue({ ...acceptance, progressValue: 2 });
+    const { result } = renderHook(() => useQuestAcceptanceOverride({ acceptance, enabled: true, commandSource, readSource, auditSource, onCanonicalAcceptance: vi.fn() }));
+
+    act(() => { result.current.beginReview({ kind: "progress", delta: 1, reason: "Verified support request" }); });
+    await act(async () => { await result.current.submit(); });
+    await act(async () => { await result.current.reconcile(); });
+
+    expect(result.current.phase).toBe("RECONCILED_UNVERIFIED");
+    expect(result.current.intent).not.toBeNull();
+    expect(result.current.receipt).toBeNull();
+  });
+
+  it("attributes an unknown result only when exact success Audit evidence matches", async () => {
+    const { commandSource, readSource, auditSource } = sources();
+    commandSource.adjustProgress.mockRejectedValue(new Error("Connection lost"));
+    vi.mocked(readSource.getAcceptance).mockResolvedValue({ ...acceptance, progressValue: 3, status: "GOAL_REACHED" });
+    const { result } = renderHook(() => useQuestAcceptanceOverride({ acceptance, enabled: true, commandSource, readSource, auditSource, onCanonicalAcceptance: vi.fn() }));
+
+    act(() => { result.current.beginReview({ kind: "progress", delta: 1, reason: "Verified support request" }); });
+    const intent = result.current.intent!;
+    auditSource.getEvents.mockResolvedValue({ items: [successAudit(intent)], nextCursor: null });
+    await act(async () => { await result.current.submit(); });
+    await act(async () => { await result.current.reconcile(); });
+
+    expect(result.current.phase).toBe("SUCCEEDED");
+    expect(result.current.receipt).toEqual({ correlationId: intent.correlationId, idempotencyKey: intent.idempotencyKey });
+    expect(auditSource.getEvents).toHaveBeenCalledWith({
+      action: "QUEST_ACCEPTANCE_PROGRESS_ADJUST",
+      targetType: "QUEST_ACCEPTANCE",
+      targetId: "9001",
+      result: "SUCCESS",
+      correlationId: intent.correlationId,
+    });
+  });
+
+  it("keeps UNKNOWN_RESULT when Audit evidence cannot be read", async () => {
+    const { commandSource, readSource, auditSource } = sources();
+    commandSource.adjustProgress.mockRejectedValue(new Error("Connection lost"));
+    vi.mocked(readSource.getAcceptance).mockResolvedValue(acceptance);
+    auditSource.getEvents.mockRejectedValue(new Error("Audit unavailable"));
+    const { result } = renderHook(() => useQuestAcceptanceOverride({ acceptance, enabled: true, commandSource, readSource, auditSource, onCanonicalAcceptance: vi.fn() }));
+
+    act(() => { result.current.beginReview({ kind: "progress", delta: 1, reason: "Verified support request" }); });
+    await act(async () => { await result.current.submit(); });
+    await act(async () => { await result.current.reconcile(); });
+
+    expect(result.current.phase).toBe("UNKNOWN_RESULT");
+    expect(result.current.intent).not.toBeNull();
+    expect(commandSource.adjustProgress).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects same-target Audit rows when any operation identity field differs", async () => {
+    const { commandSource, readSource, auditSource } = sources();
+    commandSource.adjustProgress.mockRejectedValue(new Error("Connection lost"));
+    vi.mocked(readSource.getAcceptance).mockResolvedValue({ ...acceptance, progressValue: 2 });
+    const { result } = renderHook(() => useQuestAcceptanceOverride({ acceptance, enabled: true, commandSource, readSource, auditSource, onCanonicalAcceptance: vi.fn() }));
+
+    act(() => { result.current.beginReview({ kind: "progress", delta: 1, reason: "Verified support request" }); });
+    const intent = result.current.intent!;
+    auditSource.getEvents.mockResolvedValue({ items: [
+      successAudit(intent, { action: "QUEST_ACCEPTANCE_STATUS_CHANGE" }),
+      successAudit(intent, { correlationId: "quest-operation:other" }),
+      successAudit(intent, { idempotencyKey: "quest-override:other" }),
+    ], nextCursor: null });
+    await act(async () => { await result.current.submit(); });
+    await act(async () => { await result.current.reconcile(); });
+
+    expect(result.current.phase).toBe("RECONCILED_UNVERIFIED");
+    expect(result.current.receipt).toBeNull();
+  });
+
+  it("proves a 409 successful only with the exact status Audit", async () => {
+    const { commandSource, readSource, auditSource } = sources();
+    commandSource.changeStatus.mockRejectedValue(new ApiError(409, "CONFLICT", "Already applied"));
+    vi.mocked(readSource.getAcceptance).mockResolvedValue({ ...acceptance, status: "CANCELED" });
+    const { result } = renderHook(() => useQuestAcceptanceOverride({ acceptance, enabled: true, commandSource, readSource, auditSource, onCanonicalAcceptance: vi.fn() }));
+
+    act(() => { result.current.beginReview({ kind: "status", status: "CANCELED", reason: "Verified cancellation" }); });
+    const intent = result.current.intent!;
+    auditSource.getEvents.mockResolvedValue({ items: [successAudit(intent)], nextCursor: null });
+    await act(async () => { await result.current.submit(); });
+
+    expect(result.current.phase).toBe("SUCCEEDED");
+    expect(auditSource.getEvents).toHaveBeenCalledWith({
+      action: "QUEST_ACCEPTANCE_STATUS_CHANGE",
+      targetType: "QUEST_ACCEPTANCE",
+      targetId: "9001",
+      result: "SUCCESS",
+      correlationId: intent.correlationId,
+    });
+  });
+
+  it("keeps a 409 without matching Audit conflict-reconciled and not successful", async () => {
+    const { commandSource, readSource, auditSource } = sources();
     commandSource.changeStatus.mockRejectedValue(new ApiError(409, "CONFLICT", "Already applied"));
     vi.mocked(readSource.getAcceptance).mockResolvedValue({ ...acceptance, status: "GOAL_REACHED" });
     const onCanonicalAcceptance = vi.fn();
-    const { result } = renderHook(() => useQuestAcceptanceOverride({ acceptance, enabled: true, commandSource, readSource, onCanonicalAcceptance }));
+    const { result } = renderHook(() => useQuestAcceptanceOverride({ acceptance, enabled: true, commandSource, readSource, auditSource, onCanonicalAcceptance }));
 
     act(() => { result.current.beginReview({ kind: "status", status: "GOAL_REACHED", reason: "Verified goal evidence" }); });
     await act(async () => { await result.current.submit(); });
@@ -86,8 +206,8 @@ describe("Quest Acceptance override workflow", () => {
   });
 
   it("creates a new key only when operator intent changes", () => {
-    const { commandSource, readSource } = sources();
-    const { result } = renderHook(() => useQuestAcceptanceOverride({ acceptance, enabled: true, commandSource, readSource, onCanonicalAcceptance: vi.fn() }));
+    const { commandSource, readSource, auditSource } = sources();
+    const { result } = renderHook(() => useQuestAcceptanceOverride({ acceptance, enabled: true, commandSource, readSource, auditSource, onCanonicalAcceptance: vi.fn() }));
 
     act(() => { result.current.beginReview({ kind: "progress", delta: 1, reason: "Same reason" }); });
     const initialKey = result.current.intent?.idempotencyKey;
@@ -101,9 +221,9 @@ describe("Quest Acceptance override workflow", () => {
   });
 
   it("clears pending command metadata on authorization failure", async () => {
-    const { commandSource, readSource } = sources();
+    const { commandSource, readSource, auditSource } = sources();
     commandSource.adjustProgress.mockRejectedValue(new ApiError(403, "FORBIDDEN", "Admin access denied"));
-    const { result } = renderHook(() => useQuestAcceptanceOverride({ acceptance, enabled: true, commandSource, readSource, onCanonicalAcceptance: vi.fn() }));
+    const { result } = renderHook(() => useQuestAcceptanceOverride({ acceptance, enabled: true, commandSource, readSource, auditSource, onCanonicalAcceptance: vi.fn() }));
 
     act(() => { result.current.beginReview({ kind: "progress", delta: 1, reason: "Verified support request" }); });
     expect(result.current.intent).not.toBeNull();

--- a/features/admin/quest/useQuestAcceptanceOverride.ts
+++ b/features/admin/quest/useQuestAcceptanceOverride.ts
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import { ApiError } from "@/shared/api/client";
+import type { AdminAuditDataSource } from "../api/audit.source";
 import type {
   AdminQuestCommandSource,
   AdminQuestStatusCommand,
@@ -17,7 +18,7 @@ export type QuestOverrideDraft =
   | { kind: "progress"; delta: number; reason: string }
   | { kind: "status"; status: AdminQuestStatusCommand; reason: string };
 
-type QuestOverrideIntent = QuestOverrideDraft & {
+export type QuestOverrideIntent = QuestOverrideDraft & {
   acceptanceId: number;
   questCode: string;
   playerId: number;
@@ -38,7 +39,8 @@ export type QuestOverridePhase =
   | "CONFLICT_RECONCILING"
   | "UNKNOWN_RESULT"
   | "RECONCILING"
-  | "RECONCILED"
+  | "RECONCILED_RETRYABLE"
+  | "RECONCILED_UNVERIFIED"
   | "CONFLICT_RECONCILED"
   | "SUCCEEDED";
 
@@ -73,9 +75,31 @@ function commandError(caught: unknown) {
   };
 }
 
-function completedIntent(intent: QuestOverrideIntent, acceptance: AdminQuestAcceptance) {
+function requestedOutcomeIsReflected(intent: QuestOverrideIntent, acceptance: AdminQuestAcceptance) {
   if (intent.kind === "status") return acceptance.status === intent.status;
   return intent.delta > 0 && acceptance.progressValue >= intent.originalProgress + intent.delta;
+}
+
+function auditAction(intent: QuestOverrideIntent) {
+  return intent.kind === "progress" ? "QUEST_ACCEPTANCE_PROGRESS_ADJUST" : "QUEST_ACCEPTANCE_STATUS_CHANGE";
+}
+
+async function hasExactSuccessAudit(intent: QuestOverrideIntent, auditSource: AdminAuditDataSource) {
+  const action = auditAction(intent);
+  const targetId = String(intent.acceptanceId);
+  const page = await auditSource.getEvents({
+    action,
+    targetType: "QUEST_ACCEPTANCE",
+    targetId,
+    result: "SUCCESS",
+    correlationId: intent.correlationId,
+  });
+  return page.items.some((event) => event.action === action
+    && event.targetType === "QUEST_ACCEPTANCE"
+    && event.targetId === targetId
+    && event.result === "SUCCESS"
+    && event.correlationId === intent.correlationId
+    && event.idempotencyKey === intent.idempotencyKey);
 }
 
 export function useQuestAcceptanceOverride({
@@ -83,19 +107,22 @@ export function useQuestAcceptanceOverride({
   enabled,
   commandSource,
   readSource,
+  auditSource,
   onCanonicalAcceptance,
 }: {
   acceptance: AdminQuestAcceptance;
   enabled: boolean;
   commandSource: AdminQuestCommandSource;
   readSource: AdminQuestDataSource;
+  auditSource: AdminAuditDataSource;
   onCanonicalAcceptance: (acceptance: AdminQuestAcceptance) => void;
 }) {
   const [state, setState] = useState<QuestOverrideState>(INITIAL_STATE);
+  const [reviewVersion, setReviewVersion] = useState(0);
   const submitting = useRef(false);
 
   useEffect(() => {
-    if (!enabled || !commandSource.available) {
+    if (!enabled || !commandSource.available || auditSource.descriptor.mode !== "api") {
       submitting.current = false;
       setState(INITIAL_STATE);
       return;
@@ -103,7 +130,7 @@ export function useQuestAcceptanceOverride({
     setState((current) => current.intent && (
       current.intent.acceptanceId !== acceptance.id || current.intent.questCode !== acceptance.code
     ) ? INITIAL_STATE : current);
-  }, [acceptance.code, acceptance.id, commandSource.available, enabled]);
+  }, [acceptance.code, acceptance.id, auditSource.descriptor.mode, commandSource.available, enabled]);
 
   const loadCanonical = useCallback(async (intent: QuestOverrideIntent) => {
     const canonical = assertAdminQuestAcceptanceIdentity(
@@ -115,8 +142,13 @@ export function useQuestAcceptanceOverride({
     return canonical;
   }, [onCanonicalAcceptance, readSource]);
 
+  const reconcileEvidence = useCallback(async (intent: QuestOverrideIntent) => {
+    const canonical = await loadCanonical(intent);
+    return { canonical, exactAudit: await hasExactSuccessAudit(intent, auditSource) };
+  }, [auditSource, loadCanonical]);
+
   const beginReview = useCallback((draft: QuestOverrideDraft) => {
-    if (!enabled || !commandSource.available) return false;
+    if (!enabled || !commandSource.available || auditSource.descriptor.mode !== "api") return false;
     const reason = validateAdminQuestOverrideReason(draft.reason);
     if (draft.kind === "progress") {
       if (acceptance.status !== "IN_PROGRESS") throw new RangeError("Progress can only be adjusted for an IN_PROGRESS Acceptance.");
@@ -135,6 +167,7 @@ export function useQuestAcceptanceOverride({
       acceptance.targetValue,
       normalizedDraft,
     ]);
+    setReviewVersion((current) => current + 1);
     setState((current) => {
       const reusable = current.intent?.fingerprint === fingerprint ? current.intent : null;
       const intent: QuestOverrideIntent = reusable ?? {
@@ -153,22 +186,53 @@ export function useQuestAcceptanceOverride({
       return { phase: "REVIEWING", intent, error: null, receipt: null };
     });
     return true;
-  }, [acceptance, commandSource.available, enabled]);
+  }, [acceptance, auditSource.descriptor.mode, commandSource.available, enabled]);
 
   const submit = useCallback(async () => {
     const intent = state.intent;
-    if (!intent || !enabled || !commandSource.available || submitting.current) return;
+    if (!intent || !enabled || !commandSource.available || auditSource.descriptor.mode !== "api" || submitting.current) return;
     submitting.current = true;
     setState((current) => ({ ...current, phase: "SUBMITTING", error: null }));
 
+    const metadata = { idempotencyKey: intent.idempotencyKey, correlationId: intent.correlationId };
     try {
-      const metadata = { idempotencyKey: intent.idempotencyKey, correlationId: intent.correlationId };
       if (intent.kind === "progress") {
         await commandSource.adjustProgress(intent.acceptanceId, { delta: intent.delta, reason: intent.reason }, metadata);
       } else {
         await commandSource.changeStatus(intent.acceptanceId, { status: intent.status, reason: intent.reason }, metadata);
       }
-      setState((current) => ({ ...current, phase: "SUCCEEDED_RECONCILING" }));
+    } catch (caught) {
+      const error = commandError(caught);
+      if (error.status === 401 || error.status === 403) {
+        setState({ ...INITIAL_STATE, error });
+      } else if (error.status === 409) {
+        setState((current) => ({ ...current, phase: "CONFLICT_RECONCILING", error }));
+        try {
+          const { exactAudit } = await reconcileEvidence(intent);
+          setState(exactAudit ? {
+            phase: "SUCCEEDED",
+            intent: null,
+            error: null,
+            receipt: { correlationId: intent.correlationId, idempotencyKey: intent.idempotencyKey },
+          } : (current) => ({ ...current, phase: "CONFLICT_RECONCILED", error }));
+        } catch (reconcileError) {
+          const reconcileFailure = commandError(reconcileError);
+          setState(reconcileFailure.status === 401 || reconcileFailure.status === 403
+            ? { ...INITIAL_STATE, error: reconcileFailure }
+            : (current) => ({ ...current, phase: "UNKNOWN_RESULT", error: reconcileFailure }));
+        }
+      } else if (error.status === null || error.status >= 500) {
+        setState((current) => ({ ...current, phase: "UNKNOWN_RESULT", error }));
+      } else {
+        setReviewVersion((current) => current + 1);
+        setState((current) => ({ ...current, phase: "REVIEWING", error }));
+      }
+      submitting.current = false;
+      return;
+    }
+
+    setState((current) => ({ ...current, phase: "SUCCEEDED_RECONCILING" }));
+    try {
       await loadCanonical(intent);
       setState({
         phase: "SUCCEEDED",
@@ -178,25 +242,13 @@ export function useQuestAcceptanceOverride({
       });
     } catch (caught) {
       const error = commandError(caught);
-      if (error.status === 401 || error.status === 403) {
-        setState({ ...INITIAL_STATE, error });
-      } else if (error.status === 409) {
-        setState((current) => ({ ...current, phase: "CONFLICT_RECONCILING", error }));
-        try {
-          await loadCanonical(intent);
-          setState((current) => ({ ...current, phase: "CONFLICT_RECONCILED", error }));
-        } catch (reconcileError) {
-          setState((current) => ({ ...current, phase: "UNKNOWN_RESULT", error: commandError(reconcileError) }));
-        }
-      } else if (error.status === null || error.status >= 500) {
-        setState((current) => ({ ...current, phase: "UNKNOWN_RESULT", error }));
-      } else {
-        setState((current) => ({ ...current, phase: "REVIEWING", error }));
-      }
+      setState(error.status === 401 || error.status === 403
+        ? { ...INITIAL_STATE, error }
+        : (current) => ({ ...current, phase: "UNKNOWN_RESULT", error }));
     } finally {
       submitting.current = false;
     }
-  }, [commandSource, enabled, loadCanonical, state.intent]);
+  }, [auditSource.descriptor.mode, commandSource, enabled, loadCanonical, reconcileEvidence, state.intent]);
 
   const reconcile = useCallback(async () => {
     const intent = state.intent;
@@ -204,16 +256,18 @@ export function useQuestAcceptanceOverride({
     submitting.current = true;
     setState((current) => ({ ...current, phase: "RECONCILING", error: null }));
     try {
-      const canonical = await loadCanonical(intent);
-      if (completedIntent(intent, canonical)) {
+      const { canonical, exactAudit } = await reconcileEvidence(intent);
+      if (exactAudit) {
         setState({
           phase: "SUCCEEDED",
           intent: null,
           error: null,
           receipt: { correlationId: intent.correlationId, idempotencyKey: intent.idempotencyKey },
         });
+      } else if (requestedOutcomeIsReflected(intent, canonical)) {
+        setState((current) => ({ ...current, phase: "RECONCILED_UNVERIFIED", error: null }));
       } else {
-        setState((current) => ({ ...current, phase: "RECONCILED", error: null }));
+        setState((current) => ({ ...current, phase: "RECONCILED_RETRYABLE", error: null }));
       }
     } catch (caught) {
       const error = commandError(caught);
@@ -223,10 +277,11 @@ export function useQuestAcceptanceOverride({
     } finally {
       submitting.current = false;
     }
-  }, [loadCanonical, state.intent]);
+  }, [reconcileEvidence, state.intent]);
 
   return {
     ...state,
+    reviewVersion,
     beginReview,
     submit,
     reconcile,

--- a/features/admin/quest/useQuestAcceptanceOverride.ts
+++ b/features/admin/quest/useQuestAcceptanceOverride.ts
@@ -1,0 +1,236 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { ApiError } from "@/shared/api/client";
+import type {
+  AdminQuestCommandSource,
+  AdminQuestStatusCommand,
+} from "../api/quest.command";
+import { validateAdminQuestOverrideReason } from "../api/quest.command";
+import { assertAdminQuestAcceptanceIdentity } from "../api/quest.query";
+import type { AdminQuestDataSource } from "../api/quest.source";
+import type { AdminQuestAcceptance } from "./model";
+
+export type QuestOverrideRisk = "L2" | "L3";
+export type QuestOverrideDraft =
+  | { kind: "progress"; delta: number; reason: string }
+  | { kind: "status"; status: AdminQuestStatusCommand; reason: string };
+
+type QuestOverrideIntent = QuestOverrideDraft & {
+  acceptanceId: number;
+  questCode: string;
+  playerId: number;
+  originalProgress: number;
+  originalStatus: AdminQuestAcceptance["status"];
+  targetValue: number;
+  risk: QuestOverrideRisk;
+  fingerprint: string;
+  idempotencyKey: string;
+  correlationId: string;
+};
+
+export type QuestOverridePhase =
+  | "IDLE"
+  | "REVIEWING"
+  | "SUBMITTING"
+  | "SUCCEEDED_RECONCILING"
+  | "CONFLICT_RECONCILING"
+  | "UNKNOWN_RESULT"
+  | "RECONCILING"
+  | "RECONCILED"
+  | "CONFLICT_RECONCILED"
+  | "SUCCEEDED";
+
+type QuestOverrideState = {
+  phase: QuestOverridePhase;
+  intent: QuestOverrideIntent | null;
+  error: { status: number | null; message: string } | null;
+  receipt: { correlationId: string; idempotencyKey: string } | null;
+};
+
+const INITIAL_STATE: QuestOverrideState = { phase: "IDLE", intent: null, error: null, receipt: null };
+
+export function allowedAdminQuestStatusTargets(status: AdminQuestAcceptance["status"]): AdminQuestStatusCommand[] {
+  if (status === "IN_PROGRESS") return ["GOAL_REACHED", "CANCELED"];
+  if (status === "GOAL_REACHED") return ["COMPLETED", "CANCELED"];
+  return [];
+}
+
+export function adminQuestOverrideRisk(acceptance: AdminQuestAcceptance, draft: QuestOverrideDraft): QuestOverrideRisk {
+  if (draft.kind === "progress") return acceptance.progressValue + draft.delta >= acceptance.targetValue ? "L3" : "L2";
+  return draft.status === "COMPLETED" || draft.status === "CANCELED" ? "L3" : "L2";
+}
+
+function operationId(prefix: string) {
+  return `${prefix}:${globalThis.crypto.randomUUID()}`;
+}
+
+function commandError(caught: unknown) {
+  return {
+    status: caught instanceof ApiError ? caught.status : null,
+    message: caught instanceof Error ? caught.message : "Quest Acceptance command failed.",
+  };
+}
+
+function completedIntent(intent: QuestOverrideIntent, acceptance: AdminQuestAcceptance) {
+  if (intent.kind === "status") return acceptance.status === intent.status;
+  return intent.delta > 0 && acceptance.progressValue >= intent.originalProgress + intent.delta;
+}
+
+export function useQuestAcceptanceOverride({
+  acceptance,
+  enabled,
+  commandSource,
+  readSource,
+  onCanonicalAcceptance,
+}: {
+  acceptance: AdminQuestAcceptance;
+  enabled: boolean;
+  commandSource: AdminQuestCommandSource;
+  readSource: AdminQuestDataSource;
+  onCanonicalAcceptance: (acceptance: AdminQuestAcceptance) => void;
+}) {
+  const [state, setState] = useState<QuestOverrideState>(INITIAL_STATE);
+  const submitting = useRef(false);
+
+  useEffect(() => {
+    if (!enabled || !commandSource.available) {
+      submitting.current = false;
+      setState(INITIAL_STATE);
+      return;
+    }
+    setState((current) => current.intent && (
+      current.intent.acceptanceId !== acceptance.id || current.intent.questCode !== acceptance.code
+    ) ? INITIAL_STATE : current);
+  }, [acceptance.code, acceptance.id, commandSource.available, enabled]);
+
+  const loadCanonical = useCallback(async (intent: QuestOverrideIntent) => {
+    const canonical = assertAdminQuestAcceptanceIdentity(
+      await readSource.getAcceptance(intent.acceptanceId),
+      intent.acceptanceId,
+      intent.questCode,
+    );
+    onCanonicalAcceptance(canonical);
+    return canonical;
+  }, [onCanonicalAcceptance, readSource]);
+
+  const beginReview = useCallback((draft: QuestOverrideDraft) => {
+    if (!enabled || !commandSource.available) return false;
+    const reason = validateAdminQuestOverrideReason(draft.reason);
+    if (draft.kind === "progress") {
+      if (acceptance.status !== "IN_PROGRESS") throw new RangeError("Progress can only be adjusted for an IN_PROGRESS Acceptance.");
+      if (!Number.isInteger(draft.delta) || draft.delta < 0) throw new RangeError("Progress delta must be a non-negative integer.");
+    } else if (!allowedAdminQuestStatusTargets(acceptance.status).includes(draft.status)) {
+      throw new RangeError("The requested status is not an allowed transition from the current Acceptance state.");
+    }
+
+    const normalizedDraft = { ...draft, reason } as QuestOverrideDraft;
+    const fingerprint = JSON.stringify([
+      acceptance.id,
+      acceptance.code,
+      acceptance.playerId,
+      acceptance.progressValue,
+      acceptance.status,
+      acceptance.targetValue,
+      normalizedDraft,
+    ]);
+    setState((current) => {
+      const reusable = current.intent?.fingerprint === fingerprint ? current.intent : null;
+      const intent: QuestOverrideIntent = reusable ?? {
+        ...normalizedDraft,
+        acceptanceId: acceptance.id,
+        questCode: acceptance.code,
+        playerId: acceptance.playerId,
+        originalProgress: acceptance.progressValue,
+        originalStatus: acceptance.status,
+        targetValue: acceptance.targetValue,
+        risk: adminQuestOverrideRisk(acceptance, normalizedDraft),
+        fingerprint,
+        idempotencyKey: operationId("quest-override"),
+        correlationId: operationId("quest-operation"),
+      };
+      return { phase: "REVIEWING", intent, error: null, receipt: null };
+    });
+    return true;
+  }, [acceptance, commandSource.available, enabled]);
+
+  const submit = useCallback(async () => {
+    const intent = state.intent;
+    if (!intent || !enabled || !commandSource.available || submitting.current) return;
+    submitting.current = true;
+    setState((current) => ({ ...current, phase: "SUBMITTING", error: null }));
+
+    try {
+      const metadata = { idempotencyKey: intent.idempotencyKey, correlationId: intent.correlationId };
+      if (intent.kind === "progress") {
+        await commandSource.adjustProgress(intent.acceptanceId, { delta: intent.delta, reason: intent.reason }, metadata);
+      } else {
+        await commandSource.changeStatus(intent.acceptanceId, { status: intent.status, reason: intent.reason }, metadata);
+      }
+      setState((current) => ({ ...current, phase: "SUCCEEDED_RECONCILING" }));
+      await loadCanonical(intent);
+      setState({
+        phase: "SUCCEEDED",
+        intent: null,
+        error: null,
+        receipt: { correlationId: intent.correlationId, idempotencyKey: intent.idempotencyKey },
+      });
+    } catch (caught) {
+      const error = commandError(caught);
+      if (error.status === 401 || error.status === 403) {
+        setState({ ...INITIAL_STATE, error });
+      } else if (error.status === 409) {
+        setState((current) => ({ ...current, phase: "CONFLICT_RECONCILING", error }));
+        try {
+          await loadCanonical(intent);
+          setState((current) => ({ ...current, phase: "CONFLICT_RECONCILED", error }));
+        } catch (reconcileError) {
+          setState((current) => ({ ...current, phase: "UNKNOWN_RESULT", error: commandError(reconcileError) }));
+        }
+      } else if (error.status === null || error.status >= 500) {
+        setState((current) => ({ ...current, phase: "UNKNOWN_RESULT", error }));
+      } else {
+        setState((current) => ({ ...current, phase: "REVIEWING", error }));
+      }
+    } finally {
+      submitting.current = false;
+    }
+  }, [commandSource, enabled, loadCanonical, state.intent]);
+
+  const reconcile = useCallback(async () => {
+    const intent = state.intent;
+    if (!intent || submitting.current) return;
+    submitting.current = true;
+    setState((current) => ({ ...current, phase: "RECONCILING", error: null }));
+    try {
+      const canonical = await loadCanonical(intent);
+      if (completedIntent(intent, canonical)) {
+        setState({
+          phase: "SUCCEEDED",
+          intent: null,
+          error: null,
+          receipt: { correlationId: intent.correlationId, idempotencyKey: intent.idempotencyKey },
+        });
+      } else {
+        setState((current) => ({ ...current, phase: "RECONCILED", error: null }));
+      }
+    } catch (caught) {
+      const error = commandError(caught);
+      setState(error.status === 401 || error.status === 403
+        ? { ...INITIAL_STATE, error }
+        : (current) => ({ ...current, phase: "UNKNOWN_RESULT", error }));
+    } finally {
+      submitting.current = false;
+    }
+  }, [loadCanonical, state.intent]);
+
+  return {
+    ...state,
+    beginReview,
+    submit,
+    reconcile,
+    cancelReview: () => setState((current) => ({ ...current, phase: "IDLE", error: null, receipt: null })),
+    newIntent: () => setState(INITIAL_STATE),
+  };
+}

--- a/features/admin/quest/useQuestRuntimeStatus.ts
+++ b/features/admin/quest/useQuestRuntimeStatus.ts
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import { ApiError } from "@/shared/api/client";
+import { assertAdminQuestAcceptanceIdentity } from "../api/quest.query";
 import type { AdminQuestDataSource } from "../api/quest.source";
 import type {
   AdminQuestAcceptance,
@@ -42,6 +43,12 @@ export function useQuestRuntimeStatus(enabled: boolean, dataSource: AdminQuestDa
   const [loadedAt, setLoadedAt] = useState<Date | null>(null);
   const requestId = useRef(0);
   const lastIntent = useRef<Intent | null>(null);
+  const selectedCodeRef = useRef(selectedCode);
+  const acceptanceIdRef = useRef(acceptance?.id ?? null);
+  const statusFilterRef = useRef(statusFilter);
+  selectedCodeRef.current = selectedCode;
+  acceptanceIdRef.current = acceptance?.id ?? null;
+  statusFilterRef.current = statusFilter;
 
   const run = useCallback(async (intent: Intent) => {
     const current = ++requestId.current;
@@ -102,9 +109,11 @@ export function useQuestRuntimeStatus(enabled: boolean, dataSource: AdminQuestDa
           setLoadedAt(new Date());
         }
       } else {
-        const nextAcceptance = await dataSource.getAcceptance(intent.acceptanceId);
-        if (nextAcceptance.id !== intent.acceptanceId) throw new Error("Quest acceptance response did not match the requested Acceptance ID.");
-        if (nextAcceptance.code !== intent.questCode) throw new Error("Quest acceptance response did not match the selected Quest code.");
+        const nextAcceptance = assertAdminQuestAcceptanceIdentity(
+          await dataSource.getAcceptance(intent.acceptanceId),
+          intent.acceptanceId,
+          intent.questCode,
+        );
         if (current === requestId.current) {
           setAcceptance(nextAcceptance);
           setLoadedAt(new Date());
@@ -129,6 +138,18 @@ export function useQuestRuntimeStatus(enabled: boolean, dataSource: AdminQuestDa
       if (current === requestId.current) setLoading(null);
     }
   }, [dataSource]);
+
+  const applyCanonicalAcceptance = useCallback((nextAcceptance: AdminQuestAcceptance) => {
+    if (!selectedCodeRef.current || acceptanceIdRef.current !== nextAcceptance.id) {
+      throw new Error("Quest acceptance reconciliation no longer matches the selected Acceptance.");
+    }
+    assertAdminQuestAcceptanceIdentity(nextAcceptance, acceptanceIdRef.current, selectedCodeRef.current);
+    setAcceptance(nextAcceptance);
+    setAcceptances((current) => statusFilterRef.current && nextAcceptance.status !== statusFilterRef.current
+      ? current.filter((item) => item.id !== nextAcceptance.id)
+      : current.map((item) => item.id === nextAcceptance.id ? nextAcceptance : item));
+    setLoadedAt(new Date());
+  }, []);
 
   useEffect(() => {
     if (enabled) void run({ kind: "index" });
@@ -174,5 +195,6 @@ export function useQuestRuntimeStatus(enabled: boolean, dataSource: AdminQuestDa
       setAcceptance(null);
       setError((current) => current?.kind === "acceptance" ? null : current);
     },
+    applyCanonicalAcceptance,
   };
 }

--- a/features/admin/quest/useQuestRuntimeStatus.ts
+++ b/features/admin/quest/useQuestRuntimeStatus.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 
 import { ApiError } from "@/shared/api/client";
 import { assertAdminQuestAcceptanceIdentity } from "../api/quest.query";
@@ -46,9 +46,12 @@ export function useQuestRuntimeStatus(enabled: boolean, dataSource: AdminQuestDa
   const selectedCodeRef = useRef(selectedCode);
   const acceptanceIdRef = useRef(acceptance?.id ?? null);
   const statusFilterRef = useRef(statusFilter);
-  selectedCodeRef.current = selectedCode;
-  acceptanceIdRef.current = acceptance?.id ?? null;
-  statusFilterRef.current = statusFilter;
+
+  useLayoutEffect(() => {
+    selectedCodeRef.current = selectedCode;
+    acceptanceIdRef.current = acceptance?.id ?? null;
+    statusFilterRef.current = statusFilter;
+  }, [acceptance?.id, selectedCode, statusFilter]);
 
   const run = useCallback(async (intent: Intent) => {
     const current = ++requestId.current;

--- a/features/admin/shell/AdminShell.test.tsx
+++ b/features/admin/shell/AdminShell.test.tsx
@@ -37,6 +37,14 @@ describe("Admin Phase A3 shell", () => {
     expect(screen.queryByRole("button", { name: /grant|revoke|adjust|delete|override|deliver/i })).not.toBeInTheDocument();
   });
 
+  it("lets a completed Quest operation open the normal Audit Explorer area", () => {
+    render(<AdminShell operator="operator@lag" quest={(openAudit) => <button type="button" onClick={openAudit}>Open Audit Explorer</button>} player={<div>Player Screen</div>} audit={<div>Audit Screen</div>} source={apiSource} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Open Audit Explorer" }));
+    expect(screen.getByText("Audit Screen")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "System, SUPPORTED" })).toHaveAttribute("aria-current", "page");
+  });
+
   it.each([
     [apiSource, "API", "/admin/v1", "Session", "Authority enforced by server"],
     [mockSource, "MOCK DATA", "Local Admin Mock", "Mock session", "Server Admin authority not evaluated"],

--- a/features/admin/shell/AdminShell.tsx
+++ b/features/admin/shell/AdminShell.tsx
@@ -12,7 +12,13 @@ function CapabilityBadge({ state, compact = false }: { state: AdminCapabilitySta
   return <span className={styles.badge} data-state={state} data-compact={compact || undefined}>{marker} {state}</span>;
 }
 
-export function AdminShell({ operator, audit, player, quest, source }: { operator: string; audit: React.ReactNode; player: React.ReactNode; quest: React.ReactNode; source: AdminDataSourceDescriptor }) {
+export function AdminShell({ operator, audit, player, quest, source }: {
+  operator: string;
+  audit: React.ReactNode;
+  player: React.ReactNode;
+  quest: React.ReactNode | ((openAudit: () => void) => React.ReactNode);
+  source: AdminDataSourceDescriptor;
+}) {
   const [activeArea, setActiveArea] = useState<AdminAreaId>("content");
   const active = ADMIN_AREAS.find((area) => area.id === activeArea)!;
 
@@ -45,7 +51,7 @@ export function AdminShell({ operator, audit, player, quest, source }: { operato
               {(area.id === "system" || area.id === "players" || area.id === "content") && activeArea === area.id ? (
                 <div className={styles.subnav} aria-label={`${area.label} capabilities`}>
                   <span>{area.id === "system" ? "Admin Audit" : area.id === "players" ? "Player Lookup" : "Quest Runtime Status"}</span>
-                  <CapabilityBadge state={area.id === "system" ? "SUPPORTED" : "READ_ONLY"} compact />
+                  <CapabilityBadge state={area.id === "players" ? "READ_ONLY" : "SUPPORTED"} compact />
                 </div>
               ) : null}
             </div>
@@ -58,7 +64,9 @@ export function AdminShell({ operator, audit, player, quest, source }: { operato
       </aside>
 
       <main className={styles.workspace}>
-        {activeArea === "system" ? audit : activeArea === "players" ? player : activeArea === "content" ? quest : (
+        {activeArea === "system" ? audit : activeArea === "players" ? player : activeArea === "content"
+          ? typeof quest === "function" ? quest(() => setActiveArea("system")) : quest
+          : (
           <section className={styles.capabilityPanel} aria-labelledby="admin-capability-title">
             <div className={styles.capabilityHeader}>
               <div>
@@ -70,7 +78,7 @@ export function AdminShell({ operator, audit, player, quest, source }: { operato
             <p>{active.reason}</p>
             <p className={styles.safeNote}>No data or command API is connected for this area in the current approved slice.</p>
           </section>
-        )}
+          )}
       </main>
     </div>
   );


### PR DESCRIPTION
## Purpose

Extend the Admin Quest Runtime Status screen with the two Quest Acceptance corrective commands hardened by Backend #309.

Closes #82

## Commands

```text
PATCH /admin/v1/quests/acceptances/{acceptanceId}/progress
PATCH /admin/v1/quests/acceptances/{acceptanceId}/status
```

Both commands use required operator reason and durable idempotency metadata.

## Safety Workflow

```text
inspect exact Acceptance
-> review current/requested effect
-> Level 2/3 confirmation
-> submit once
-> reload canonical Acceptance
-> reconcile success/conflict/unknown result
```

No optimistic mutation or automatic retry is used.

## Mock Boundary

Mock mode remains read-only and never fabricates high-risk command success.

## Domain Semantics

```text
Quest Definition != Quest Acceptance
QuestRoute != Quest folder
Quest completion != automatic QuestRoute advance
```

No QuestRoute write or reward repair is introduced.

## Validation

Focused tests cover command transport, Level 2/3 review, idempotency-key lifecycle, reconciliation, Mock safety, canonical reload, and one final production build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added controlled quest acceptance overrides for progress and status updates.
  * Added validation, risk assessment, confirmation, receipts, conflict handling, and audit navigation.
  * Added responsive layouts and mobile safeguards for higher-risk operations.
  * Added reconciliation to keep acceptance details and lists current after changes.
  * Added command availability handling for API and mock data sources.

* **Bug Fixes**
  * Added response identity checks to prevent mismatched acceptance data from being applied.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->