### PR TITLE
[Camera] Fit consumer desktop active stacks to v7 safe bounds

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -211,6 +211,7 @@ body {
 }
 
 .lag-workspace {
+  --lag-wide-stage-max: none;
   padding: var(--lag-space-6);
   scroll-padding-inline: 24px;
   background-color: color-mix(in srgb, var(--lag-workspace) 94%, transparent);
@@ -2956,6 +2957,43 @@ body {
 .lag-exchange-trade em {
   grid-column: 3;
   grid-row: 1 / 3;
+}
+
+@media (min-width: 1200px) {
+  .lag-app-shell {
+    min-width: 0 !important;
+    gap: var(--lag-space-4) !important;
+    padding-inline: var(--lag-space-6) !important;
+  }
+
+  .lag-left-anchor[data-context-present="false"] {
+    display: none;
+  }
+
+  .lag-orb-column {
+    width: 96px !important;
+  }
+
+  .lag-workspace {
+    min-width: 0 !important;
+    overflow-x: hidden;
+  }
+
+  .lag-workspace[data-wide-stage-fit="true"] > :only-child {
+    margin-inline: auto;
+  }
+
+  .lag-workspace[data-wide-stage-fit="true"] .lag-panel-stage {
+    min-width: 0;
+  }
+
+  .lag-workspace[data-wide-stage-fit="true"] .lag-panel-frame {
+    max-width: var(--lag-wide-stage-max);
+  }
+
+  .lag-workspace[data-wide-stage-fit="true"] .lag-home {
+    width: 100%;
+  }
 }
 
 @media (min-width: 768px) and (max-width: 1199px) {

--- a/app/globals.css
+++ b/app/globals.css
@@ -2985,6 +2985,7 @@ body {
 
   .lag-workspace[data-wide-stage-fit="true"] .lag-panel-stage {
     min-width: 0;
+    max-width: var(--lag-wide-stage-max);
   }
 
   .lag-workspace[data-wide-stage-fit="true"] .lag-panel-frame {

--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -132,6 +132,10 @@ describe("Home shell에서 feature surface를 routing할 때", () => {
     expect(css).toMatch(/\.lag-left-context\s*{[^}]*height:\s*min\(680px, calc\(100svh[^}]*max-height:\s*calc\(100svh/);
     expect(css).toMatch(/\.lag-left-context-content\s*{[^}]*overflow-y:\s*auto/);
     expect(page).toContain('className="lag-app-shell mx-auto flex w-full min-w-max items-start"');
+    expect(page).toContain('data-camera-layout-owner="fixed"');
+    expect(css).toMatch(/@media \(min-width: 1200px\)[\s\S]*\.lag-left-anchor\[data-context-present="false"\]\s*{[^}]*display:\s*none/);
+    expect(css).toMatch(/@media \(min-width: 1200px\)[\s\S]*\.lag-workspace\s*{[^}]*min-width:\s*0 !important;[^}]*overflow-x:\s*hidden/);
+    expect(css).toContain("max-width: var(--lag-wide-stage-max)");
   });
 
   describe("인증된 player가 처음 진입하면", () => {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -230,7 +230,7 @@ export default function Home() {
           zIndex={getSurfaceZIndex("left-context", SURFACE_GROUP_BASE_Z.left)}
         />
 
-        <div className="lag-orb-column shrink-0" style={{ width: UI_CONSTS.layout.centerWidth }}>
+        <div className="lag-orb-column shrink-0" data-camera-layout-owner="fixed" style={{ width: UI_CONSTS.layout.centerWidth }}>
           <div className="lag-utility-cluster" style={{ zIndex: getSurfaceZIndex("orb-nav", SURFACE_GROUP_BASE_Z.nav) + 1 }}>
             <SocialUtilityHub />
             <NotificationBell />

--- a/features/home/HomeShell.tsx
+++ b/features/home/HomeShell.tsx
@@ -102,7 +102,7 @@ export default function HomeShell({
   if (!data) return null;
 
   return (
-    <div className="lag-home" data-testid="home-shell">
+    <div className="lag-home" data-camera-layout-owner="surface" data-testid="home-shell">
       <header className="lag-home-surface lag-home-hero">
         <div>
           <p className="lag-home-eyebrow">World overview</p>

--- a/features/role/RoleShell.test.tsx
+++ b/features/role/RoleShell.test.tsx
@@ -88,6 +88,20 @@ describe("실제 Role shell을 사용할 때", () => {
     expect(css).toContain("@media (max-width: 767px)");
   });
 
+  it("실제 Role summary/detail stage wrapper가 shared wide width budget을 소유한다", () => {
+    render(<Harness />);
+    fireEvent.click(screen.getByRole("button", { name: /Overview/ }));
+
+    const summary = document.querySelector('[data-stage-key="role-summary"]');
+    const detail = document.querySelector('[data-stage-key="role-detail"]');
+    expect(summary).toHaveClass("lag-panel-stage");
+    expect(detail).toHaveClass("lag-panel-stage");
+
+    const css = readFileSync("app/globals.css", "utf8");
+    expect(css).toMatch(/\.lag-workspace\[data-wide-stage-fit="true"\] \.lag-panel-stage\s*{[^}]*min-width:\s*0;[^}]*max-width:\s*var\(--lag-wide-stage-max\)/);
+    expect(css).toMatch(/\.lag-workspace\[data-wide-stage-fit="true"\] \.lag-panel-frame\s*{[^}]*max-width:\s*var\(--lag-wide-stage-max\)/);
+  });
+
   describe("Role 목록을 탐색하고 관리하면", () => {
     it("canonical selector가 loading/empty/error/retry와 선택·create·edit·archive 흐름을 제공한다", async () => {
       const refresh = vi.fn().mockResolvedValue(undefined);

--- a/shared/hooks/useStageCamera.test.ts
+++ b/shared/hooks/useStageCamera.test.ts
@@ -11,6 +11,7 @@ import {
   requestStageFocus,
   stageFocusPlan,
   useStageCamera,
+  wideCameraScrollTarget,
   wideCompositionScrollDelta,
   wideStageMaxWidth,
 } from "./useStageCamera";
@@ -27,7 +28,7 @@ const domRect = (left: number, width: number) => ({
   toJSON: () => ({}),
 });
 
-function cameraOwner(clientWidth = 400, scrollWidth = 1200) {
+function cameraOwner(clientWidth = 400, scrollWidth = 1200, left = 0) {
   const owner = document.createElement("div");
   const scrollTo = vi.fn(({ left }: { left: number }) => { owner.scrollLeft = left; });
   Object.defineProperties(owner, {
@@ -36,7 +37,7 @@ function cameraOwner(clientWidth = 400, scrollWidth = 1200) {
     clientWidth: { configurable: true, value: clientWidth },
     scrollWidth: { configurable: true, value: scrollWidth },
   });
-  owner.getBoundingClientRect = () => domRect(0, clientWidth);
+  owner.getBoundingClientRect = () => domRect(left, clientWidth);
   return { owner, scrollTo };
 }
 
@@ -118,6 +119,58 @@ describe("stage camera contract", () => {
     document.documentElement.dataset.theme = "astral";
     expect(wideStageMaxWidth(1_440, 3)).toBe(warm);
     delete document.documentElement.dataset.theme;
+  });
+
+  it("honors wide center and nearest preferences inside the composition-safe interval", () => {
+    const base = {
+      scrollWidth: 2_000,
+      clientWidth: 1_000,
+      bounds: { left: 800, right: 1_200, width: 400 },
+      safeLeft: 524,
+      safeRight: 1_476,
+      targetLeft: 500,
+      targetWidth: 200,
+      insets: { leading: 32, trailing: 120 },
+    };
+
+    expect(wideCameraScrollTarget({ ...base, scrollLeft: 0, align: "center" })).toBe(100);
+    expect(wideCameraScrollTarget({
+      ...base,
+      scrollLeft: 120,
+      bounds: { left: 700, right: 1_100, width: 400 },
+      targetLeft: 420,
+      align: "nearest",
+    })).toBe(120);
+  });
+
+  it.each(["forward", "back"] as const)("honors wide %s preference while the whole composition remains safe", (align) => {
+    expect(wideCameraScrollTarget({
+      scrollLeft: 0,
+      scrollWidth: 2_000,
+      clientWidth: 1_000,
+      bounds: { left: 700, right: 1_450, width: 750 },
+      safeLeft: 524,
+      safeRight: 1_476,
+      targetLeft: 600,
+      targetWidth: 350,
+      align,
+      insets: { leading: 32, trailing: 120 },
+    })).toBe(70);
+  });
+
+  it("keeps wide composition safety authoritative over a conflicting center preference", () => {
+    expect(wideCameraScrollTarget({
+      scrollLeft: 0,
+      scrollWidth: 2_000,
+      clientWidth: 1_000,
+      bounds: { left: 524, right: 1_476, width: 952 },
+      safeLeft: 524,
+      safeRight: 1_476,
+      targetLeft: 700,
+      targetWidth: 200,
+      align: "center",
+      insets: { leading: 32, trailing: 120 },
+    })).toBe(0);
   });
 
   it("targets only genuine stage topology changes and returns to the immediate parent", () => {
@@ -227,6 +280,63 @@ describe("stage camera contract", () => {
     viewport.remove();
   });
 
+  it("rescans and recomposes when a non-stage loading owner is replaced by the Home surface", async () => {
+    const observed: Element[] = [];
+    class TestResizeObserver {
+      observe = (element: Element) => { observed.push(element); };
+      disconnect = vi.fn();
+      unobserve = vi.fn();
+    }
+    vi.stubGlobal("ResizeObserver", TestResizeObserver);
+    const { owner: viewport } = cameraOwner(1_600, 1_600);
+    const { owner: workspace, scrollTo } = cameraOwner(1_440, 2_000, 136);
+    const loading = layoutElement(160, 400);
+    workspace.append(loading);
+    viewport.append(workspace);
+    document.body.append(viewport);
+    const view = renderHook(() => useStageCamera({ current: viewport }, { current: workspace }, "home"));
+    expect(observed).toContain(loading);
+    observed.length = 0;
+    scrollTo.mockClear();
+
+    const loaded = loading;
+    act(() => {
+      loaded.dataset.cameraLayoutOwner = "surface";
+      loaded.getBoundingClientRect = () => domRect(160, 1_540);
+      loaded.replaceChildren(document.createElement("section"));
+    });
+
+    await waitFor(() => expect(observed).toContain(loaded));
+    expect(scrollTo).toHaveBeenCalledWith({ left: 148, behavior: "smooth" });
+    scrollTo.mockClear();
+
+    act(() => loaded.append(document.createElement("span")));
+    await act(async () => { await Promise.resolve(); });
+    expect(scrollTo).not.toHaveBeenCalled();
+    view.unmount();
+    viewport.remove();
+  });
+
+  it("passes wide center and nearest intent through the hook", () => {
+    const { owner: viewport } = cameraOwner(1_600, 1_600);
+    const { owner: workspace, scrollTo } = cameraOwner(1_000, 2_000, 500);
+    viewport.append(workspace);
+    document.body.append(viewport);
+    appendStage(workspace, "detail", 1_000, 200);
+    const view = renderHook(() => useStageCamera({ current: viewport }, { current: workspace }, "player"));
+    scrollTo.mockClear();
+
+    act(() => requestStageFocus("detail", "center"));
+    expect(scrollTo).toHaveBeenCalledWith({ left: 100, behavior: "smooth" });
+
+    workspace.scrollLeft = 0;
+    scrollTo.mockClear();
+    act(() => requestStageFocus("detail", "nearest"));
+    expect(scrollTo).not.toHaveBeenCalled();
+    view.unmount();
+    viewport.remove();
+  });
+
   it("recomposes wide bounds after a relevant measured-size change", () => {
     let resizeCallback: ResizeObserverCallback = () => {};
     class TestResizeObserver {
@@ -237,7 +347,7 @@ describe("stage camera contract", () => {
     }
     vi.stubGlobal("ResizeObserver", TestResizeObserver);
     const { owner: viewport } = cameraOwner(1_600, 1_600);
-    const { owner: workspace, scrollTo } = cameraOwner(900, 2_000);
+    const { owner: workspace, scrollTo } = cameraOwner(900, 2_000, 676);
     viewport.append(workspace);
     document.body.append(viewport);
     let detailLeft = 1_100;
@@ -250,7 +360,7 @@ describe("stage camera contract", () => {
     act(() => resizeCallback([], {} as ResizeObserver));
 
     expect(scrollTo).toHaveBeenCalledTimes(1);
-    expect(scrollTo).toHaveBeenCalledWith({ left: 174, behavior: "smooth" });
+    expect(scrollTo).toHaveBeenCalledWith({ left: 198, behavior: "smooth" });
     view.unmount();
     viewport.remove();
   });
@@ -460,7 +570,7 @@ describe("stage camera contract", () => {
 
   it("recomposes the complete wide composition after a same-profile viewport resize", async () => {
     const { owner: viewport } = cameraOwner(1_600, 1_600);
-    const { owner: workspace, scrollTo } = cameraOwner(900, 2_000);
+    const { owner: workspace, scrollTo } = cameraOwner(900, 2_000, 400);
     viewport.append(workspace);
     document.body.append(viewport);
     let detailLeft = 1_100;
@@ -477,7 +587,7 @@ describe("stage camera contract", () => {
     act(() => window.dispatchEvent(new Event("resize")));
 
     await waitFor(() => expect(scrollTo).toHaveBeenCalledTimes(1));
-    expect(scrollTo).toHaveBeenCalledWith({ left: 524, behavior: "smooth" });
+    expect(scrollTo).toHaveBeenCalledWith({ left: 608, behavior: "smooth" });
     view.unmount();
     viewport.remove();
   });

--- a/shared/hooks/useStageCamera.test.ts
+++ b/shared/hooks/useStageCamera.test.ts
@@ -2,13 +2,17 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
+  activeHorizontalBounds,
   cameraInsets,
   cameraProfileForWidth,
   cameraScrollTarget,
   focusStage,
+  horizontalBounds,
   requestStageFocus,
   stageFocusPlan,
   useStageCamera,
+  wideCompositionScrollDelta,
+  wideStageMaxWidth,
 } from "./useStageCamera";
 
 const domRect = (left: number, width: number) => ({
@@ -45,12 +49,75 @@ function appendStage(owner: HTMLElement, key: string, left: number, width = 300,
   return stage;
 }
 
+function layoutElement(left: number, width: number, display = "block") {
+  const element = document.createElement("div");
+  element.style.display = display;
+  element.getBoundingClientRect = () => domRect(left, width);
+  return element;
+}
+
 describe("stage camera contract", () => {
   beforeEach(() => {
     Object.defineProperty(window, "innerWidth", { configurable: true, value: 1440 });
     vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => { callback(0); return 1; });
     vi.stubGlobal("cancelAnimationFrame", vi.fn());
     vi.stubGlobal("matchMedia", vi.fn(() => ({ matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn() })));
+    vi.stubGlobal("ResizeObserver", undefined);
+  });
+
+  it.each([
+    { name: "two-stage", clientWidth: 924, naturalWidths: [520, 660] },
+    { name: "three-stage", clientWidth: 1_440, naturalWidths: [344, 720, 620] },
+  ])("allocates a wide $name composition inside 24px safe bounds", ({ clientWidth, naturalWidths }) => {
+    const maxWidth = wideStageMaxWidth(clientWidth, naturalWidths.length);
+    const renderedWidth = naturalWidths.reduce((total, width) => total + Math.min(width, maxWidth), 0)
+      + 18 * (naturalWidths.length - 1);
+
+    expect(renderedWidth).toBeLessThanOrEqual(clientWidth - 48);
+  });
+
+  it("excludes a hidden context and includes it as soon as it owns visible geometry", () => {
+    const context = layoutElement(24, 500, "none");
+    const navigation = layoutElement(24, 96);
+    const primary = layoutElement(136, 1_440);
+    document.body.append(context, navigation, primary);
+
+    expect(activeHorizontalBounds([context, navigation, primary])).toEqual({ left: 24, right: 1_576, width: 1_552 });
+
+    context.style.display = "block";
+    expect(activeHorizontalBounds([context, navigation, primary])).toEqual({ left: 24, right: 1_576, width: 1_552 });
+    expect(activeHorizontalBounds([context, navigation])?.right).toBe(524);
+    context.remove();
+    navigation.remove();
+    primary.remove();
+  });
+
+  it("fits representative Quick Record and Role compositions at 1600px without theme geometry", () => {
+    const quickMax = wideStageMaxWidth(1_440, 3);
+    const quickBounds = horizontalBounds([
+      domRect(24, 96),
+      domRect(160, Math.min(344, quickMax)),
+      domRect(516, Math.min(720, quickMax)),
+      domRect(980, Math.min(620, quickMax)),
+    ])!;
+    const roleMax = wideStageMaxWidth(924, 2);
+    const roleBounds = horizontalBounds([
+      domRect(24, 500),
+      domRect(540, 96),
+      domRect(676, roleMax),
+      domRect(676 + roleMax + 12, roleMax),
+    ])!;
+
+    expect(wideCompositionScrollDelta(quickBounds, 1_600)).toBe(0);
+    expect(wideCompositionScrollDelta(roleBounds, 1_600)).toBe(0);
+    expect(quickBounds.right).toBeLessThanOrEqual(1_576);
+    expect(roleBounds.right).toBeLessThanOrEqual(1_576);
+
+    document.documentElement.dataset.theme = "warm-beige";
+    const warm = wideStageMaxWidth(1_440, 3);
+    document.documentElement.dataset.theme = "astral";
+    expect(wideStageMaxWidth(1_440, 3)).toBe(warm);
+    delete document.documentElement.dataset.theme;
   });
 
   it("targets only genuine stage topology changes and returns to the immediate parent", () => {
@@ -142,6 +209,50 @@ describe("stage camera contract", () => {
     act(() => root.append(document.createElement("span")));
     await act(async () => { await Promise.resolve(); });
     expect(scrollTo).not.toHaveBeenCalled();
+  });
+
+  it("reallocates wide stage width when active topology changes", async () => {
+    const { owner: viewport } = cameraOwner(1_600, 1_600);
+    const { owner: workspace } = cameraOwner(924, 1_600);
+    viewport.append(workspace);
+    document.body.append(viewport);
+    appendStage(workspace, "root", 676, 520);
+    const view = renderHook(() => useStageCamera({ current: viewport }, { current: workspace }, "role"));
+
+    expect(workspace.style.getPropertyValue("--lag-wide-stage-max")).toBe("876px");
+    act(() => appendStage(workspace, "detail", 1_208, 660));
+
+    await waitFor(() => expect(workspace.style.getPropertyValue("--lag-wide-stage-max")).toBe("429px"));
+    view.unmount();
+    viewport.remove();
+  });
+
+  it("recomposes wide bounds after a relevant measured-size change", () => {
+    let resizeCallback: ResizeObserverCallback = () => {};
+    class TestResizeObserver {
+      constructor(callback: ResizeObserverCallback) { resizeCallback = callback; }
+      observe = vi.fn();
+      disconnect = vi.fn();
+      unobserve = vi.fn();
+    }
+    vi.stubGlobal("ResizeObserver", TestResizeObserver);
+    const { owner: viewport } = cameraOwner(1_600, 1_600);
+    const { owner: workspace, scrollTo } = cameraOwner(900, 2_000);
+    viewport.append(workspace);
+    document.body.append(viewport);
+    let detailLeft = 1_100;
+    const detail = appendStage(workspace, "detail", detailLeft, 300);
+    detail.getBoundingClientRect = () => domRect(detailLeft - workspace.scrollLeft, 300);
+    const view = renderHook(() => useStageCamera({ current: viewport }, { current: workspace }, "player"));
+    scrollTo.mockClear();
+
+    detailLeft = 1_450;
+    act(() => resizeCallback([], {} as ResizeObserver));
+
+    expect(scrollTo).toHaveBeenCalledTimes(1);
+    expect(scrollTo).toHaveBeenCalledWith({ left: 174, behavior: "smooth" });
+    view.unmount();
+    viewport.remove();
   });
 
   it("preserves a spatial stage that opts out of forward auto-focus", async () => {
@@ -347,6 +458,30 @@ describe("stage camera contract", () => {
     expect(scrollTo).toHaveBeenCalledWith({ left: expectedLeft, behavior: "smooth" });
   });
 
+  it("recomposes the complete wide composition after a same-profile viewport resize", async () => {
+    const { owner: viewport } = cameraOwner(1_600, 1_600);
+    const { owner: workspace, scrollTo } = cameraOwner(900, 2_000);
+    viewport.append(workspace);
+    document.body.append(viewport);
+    let detailLeft = 1_100;
+    const detail = appendStage(workspace, "detail", detailLeft, 300);
+    detail.getBoundingClientRect = () => domRect(detailLeft - workspace.scrollLeft, 300);
+    const viewportRef = { current: viewport };
+    const workspaceRef = { current: workspace };
+    const view = renderHook(() => useStageCamera(viewportRef, workspaceRef, "player"));
+    scrollTo.mockClear();
+
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: 1_300 });
+    Object.defineProperty(viewport, "clientWidth", { configurable: true, value: 1_300 });
+    detailLeft = 1_500;
+    act(() => window.dispatchEvent(new Event("resize")));
+
+    await waitFor(() => expect(scrollTo).toHaveBeenCalledTimes(1));
+    expect(scrollTo).toHaveBeenCalledWith({ left: 524, behavior: "smooth" });
+    view.unmount();
+    viewport.remove();
+  });
+
   it("coalesces a resize burst into one camera recomposition", async () => {
     const frames = new Map<number, FrameRequestCallback>();
     let frameId = 0;
@@ -430,7 +565,7 @@ describe("stage camera contract", () => {
     act(() => window.dispatchEvent(new Event("resize")));
 
     await waitFor(() => expect(workspaceScroll).toHaveBeenCalledTimes(1));
-    expect(workspaceScroll).toHaveBeenCalledWith({ left: 548, behavior: "smooth" });
+    expect(workspaceScroll).toHaveBeenCalledWith({ left: 524, behavior: "smooth" });
   });
 
   it("falls back to the deepest surviving stage when the active stage is missing after profile switch", async () => {

--- a/shared/hooks/useStageCamera.test.ts
+++ b/shared/hooks/useStageCamera.test.ts
@@ -317,6 +317,34 @@ describe("stage camera contract", () => {
     viewport.remove();
   });
 
+  it("rescans wide layout owners when a fixed viewport sibling changes", async () => {
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: 1_600 });
+    const { owner: viewport } = cameraOwner(1_600, 1_600);
+    const { owner: workspace, scrollTo } = cameraOwner(1_440, 2_000, 136);
+    const fixed = layoutElement(24, 500);
+    fixed.dataset.cameraLayoutOwner = "fixed";
+    fixed.setAttribute("aria-hidden", "true");
+    let stageLeft = 1_000;
+    const stage = appendStage(workspace, "overview", stageLeft, 300);
+    stage.getBoundingClientRect = () => domRect(stageLeft - workspace.scrollLeft, 300);
+    viewport.append(fixed, workspace);
+    document.body.append(viewport);
+    const view = renderHook(() => useStageCamera({ current: viewport }, { current: workspace }, "role"));
+    scrollTo.mockClear();
+
+    act(() => {
+      Object.defineProperty(workspace, "clientWidth", { configurable: true, value: 900 });
+      workspace.getBoundingClientRect = () => domRect(676, 900);
+      stageLeft = 1_450;
+      fixed.removeAttribute("aria-hidden");
+    });
+
+    await waitFor(() => expect(scrollTo).toHaveBeenCalledWith({ left: 198, behavior: "smooth" }));
+    expect(workspace.style.getPropertyValue("--lag-wide-stage-max")).toBe("852px");
+    view.unmount();
+    viewport.remove();
+  });
+
   it("passes wide center and nearest intent through the hook", () => {
     const { owner: viewport } = cameraOwner(1_600, 1_600);
     const { owner: workspace, scrollTo } = cameraOwner(1_000, 2_000, 500);

--- a/shared/hooks/useStageCamera.ts
+++ b/shared/hooks/useStageCamera.ts
@@ -414,12 +414,16 @@ export function useStageCamera(
       focus(pending, pending.id);
     };
 
-    observer.observe(owner, {
+    const mutationOptions: MutationObserverInit = {
       childList: true,
       subtree: true,
       attributes: true,
       attributeFilter: ["aria-hidden", "data-camera-layout-owner", "data-stage-key"],
-    });
+    };
+    observer.observe(owner, mutationOptions);
+    if (usesWideComposition && viewport !== null && viewport !== owner) {
+      observer.observe(viewport, mutationOptions);
+    }
     window.addEventListener(STAGE_FOCUS_EVENT, focusRequested);
     const finishWideScroll = () => { pendingWideScroll = null; };
     owner.addEventListener("scrollend", finishWideScroll);

--- a/shared/hooks/useStageCamera.ts
+++ b/shared/hooks/useStageCamera.ts
@@ -6,6 +6,7 @@ export type CameraProfile = "wide" | "compact" | "mobile";
 export type CameraFocusIntent = "forward" | "back" | "center" | "nearest";
 type StageFocusPlan = { key: string; align: CameraFocusIntent } | null;
 type StageFocusDetail = NonNullable<StageFocusPlan>;
+export type HorizontalBounds = { left: number; right: number; width: number };
 
 export const STAGE_FOCUS_EVENT = "lag:stage-focus";
 
@@ -113,9 +114,40 @@ export function cameraInsets(owner: HTMLElement, profile: CameraProfile) {
   };
 }
 
+export function horizontalBounds(rects: Array<Pick<DOMRect, "left" | "right">>): HorizontalBounds | null {
+  if (rects.length === 0) return null;
+  const left = Math.min(...rects.map((rect) => rect.left));
+  const right = Math.max(...rects.map((rect) => rect.right));
+  return { left, right, width: right - left };
+}
+
+export function wideStageMaxWidth(clientWidth: number, stageCount: number, edge = 24, gap = 18) {
+  const count = Math.max(1, stageCount);
+  return Math.max(0, (clientWidth - edge * 2 - gap * (count - 1)) / count);
+}
+
+export function wideCompositionScrollDelta(bounds: HorizontalBounds, viewportWidth: number, edge = 24) {
+  const trailingOverflow = bounds.right - (viewportWidth - edge);
+  if (trailingOverflow > 0) return trailingOverflow;
+  const leadingOverflow = edge - bounds.left;
+  return leadingOverflow > 0 ? -leadingOverflow : 0;
+}
+
+function consumesGeometry(element: HTMLElement) {
+  if (element.getAttribute("aria-hidden") === "true") return false;
+  const style = getComputedStyle(element);
+  if (style.display === "none" || style.visibility === "hidden") return false;
+  const rect = element.getBoundingClientRect();
+  return rect.width > 0 && rect.height > 0;
+}
+
+export function activeHorizontalBounds(elements: HTMLElement[]) {
+  return horizontalBounds(elements.filter(consumesGeometry).map((element) => element.getBoundingClientRect()));
+}
+
 function stages(owner: HTMLElement, invalidated: Set<string>) {
   return [...owner.querySelectorAll<HTMLElement>("[data-stage-key]")]
-    .filter((stage) => stage.getAttribute("aria-hidden") !== "true" && !invalidated.has(stage.dataset.stageKey!));
+    .filter((stage) => !invalidated.has(stage.dataset.stageKey!) && consumesGeometry(stage));
 }
 
 function prefersReducedMotion() {
@@ -168,13 +200,67 @@ export function useStageCamera(
     const context = mainSelectionKey;
     const owner = profile === "mobile" ? viewportRef.current : workspaceRef.current;
     if (!owner) return;
+    const viewport = viewportRef.current;
+    const usesWideComposition = profile === "wide" && viewport !== null && viewport !== owner;
     const inactiveOwner = profile === "mobile" ? workspaceRef.current : viewportRef.current;
     if (inactiveOwner && inactiveOwner !== owner && inactiveOwner.scrollLeft !== 0) {
       inactiveOwner.scrollTo({ left: 0, behavior: "auto" });
     }
     let previous = stages(owner, invalidatedKeys.current).map((stage) => stage.dataset.stageKey!);
     let frame = 0;
+    let recomposeFrame = 0;
     let scheduledFocus = 0;
+    let pendingWideScroll: number | null = null;
+
+    const wideLayoutOwners = (currentStages = stages(owner, invalidatedKeys.current)) => {
+      if (!viewport) return currentStages;
+      const fixed = [...viewport.querySelectorAll<HTMLElement>("[data-camera-layout-owner='fixed']")];
+      const surfaces = currentStages.length > 0
+        ? currentStages
+        : [...owner.querySelectorAll<HTMLElement>("[data-camera-layout-owner='surface']")];
+      const fallback = surfaces.length === 0 && owner.firstElementChild instanceof HTMLElement
+        ? [owner.firstElementChild]
+        : [];
+      return [...new Set([...fixed, ...surfaces, ...fallback])].filter(consumesGeometry);
+    };
+
+    const recomposeWide = () => {
+      if (!usesWideComposition || !viewport) return;
+      const currentStages = stages(owner, invalidatedKeys.current);
+      const stageCount = Math.max(1, currentStages.length || Number(Boolean(owner.firstElementChild)));
+      owner.dataset.wideStageFit = "true";
+      owner.style.setProperty("--lag-wide-stage-max", `${wideStageMaxWidth(owner.clientWidth, stageCount)}px`);
+
+      const bounds = activeHorizontalBounds(wideLayoutOwners(currentStages));
+      if (!bounds) return;
+      const delta = wideCompositionScrollDelta(bounds, viewport.clientWidth || window.innerWidth);
+      const maxScroll = Math.max(0, owner.scrollWidth - owner.clientWidth);
+      const next = Math.max(0, Math.min(owner.scrollLeft + delta, maxScroll));
+      if (Math.abs(next - owner.scrollLeft) < 0.5) {
+        pendingWideScroll = null;
+        return;
+      }
+      if (pendingWideScroll !== null && Math.abs(next - pendingWideScroll) < 0.5) return;
+      pendingWideScroll = next;
+      owner.scrollTo({ left: next, behavior: prefersReducedMotion() ? "auto" : "smooth" });
+    };
+
+    const scheduleWideRecompose = () => {
+      if (!usesWideComposition) return;
+      cancelAnimationFrame(recomposeFrame);
+      recomposeFrame = requestAnimationFrame(recomposeWide);
+    };
+
+    const geometryObserver = usesWideComposition && typeof ResizeObserver !== "undefined"
+      ? new ResizeObserver(scheduleWideRecompose)
+      : null;
+    const observeWideGeometry = () => {
+      if (!geometryObserver || !viewport) return;
+      geometryObserver.disconnect();
+      geometryObserver.observe(viewport);
+      geometryObserver.observe(owner);
+      wideLayoutOwners().forEach((element) => geometryObserver.observe(element));
+    };
 
     const focus = (detail: StageFocusDetail, pendingId?: number) => {
       const scheduled = ++scheduledFocus;
@@ -183,7 +269,8 @@ export function useStageCamera(
         if (scheduled !== scheduledFocus || contextRef.current !== context) return;
         const target = stages(owner, invalidatedKeys.current).find((stage) => stage.dataset.stageKey === detail.key);
         if (!target) return;
-        focusStage(owner, target, detail.align, prefersReducedMotion(), cameraInsets(owner, profile), profile);
+        if (usesWideComposition) recomposeWide();
+        else focusStage(owner, target, detail.align, prefersReducedMotion(), cameraInsets(owner, profile), profile);
         lastFocusedStage.current = { context, key: detail.key };
         if (pendingId && pendingFocus.current?.id === pendingId) pendingFocus.current = null;
       });
@@ -193,6 +280,11 @@ export function useStageCamera(
       if (contextRef.current !== context) return;
       const nextStages = stages(owner, invalidatedKeys.current);
       const next = nextStages.map((stage) => stage.dataset.stageKey!);
+      const topologyChanged = previous.length !== next.length || previous.some((key, index) => key !== next[index]);
+      if (topologyChanged) {
+        observeWideGeometry();
+        scheduleWideRecompose();
+      }
       const pending = pendingFocus.current?.context === context ? pendingFocus.current : null;
       const pendingTarget = pending && nextStages.find((stage) => stage.dataset.stageKey === pending.key);
       if (pendingTarget) {
@@ -234,6 +326,9 @@ export function useStageCamera(
 
     observer.observe(owner, { childList: true, subtree: true });
     window.addEventListener(STAGE_FOCUS_EVENT, focusRequested);
+    const finishWideScroll = () => { pendingWideScroll = null; };
+    owner.addEventListener("scrollend", finishWideScroll);
+    observeWideGeometry();
 
     const currentPending = pendingFocus.current?.context === context ? pendingFocus.current : null;
     const currentStages = stages(owner, invalidatedKeys.current);
@@ -245,13 +340,21 @@ export function useStageCamera(
         : null;
       const fallback = active ?? currentStages.at(-1);
       if (fallback) focus({ key: fallback.dataset.stageKey!, align: "forward" });
+      else scheduleWideRecompose();
     }
 
     return () => {
       scheduledFocus += 1;
       cancelAnimationFrame(frame);
+      cancelAnimationFrame(recomposeFrame);
       observer.disconnect();
+      geometryObserver?.disconnect();
       window.removeEventListener(STAGE_FOCUS_EVENT, focusRequested);
+      owner.removeEventListener("scrollend", finishWideScroll);
+      if (usesWideComposition) {
+        delete owner.dataset.wideStageFit;
+        owner.style.removeProperty("--lag-wide-stage-max");
+      }
     };
   }, [mainSelectionKey, profile, viewportRef, viewportRevision, workspaceRef]);
 }

--- a/shared/hooks/useStageCamera.ts
+++ b/shared/hooks/useStageCamera.ts
@@ -133,6 +133,55 @@ export function wideCompositionScrollDelta(bounds: HorizontalBounds, viewportWid
   return leadingOverflow > 0 ? -leadingOverflow : 0;
 }
 
+export function wideCameraScrollTarget({
+  scrollLeft,
+  scrollWidth,
+  clientWidth,
+  bounds,
+  safeLeft,
+  safeRight,
+  targetLeft,
+  targetWidth,
+  align = "nearest",
+  insets,
+}: {
+  scrollLeft: number;
+  scrollWidth: number;
+  clientWidth: number;
+  bounds: HorizontalBounds;
+  safeLeft: number;
+  safeRight: number;
+  targetLeft?: number;
+  targetWidth?: number;
+  align?: CameraFocusIntent;
+  insets: { leading: number; trailing: number };
+}) {
+  const maxScroll = Math.max(0, scrollWidth - clientWidth);
+  const clamp = (value: number) => Math.max(0, Math.min(value, maxScroll));
+  const minimumSafe = clamp(scrollLeft + bounds.right - safeRight);
+  const maximumSafe = clamp(scrollLeft + bounds.left - safeLeft);
+  const preferred = targetLeft === undefined || targetWidth === undefined
+    ? clamp(scrollLeft)
+    : cameraScrollTarget({
+        scrollLeft,
+        scrollWidth,
+        clientWidth,
+        targetLeft,
+        targetWidth,
+        profile: "wide",
+        align,
+        insets,
+      });
+
+  if (minimumSafe <= maximumSafe) return Math.max(minimumSafe, Math.min(preferred, maximumSafe));
+  const correction = bounds.right > safeRight
+    ? bounds.right - safeRight
+    : bounds.left < safeLeft
+      ? bounds.left - safeLeft
+      : 0;
+  return clamp(scrollLeft + correction);
+}
+
 function consumesGeometry(element: HTMLElement) {
   if (element.getAttribute("aria-hidden") === "true") return false;
   const style = getComputedStyle(element);
@@ -212,30 +261,57 @@ export function useStageCamera(
     let scheduledFocus = 0;
     let pendingWideScroll: number | null = null;
 
-    const wideLayoutOwners = (currentStages = stages(owner, invalidatedKeys.current)) => {
-      if (!viewport) return currentStages;
-      const fixed = [...viewport.querySelectorAll<HTMLElement>("[data-camera-layout-owner='fixed']")];
-      const surfaces = currentStages.length > 0
+    const wideSurfaceOwners = (currentStages = stages(owner, invalidatedKeys.current)) => {
+      const surfaces = (currentStages.length > 0
         ? currentStages
-        : [...owner.querySelectorAll<HTMLElement>("[data-camera-layout-owner='surface']")];
-      const fallback = surfaces.length === 0 && owner.firstElementChild instanceof HTMLElement
-        ? [owner.firstElementChild]
-        : [];
-      return [...new Set([...fixed, ...surfaces, ...fallback])].filter(consumesGeometry);
+        : [...owner.querySelectorAll<HTMLElement>("[data-camera-layout-owner='surface']")])
+        .filter(consumesGeometry);
+      return surfaces.length > 0
+        ? surfaces
+        : owner.firstElementChild instanceof HTMLElement && consumesGeometry(owner.firstElementChild)
+          ? [owner.firstElementChild]
+          : [];
     };
 
-    const recomposeWide = () => {
+    const wideLayoutOwners = (currentStages = stages(owner, invalidatedKeys.current)) => {
+      if (!viewport) return currentStages;
+      const fixed = [...viewport.querySelectorAll<HTMLElement>("[data-camera-layout-owner='fixed']")]
+        .filter(consumesGeometry);
+      return [...new Set([...fixed, ...wideSurfaceOwners(currentStages)])];
+    };
+
+    const layoutOwnerSnapshot = (currentStages = stages(owner, invalidatedKeys.current)) =>
+      wideLayoutOwners(currentStages).map((element) => ({
+        element,
+        kind: element.dataset.cameraLayoutOwner ?? (element.dataset.stageKey ? `stage:${element.dataset.stageKey}` : "fallback"),
+      }));
+    let previousLayoutOwners = layoutOwnerSnapshot();
+
+    const recomposeWide = (target?: HTMLElement, align: CameraFocusIntent = "nearest") => {
       if (!usesWideComposition || !viewport) return;
       const currentStages = stages(owner, invalidatedKeys.current);
       const stageCount = Math.max(1, currentStages.length || Number(Boolean(owner.firstElementChild)));
       owner.dataset.wideStageFit = "true";
       owner.style.setProperty("--lag-wide-stage-max", `${wideStageMaxWidth(owner.clientWidth, stageCount)}px`);
 
-      const bounds = activeHorizontalBounds(wideLayoutOwners(currentStages));
-      if (!bounds) return;
-      const delta = wideCompositionScrollDelta(bounds, viewport.clientWidth || window.innerWidth);
-      const maxScroll = Math.max(0, owner.scrollWidth - owner.clientWidth);
-      const next = Math.max(0, Math.min(owner.scrollLeft + delta, maxScroll));
+      const compositionBounds = activeHorizontalBounds(wideLayoutOwners(currentStages));
+      const surfaceBounds = activeHorizontalBounds(wideSurfaceOwners(currentStages));
+      if (!compositionBounds || !surfaceBounds) return;
+      const ownerRect = owner.getBoundingClientRect();
+      const viewportWidth = viewport.clientWidth || window.innerWidth;
+      const targetRect = target?.getBoundingClientRect();
+      const next = wideCameraScrollTarget({
+        scrollLeft: owner.scrollLeft,
+        scrollWidth: owner.scrollWidth,
+        clientWidth: owner.clientWidth,
+        bounds: surfaceBounds,
+        safeLeft: Math.max(24, ownerRect.left + 24),
+        safeRight: Math.min(viewportWidth - 24, ownerRect.right - 24),
+        targetLeft: targetRect ? owner.scrollLeft + targetRect.left - ownerRect.left : undefined,
+        targetWidth: targetRect?.width,
+        align,
+        insets: cameraInsets(owner, "wide"),
+      });
       if (Math.abs(next - owner.scrollLeft) < 0.5) {
         pendingWideScroll = null;
         return;
@@ -248,7 +324,7 @@ export function useStageCamera(
     const scheduleWideRecompose = () => {
       if (!usesWideComposition) return;
       cancelAnimationFrame(recomposeFrame);
-      recomposeFrame = requestAnimationFrame(recomposeWide);
+      recomposeFrame = requestAnimationFrame(() => recomposeWide());
     };
 
     const geometryObserver = usesWideComposition && typeof ResizeObserver !== "undefined"
@@ -269,7 +345,10 @@ export function useStageCamera(
         if (scheduled !== scheduledFocus || contextRef.current !== context) return;
         const target = stages(owner, invalidatedKeys.current).find((stage) => stage.dataset.stageKey === detail.key);
         if (!target) return;
-        if (usesWideComposition) recomposeWide();
+        if (usesWideComposition) {
+          pendingWideScroll = null;
+          recomposeWide(target, detail.align);
+        }
         else focusStage(owner, target, detail.align, prefersReducedMotion(), cameraInsets(owner, profile), profile);
         lastFocusedStage.current = { context, key: detail.key };
         if (pendingId && pendingFocus.current?.id === pendingId) pendingFocus.current = null;
@@ -281,9 +360,14 @@ export function useStageCamera(
       const nextStages = stages(owner, invalidatedKeys.current);
       const next = nextStages.map((stage) => stage.dataset.stageKey!);
       const topologyChanged = previous.length !== next.length || previous.some((key, index) => key !== next[index]);
-      if (topologyChanged) {
+      const nextLayoutOwners = layoutOwnerSnapshot(nextStages);
+      const layoutOwnersChanged = previousLayoutOwners.length !== nextLayoutOwners.length
+        || previousLayoutOwners.some(({ element, kind }, index) =>
+          element !== nextLayoutOwners[index]?.element || kind !== nextLayoutOwners[index]?.kind);
+      previousLayoutOwners = nextLayoutOwners;
+      const geometryOwnersChanged = topologyChanged || layoutOwnersChanged;
+      if (geometryOwnersChanged) {
         observeWideGeometry();
-        scheduleWideRecompose();
       }
       const pending = pendingFocus.current?.context === context ? pendingFocus.current : null;
       const pendingTarget = pending && nextStages.find((stage) => stage.dataset.stageKey === pending.key);
@@ -295,8 +379,14 @@ export function useStageCamera(
       const plan = stageFocusPlan(previous, next);
       previous = next;
       const target = plan && nextStages.find((stage) => stage.dataset.stageKey === plan.key);
-      if (!plan || !target || lastFocusedStage.current?.context === context && lastFocusedStage.current.key === plan.key) return;
-      if (plan.align === "forward" && target.dataset.stageAutoFocus === "false") return;
+      if (!plan || !target || lastFocusedStage.current?.context === context && lastFocusedStage.current.key === plan.key) {
+        if (geometryOwnersChanged) scheduleWideRecompose();
+        return;
+      }
+      if (plan.align === "forward" && target.dataset.stageAutoFocus === "false") {
+        scheduleWideRecompose();
+        return;
+      }
       if (pending) {
         invalidatedKeys.current.add(pending.key);
         pendingFocus.current = null;
@@ -324,7 +414,12 @@ export function useStageCamera(
       focus(pending, pending.id);
     };
 
-    observer.observe(owner, { childList: true, subtree: true });
+    observer.observe(owner, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ["aria-hidden", "data-camera-layout-owner", "data-stage-key"],
+    });
     window.addEventListener(STAGE_FOCUS_EVENT, focusRequested);
     const finishWideScroll = () => { pendingWideScroll = null; };
     owner.addEventListener("scrollend", finishWideScroll);

--- a/widgets/left-context/LeftContext.tsx
+++ b/widgets/left-context/LeftContext.tsx
@@ -47,7 +47,7 @@ export default function LeftContext({
   const reducedMotion = useReducedMotion();
   const visible = mode !== "hidden";
   return (
-    <div className="lag-left-anchor" data-context-present={visible}>
+    <div className="lag-left-anchor" data-camera-layout-owner="fixed" data-context-present={visible}>
       <AnimatePresence initial={false}>
         {visible ? (
         <motion.div


### PR DESCRIPTION
## Purpose

Close the approved Consumer v7 desktop active-stack fit defect.

Closes #92

## Visual Authority

Implemented from the approved Runtime Fidelity Review v2:

```text
R1 Desktop Camera / Active-Stack Fit
R2 minimum shared desktop geometry required for safe Wide3/Standard2 framing
```

Primary P0 evidence:

```text
WA-D-03
AS-D-03
```

## Delivered

- desktop active composition framed from visible bounds
- hidden contexts no longer reserve phantom width
- Quick Record form and Save kept inside the 1600×1000 safe viewport
- Role detail kept inside the desktop viewport
- Home desktop placement corrected without changing feature data
- recomposition on relevant topology/measurement/viewport change
- existing camera focus lineage preserved
- identical geometry across Warm Beige and Astral

## Preserved

- forward/back/same-depth camera semantics
- compact/mobile behavior
- reduced motion
- one shared component tree
- Gear content-blocked truth
- Direct Chat mutual exclusion
- System Shop fail-closed
- Marketplace separation
- Settings theme behavior
- all backend/API/domain contracts

## Exclusions

No mobile single-focus work, bottom-safe-area work, overlay redesign, typography hierarchy, screen-local content hierarchy, theme-material polish, backend/Admin/content change, or final visual sign-off.

## Validation

Focused shared camera/layout tests, representative Home/Journal/Role regressions, one final production build, and external runtime desktop capture evidence before merge-ready determination.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved wide-screen layouts with better spacing, centering, and responsive sizing.
  - Prevented unwanted horizontal overflow on large displays.
  - Automatically hides the empty left-side context area when it has no content.
  - Improved stage positioning and scrolling so focused content remains within safe viewport boundaries.
  - Enhanced layout adaptation when panels, content sizes, or viewport dimensions change.
  - Improved alignment when navigating between content stages on wide screens.
  - Ensured content panels fit within the available wide-screen layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->