### PR TITLE
[Visual] Fix mobile settled focus and bottom safe bounds

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -4567,20 +4567,11 @@ textarea.lag-journal-control {
   .lag-notification-dropdown {
     top: max(16px, env(safe-area-inset-top)) !important;
     right: 16px;
-    bottom: max(16px, env(safe-area-inset-bottom));
+    bottom: calc(148px + env(safe-area-inset-bottom));
     left: 16px !important;
     width: calc(100vw - 32px) !important;
     height: auto;
     max-height: none !important;
-  }
-
-  .lag-notification-backdrop {
-    position: fixed;
-    inset: 0;
-    z-index: 600000;
-    background: color-mix(in srgb, var(--lag-ambient) 72%, transparent);
-    backdrop-filter: blur(3px);
-    pointer-events: none;
   }
 
   .lag-notification-header {

--- a/app/globals.css
+++ b/app/globals.css
@@ -4080,8 +4080,11 @@ textarea.lag-journal-control {
 
 @media (max-width: 767px) {
   .lag-app-surface {
+    --lag-mobile-nav-clearance: calc(148px + env(safe-area-inset-bottom));
+    padding-bottom: var(--lag-mobile-nav-clearance);
     scroll-padding-left: calc(env(safe-area-inset-left) + 48px);
     scroll-padding-right: calc(env(safe-area-inset-right) + 24px);
+    scroll-padding-bottom: var(--lag-mobile-nav-clearance);
   }
 
   .lag-app-shell {
@@ -4090,7 +4093,7 @@ textarea.lag-journal-control {
     min-width: 100% !important;
     align-items: center;
     gap: var(--lag-space-3) !important;
-    padding: var(--lag-space-4) var(--lag-space-4) calc(140px + env(safe-area-inset-bottom)) !important;
+    padding: var(--lag-space-4) !important;
   }
 
   .lag-exchange-route {
@@ -4317,6 +4320,18 @@ textarea.lag-journal-control {
     grid-template-columns: minmax(0, 1fr);
   }
 
+  .lag-journal-segments {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .lag-journal-chip {
+    min-width: 0;
+    padding-inline: var(--lag-space-2);
+    font-size: 0.75rem;
+    letter-spacing: 0.02em;
+  }
+
   .lag-journal-entry {
     grid-template-columns: 60px minmax(0, 1fr);
     min-height: 132px;
@@ -4493,6 +4508,14 @@ textarea.lag-journal-control {
     max-height: calc(100svh - 156px);
   }
 
+  .lag-panel-stage[data-camera-active="true"] {
+    width: calc(100vw - 32px);
+  }
+
+  .lag-panel-stage[data-camera-active="true"] > .lag-panel-frame {
+    width: 100% !important;
+  }
+
   .lag-panel-rail {
     height: calc(100svh - 156px);
     min-height: 420px;
@@ -4500,6 +4523,7 @@ textarea.lag-journal-control {
 
   .lag-panel-body {
     max-height: calc(100svh - 230px) !important;
+    padding-bottom: calc(82px + env(safe-area-inset-bottom)) !important;
   }
 
   .lag-left-context {
@@ -4541,8 +4565,22 @@ textarea.lag-journal-control {
   }
 
   .lag-notification-dropdown {
+    top: max(16px, env(safe-area-inset-top)) !important;
+    right: 16px;
+    bottom: max(16px, env(safe-area-inset-bottom));
+    left: 16px !important;
     width: calc(100vw - 32px) !important;
-    max-height: calc(100dvh - 112px - env(safe-area-inset-bottom) - max(16px, env(safe-area-inset-top))) !important;
+    height: auto;
+    max-height: none !important;
+  }
+
+  .lag-notification-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 600000;
+    background: color-mix(in srgb, var(--lag-ambient) 72%, transparent);
+    backdrop-filter: blur(3px);
+    pointer-events: none;
   }
 
   .lag-notification-header {
@@ -4626,6 +4664,16 @@ textarea.lag-journal-control {
     height: 1px;
     overflow: hidden;
     clip-path: inset(50%);
+  }
+}
+
+@media (max-width: 380px) {
+  .lag-journal-segments {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .lag-journal-chip:last-child:nth-child(odd) {
+    grid-column: 1 / -1;
   }
 }
 

--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -136,6 +136,8 @@ describe("Home shell에서 feature surface를 routing할 때", () => {
     expect(css).toMatch(/@media \(min-width: 1200px\)[\s\S]*\.lag-left-anchor\[data-context-present="false"\]\s*{[^}]*display:\s*none/);
     expect(css).toMatch(/@media \(min-width: 1200px\)[\s\S]*\.lag-workspace\s*{[^}]*min-width:\s*0 !important;[^}]*overflow-x:\s*hidden/);
     expect(css).toContain("max-width: var(--lag-wide-stage-max)");
+    expect(css).toMatch(/\.lag-app-surface\s*{[^}]*padding-bottom:\s*var\(--lag-mobile-nav-clearance\);[^}]*scroll-padding-bottom:\s*var\(--lag-mobile-nav-clearance\)/);
+    expect(css).not.toContain("calc(140px + env(safe-area-inset-bottom))");
   });
 
   describe("인증된 player가 처음 진입하면", () => {

--- a/features/lifelog/JournalShell.test.tsx
+++ b/features/lifelog/JournalShell.test.tsx
@@ -232,6 +232,19 @@ describe("LifeLog Journal v7 surface", () => {
     await waitFor(() => expect(document.querySelector('[data-stage-key="lifelog-quick-record"]')).not.toBeInTheDocument());
   });
 
+  it("keeps mobile Quick Record labels and its Save action in the shared scroll contract", () => {
+    const css = readFileSync("app/globals.css", "utf8");
+    const panelFrame = readFileSync("widgets/right-panels/ui/PanelFrame.tsx", "utf8");
+    const mobile = css.slice(css.indexOf("@media (max-width: 767px)"));
+
+    expect(mobile).toMatch(/\.lag-journal-segments\s*{[^}]*display:\s*grid;[^}]*repeat\(3, minmax\(0, 1fr\)\)/);
+    expect(mobile).toMatch(/@media \(max-width: 380px\)[\s\S]*repeat\(2, minmax\(0, 1fr\)\)/);
+    expect(mobile).toMatch(/\.lag-panel-stage\[data-camera-active="true"\][\s\S]*?> \.lag-panel-frame\s*{[^}]*width:\s*100% !important/);
+    expect(css).toMatch(/\.lag-panel-body\s*{[^}]*overflow-y:\s*auto/);
+    expect(mobile).toMatch(/\.lag-panel-body\s*{[^}]*padding-bottom:\s*calc\(82px \+ env\(safe-area-inset-bottom\)\) !important/);
+    expect(panelFrame).toContain("panelContentBottomSafePadding");
+  });
+
   it("represents every current Quick Record type-specific field", async () => {
     await openQuickRecord();
     expect(screen.getByLabelText("Collection category")).toBeInTheDocument();

--- a/features/notification/NotificationBell.test.tsx
+++ b/features/notification/NotificationBell.test.tsx
@@ -92,16 +92,30 @@ describe("NotificationBell canonical surface", () => {
 
   it("closes on outside click while retaining viewport placement wiring", async () => {
     render(<NotificationBell />);
-    fireEvent.click(screen.getByRole("button", { name: "Notifications, 7 unread" }));
+    const trigger = screen.getByRole("button", { name: "Notifications, 7 unread" });
+    fireEvent.click(trigger);
     expect(screen.getByRole("dialog", { name: "Notifications" })).toBeInTheDocument();
     fireEvent.mouseDown(document.body);
     await waitFor(() => expect(screen.queryByRole("dialog", { name: "Notifications" })).not.toBeInTheDocument());
+    expect(trigger).toHaveFocus();
 
     const source = readFileSync("features/notification/NotificationBell.tsx", "utf8");
     expect(source).toContain("notificationPopupPosition");
     expect(source).toContain("ResizeObserver");
     const css = readFileSync("app/globals.css", "utf8");
-    expect(css).toContain("max-height: calc(100dvh - 112px - env(safe-area-inset-bottom)");
+    expect(css).toContain("bottom: max(16px, env(safe-area-inset-bottom))");
+  });
+
+  it("closes on Escape and restores focus to the notification trigger", async () => {
+    render(<NotificationBell />);
+    const trigger = screen.getByRole("button", { name: "Notifications, 7 unread" });
+    fireEvent.click(trigger);
+    screen.getByRole("button", { name: "Close Notifications" }).focus();
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    await waitFor(() => expect(screen.queryByRole("dialog", { name: "Notifications" })).not.toBeInTheDocument());
+    expect(trigger).toHaveFocus();
   });
 
   it("renders deterministic initial timestamp text without render-time Date.now", () => {

--- a/features/notification/NotificationBell.test.tsx
+++ b/features/notification/NotificationBell.test.tsx
@@ -90,32 +90,52 @@ describe("NotificationBell canonical surface", () => {
     expect(screen.getByText("2026-08-18 12:34 UTC").closest("time")).toHaveAttribute("dateTime", "2026-08-18T12:34:56Z");
   });
 
-  it("closes on outside click while retaining viewport placement wiring", async () => {
-    render(<NotificationBell />);
+  it("dismisses on outside interaction without stealing focus from the chosen control", async () => {
+    render(<><NotificationBell /><button type="button">Player outside</button></>);
     const trigger = screen.getByRole("button", { name: "Notifications, 7 unread" });
-    fireEvent.click(trigger);
+    const outside = screen.getByRole("button", { name: "Player outside" });
+    fireEvent.click(trigger, { detail: 1 });
     expect(screen.getByRole("dialog", { name: "Notifications" })).toBeInTheDocument();
-    fireEvent.mouseDown(document.body);
+    outside.focus();
+    fireEvent.mouseDown(outside);
     await waitFor(() => expect(screen.queryByRole("dialog", { name: "Notifications" })).not.toBeInTheDocument());
-    expect(trigger).toHaveFocus();
+    expect(outside).toHaveFocus();
 
     const source = readFileSync("features/notification/NotificationBell.tsx", "utf8");
     expect(source).toContain("notificationPopupPosition");
     expect(source).toContain("ResizeObserver");
     const css = readFileSync("app/globals.css", "utf8");
-    expect(css).toContain("bottom: max(16px, env(safe-area-inset-bottom))");
+    expect(css).toContain("bottom: calc(148px + env(safe-area-inset-bottom))");
+    expect(css).not.toContain(".lag-notification-backdrop");
   });
 
-  it("closes on Escape and restores focus to the notification trigger", async () => {
+  it.each(["Escape", "Close"])("keyboard-opens into the panel and %s restores trigger focus", async (method) => {
     render(<NotificationBell />);
     const trigger = screen.getByRole("button", { name: "Notifications, 7 unread" });
-    fireEvent.click(trigger);
-    screen.getByRole("button", { name: "Close Notifications" }).focus();
+    trigger.focus();
+    fireEvent.click(trigger, { detail: 0 });
+    const closeButton = screen.getByRole("button", { name: "Close Notifications" });
+    await waitFor(() => expect(closeButton).toHaveFocus());
 
-    fireEvent.keyDown(document, { key: "Escape" });
+    if (method === "Escape") fireEvent.keyDown(document, { key: "Escape" });
+    else fireEvent.click(closeButton);
 
     await waitFor(() => expect(screen.queryByRole("dialog", { name: "Notifications" })).not.toBeInTheDocument());
     expect(trigger).toHaveFocus();
+  });
+
+  it("returns focus from detail to the selected visible inbox row", async () => {
+    render(<NotificationBell />);
+    const trigger = screen.getByRole("button", { name: "Notifications, 7 unread" });
+    fireEvent.click(trigger, { detail: 0 });
+    await waitFor(() => expect(screen.getByRole("button", { name: "Close Notifications" })).toHaveFocus());
+
+    const selectedRow = screen.getByText("Canonical body").closest("button")!;
+    fireEvent.click(selectedRow);
+    fireEvent.click(within(screen.getByLabelText("Notification detail")).getByRole("button", { name: /Back to inbox/ }));
+
+    await waitFor(() => expect(selectedRow).toHaveFocus());
+    expect(screen.queryByLabelText("Notification detail")).not.toBeInTheDocument();
   });
 
   it("renders deterministic initial timestamp text without render-time Date.now", () => {

--- a/features/notification/NotificationBell.tsx
+++ b/features/notification/NotificationBell.tsx
@@ -41,13 +41,13 @@ function NotificationRow({ notification, pending, selected, onSelect, onMarkRead
   notification: NotificationInfo;
   pending: boolean;
   selected: boolean;
-  onSelect: (id: number) => void;
+  onSelect: (id: number, trigger: HTMLButtonElement) => void;
   onMarkRead: (id: number) => void;
 }) {
   const meta = metaFor(notification.type);
   return (
     <article className="lag-notification-row" data-read={notification.read} data-selected={selected}>
-      <button type="button" className="lag-notification-select" aria-pressed={selected} onClick={() => onSelect(notification.id)}>
+      <button type="button" className="lag-notification-select" aria-pressed={selected} onClick={(event) => onSelect(notification.id, event.currentTarget)}>
         <TypeMark notification={notification} />
         <span className="lag-notification-copy">
           <span className="lag-notification-row-meta"><span>{meta.label}</span><span>{notification.read ? "Read" : "Unread"}</span></span>
@@ -70,14 +70,24 @@ export function NotificationBell() {
   const panelRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const popupRef = useRef<HTMLDivElement>(null);
+  const closeRef = useRef<HTMLButtonElement>(null);
+  const selectedTriggerRef = useRef<HTMLButtonElement | null>(null);
+  const focusOnOpenRef = useRef(false);
+  const focusInboxRef = useRef(false);
   const [popupPosition, setPopupPosition] = useState<FloatingPosition | null>(null);
   const selected = state.inbox.find(({ id }) => id === selectedId) ?? null;
 
-  const close = useCallback(() => {
+  const dismiss = useCallback(() => {
+    focusOnOpenRef.current = false;
+    focusInboxRef.current = false;
     setOpen(false);
     setSelectedId(null);
-    triggerRef.current?.focus();
   }, []);
+
+  const close = useCallback(() => {
+    dismiss();
+    triggerRef.current?.focus({ preventScroll: true });
+  }, [dismiss]);
 
   const placePopup = useCallback(() => {
     const anchor = triggerRef.current?.getBoundingClientRect();
@@ -98,15 +108,29 @@ export function NotificationBell() {
     };
   }, [open, placePopup]);
 
+  useLayoutEffect(() => {
+    if (open && popupPosition && focusOnOpenRef.current) {
+      focusOnOpenRef.current = false;
+      closeRef.current?.focus({ preventScroll: true });
+    }
+  }, [open, popupPosition]);
+
+  useLayoutEffect(() => {
+    if (open && selectedId === null && focusInboxRef.current) {
+      focusInboxRef.current = false;
+      (selectedTriggerRef.current ?? closeRef.current)?.focus({ preventScroll: true });
+    }
+  }, [open, selectedId]);
+
   useEffect(() => {
     if (!open) return;
     const closeOutside = (event: MouseEvent) => {
       const target = event.target as Node;
-      if (!panelRef.current?.contains(target) && !popupRef.current?.contains(target)) close();
+      if (!panelRef.current?.contains(target) && !popupRef.current?.contains(target)) dismiss();
     };
     document.addEventListener("mousedown", closeOutside);
     return () => document.removeEventListener("mousedown", closeOutside);
-  }, [close, open]);
+  }, [dismiss, open]);
 
   useEffect(() => {
     if (!open) return;
@@ -117,10 +141,24 @@ export function NotificationBell() {
     return () => document.removeEventListener("keydown", closeOnEscape);
   }, [close, open]);
 
-  const toggle = () => {
+  const toggle = (event: React.MouseEvent<HTMLButtonElement>) => {
     if (!open && !state.inboxLoaded && !state.inboxLoading) void state.loadInbox();
     if (open) close();
-    else setOpen(true);
+    else {
+      focusOnOpenRef.current = event.detail === 0;
+      setPopupPosition(null);
+      setOpen(true);
+    }
+  };
+
+  const selectNotification = (id: number, trigger: HTMLButtonElement) => {
+    selectedTriggerRef.current = trigger;
+    setSelectedId(id);
+  };
+
+  const returnToInbox = () => {
+    focusInboxRef.current = true;
+    setSelectedId(null);
   };
 
   return (
@@ -147,17 +185,7 @@ export function NotificationBell() {
       <UtilityPortal>
         <AnimatePresence>
           {open ? (
-            <>
-              <motion.div
-                aria-hidden
-                className="lag-notification-backdrop"
-                key="notification-backdrop"
-                initial={reducedMotion ? false : { opacity: 0 }}
-                animate={{ opacity: 1 }}
-                exit={{ opacity: 0 }}
-                transition={{ duration: reducedMotion ? 0 : 0.16 }}
-              />
-              <motion.div
+            <motion.div
                 ref={popupRef}
                 role="dialog"
                 aria-label="Notifications"
@@ -175,7 +203,7 @@ export function NotificationBell() {
                 <div><span>Current Player</span><h2>Notifications</h2></div>
                 <div>
                   <button type="button" disabled={state.markAllPending} onClick={() => void state.markAllRead()} className="lag-notification-action">{state.markAllPending ? "Saving..." : "Mark all read"}</button>
-                  <button type="button" aria-label="Close Notifications" onClick={close} className="lag-notification-action">Close</button>
+                  <button ref={closeRef} type="button" aria-label="Close Notifications" onClick={close} className="lag-notification-action">Close</button>
                 </div>
               </header>
 
@@ -189,14 +217,14 @@ export function NotificationBell() {
                   <div className="lag-notification-list">
                     {state.inboxLoading ? <p role="status" className="lag-notification-empty">Loading notifications...</p> : null}
                     {!state.inboxLoading && state.inboxLoaded && state.inbox.length === 0 ? <p className="lag-notification-empty">No notifications</p> : null}
-                    {state.inbox.map((notification) => <NotificationRow key={notification.id} notification={notification} pending={state.pendingId === notification.id} selected={selectedId === notification.id} onSelect={setSelectedId} onMarkRead={(id) => void state.markRead(id)} />)}
+                    {state.inbox.map((notification) => <NotificationRow key={notification.id} notification={notification} pending={state.pendingId === notification.id} selected={selectedId === notification.id} onSelect={selectNotification} onMarkRead={(id) => void state.markRead(id)} />)}
                     {state.hasMore ? <button type="button" className="lag-notification-load-older" disabled={state.olderLoading} onClick={() => void state.loadOlder()}>{state.olderLoading ? "Loading..." : "Load older"}</button> : null}
                   </div>
                 </section>
 
                 {selected ? (
                   <section className="lag-notification-detail" aria-label="Notification detail">
-                    <header><button type="button" className="lag-notification-action" onClick={() => setSelectedId(null)}>← Back to inbox</button><span>{selected.read ? "Read" : "Unread"}</span></header>
+                    <header><button type="button" className="lag-notification-action" onClick={returnToInbox}>← Back to inbox</button><span>{selected.read ? "Read" : "Unread"}</span></header>
                     <div className="lag-notification-detail-content">
                       <TypeMark notification={selected} />
                       <span>{metaFor(selected.type).label}</span>
@@ -208,8 +236,7 @@ export function NotificationBell() {
                   </section>
                 ) : null}
               </div>
-              </motion.div>
-            </>
+            </motion.div>
           ) : null}
         </AnimatePresence>
       </UtilityPortal>

--- a/features/notification/NotificationBell.tsx
+++ b/features/notification/NotificationBell.tsx
@@ -76,6 +76,7 @@ export function NotificationBell() {
   const close = useCallback(() => {
     setOpen(false);
     setSelectedId(null);
+    triggerRef.current?.focus();
   }, []);
 
   const placePopup = useCallback(() => {
@@ -105,6 +106,15 @@ export function NotificationBell() {
     };
     document.addEventListener("mousedown", closeOutside);
     return () => document.removeEventListener("mousedown", closeOutside);
+  }, [close, open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") close();
+    };
+    document.addEventListener("keydown", closeOnEscape);
+    return () => document.removeEventListener("keydown", closeOnEscape);
   }, [close, open]);
 
   const toggle = () => {
@@ -137,20 +147,30 @@ export function NotificationBell() {
       <UtilityPortal>
         <AnimatePresence>
           {open ? (
-            <motion.div
-              ref={popupRef}
-              role="dialog"
-              aria-label="Notifications"
-              key="notification-dropdown"
-              initial={reducedMotion ? false : { opacity: 0, y: -6, scale: 0.98 }}
-              animate={{ opacity: 1, y: 0, scale: 1 }}
-              exit={reducedMotion ? { opacity: 0 } : { opacity: 0, y: -6, scale: 0.98 }}
-              transition={{ duration: reducedMotion ? 0 : 0.16, ease: "easeOut" }}
-              className="lag-notification-dropdown"
-              data-detail={selected !== null}
-              data-view={selected ? "detail" : "inbox"}
-              style={{ position: "fixed", left: popupPosition?.x ?? 16, top: popupPosition?.y ?? 16, zIndex: 600100, visibility: popupPosition ? "visible" : "hidden" }}
-            >
+            <>
+              <motion.div
+                aria-hidden
+                className="lag-notification-backdrop"
+                key="notification-backdrop"
+                initial={reducedMotion ? false : { opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                transition={{ duration: reducedMotion ? 0 : 0.16 }}
+              />
+              <motion.div
+                ref={popupRef}
+                role="dialog"
+                aria-label="Notifications"
+                key="notification-dropdown"
+                initial={reducedMotion ? false : { opacity: 0, y: -6, scale: 0.98 }}
+                animate={{ opacity: 1, y: 0, scale: 1 }}
+                exit={reducedMotion ? { opacity: 0 } : { opacity: 0, y: -6, scale: 0.98 }}
+                transition={{ duration: reducedMotion ? 0 : 0.16, ease: "easeOut" }}
+                className="lag-notification-dropdown"
+                data-detail={selected !== null}
+                data-view={selected ? "detail" : "inbox"}
+                style={{ position: "fixed", left: popupPosition?.x ?? 16, top: popupPosition?.y ?? 16, zIndex: 600100, visibility: popupPosition ? "visible" : "hidden" }}
+              >
               <header className="lag-notification-header">
                 <div><span>Current Player</span><h2>Notifications</h2></div>
                 <div>
@@ -188,7 +208,8 @@ export function NotificationBell() {
                   </section>
                 ) : null}
               </div>
-            </motion.div>
+              </motion.div>
+            </>
           ) : null}
         </AnimatePresence>
       </UtilityPortal>

--- a/shared/hooks/useStageCamera.test.ts
+++ b/shared/hooks/useStageCamera.test.ts
@@ -249,14 +249,19 @@ describe("stage camera contract", () => {
   });
 
   it("focuses a new child topology but ignores arbitrary child-list changes", async () => {
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: 390 });
     const { owner, scrollTo } = cameraOwner();
     const root = appendStage(owner, "root", 100);
     const ref = { current: owner };
     renderHook(() => useStageCamera(ref, ref, "player"));
+    expect(root).toHaveAttribute("data-camera-active", "true");
     scrollTo.mockClear();
 
-    act(() => appendStage(owner, "detail", 600));
+    let detail!: HTMLElement;
+    act(() => { detail = appendStage(owner, "detail", 600); });
     await waitFor(() => expect(scrollTo).toHaveBeenCalledTimes(1));
+    expect(root).not.toHaveAttribute("data-camera-active");
+    expect(detail).toHaveAttribute("data-camera-active", "true");
     scrollTo.mockClear();
 
     act(() => root.append(document.createElement("span")));

--- a/shared/hooks/useStageCamera.ts
+++ b/shared/hooks/useStageCamera.ts
@@ -345,6 +345,11 @@ export function useStageCamera(
         if (scheduled !== scheduledFocus || contextRef.current !== context) return;
         const target = stages(owner, invalidatedKeys.current).find((stage) => stage.dataset.stageKey === detail.key);
         if (!target) return;
+        if (profile === "mobile") {
+          owner.querySelectorAll<HTMLElement>("[data-camera-active]")
+            .forEach((stage) => stage.removeAttribute("data-camera-active"));
+          target.dataset.cameraActive = "true";
+        }
         if (usesWideComposition) {
           pendingWideScroll = null;
           recomposeWide(target, detail.align);
@@ -450,6 +455,8 @@ export function useStageCamera(
       geometryObserver?.disconnect();
       window.removeEventListener(STAGE_FOCUS_EVENT, focusRequested);
       owner.removeEventListener("scrollend", finishWideScroll);
+      owner.querySelectorAll<HTMLElement>("[data-camera-active]")
+        .forEach((stage) => stage.removeAttribute("data-camera-active"));
       if (usesWideComposition) {
         delete owner.dataset.wideStageFit;
         owner.style.removeProperty("--lag-wide-stage-max");


### PR DESCRIPTION
## Purpose
Complete the corrected mobile shared wave2A for Consumer v7 while preserving the approved non-modal Notification utility contract.

Closes #95
Refs #94

## Scope
- Retains the settled mobile active-stage width/origin, real scroll-owner bottom clearance, and Quick Record control reflow.
- Bounds mobile Notifications above participating utilities/navigation and keeps the inbox internally scrollable.
- Removes the mismatched full-screen veil without introducing modal semantics, a focus trap, or background inertness.
- Gives keyboard-open Notifications visible in-panel focus; restores the trigger on explicit Close/Escape with scroll prevention; preserves outside dismissal/navigation focus; restores the selected inbox row after detail Back.

## Preserved
PR #93 desktop camera fit, same-tree Warm Beige/Astral Neutral themes, navigation/selection/scroll behavior, Notification content and actions, Quick Record capabilities, Gear gates, System Shop fail-closed behavior, Marketplace separation, and Connections/Direct Chat mutual exclusion.

## Excluded
Other desktop visual correction waves, mobile Home priority redesign, Gear API integration, content activation, P2 polish, unrelated assets, Backend, and Admin.

## Validation
- `npm test -- --run features/notification/NotificationBell.test.tsx`: PASS — 9 tests.
- `npm test -- --run shared/hooks/useStageCamera.test.ts features/lifelog/JournalShell.test.tsx app/page.test.tsx`: PASS — 80 tests.
- `npm run build`: PASS — production compile, TypeScript, and 9/9 static pages.
- Runtime: PASS — 20/20 mobile references at 450x900 DPR2, 8/8 desktop regressions at 1600x1000 DPR1, and 4/4 non-reference reduced-motion diagnostics at 360x800 DPR1.
- Geometry/reachability: PASS — 32/32 rows, including Notification safe bounds, real internal scroll ownership, final action reachability, open/back/close focus, outside navigation, and stable-settled signals.

## Evidence provenance
- Reviewed/source HEAD: `265fe1eb902d55836b2c367472fa6b31ab97a91f`
- Exact uncommitted review patch SHA-256: `441858c797d22a4cd43a0c17702f99d5371278660117ab823f286ef074cd8884`
- Deterministic runtime used explicit mock mode; it is not Backend/DB activation evidence.

This evidence closes only mobile wave2A review. It is not final 42-screen Consumer v7 sign-off.
