### PR TITLE
[Visual] Refine desktop Consumer hierarchy and notification bounds

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -4668,6 +4668,120 @@ textarea.lag-journal-control {
   }
 }
 
+/* Issue 97 desktop hierarchy correction; mobile keeps the shared PR #96 contract. */
+@media (min-width: 1200px) {
+  .lag-home-grid {
+    grid-template-columns: minmax(0, 1.3fr) minmax(320px, 0.7fr);
+    align-items: stretch;
+  }
+
+  .lag-home-section-journey {
+    grid-column: 1;
+    grid-row: 1 / span 2;
+  }
+
+  .lag-home-section-journal {
+    grid-column: 2;
+    grid-row: 1;
+  }
+
+  .lag-home-section-achievements {
+    grid-column: 2;
+    grid-row: 2;
+  }
+
+  .lag-home-section-roles {
+    grid-row: 3;
+  }
+
+  .lag-journal-shell:not(:has([data-stage-key="lifelog-quick-record"], [data-stage-key="lifelog-journal-detail"]))
+    [data-stage-key="lifelog-journal"] {
+    width: min(820px, calc(100vw - 500px));
+    max-width: min(820px, calc(100vw - 500px));
+  }
+
+  .lag-journal-shell:not(:has([data-stage-key="lifelog-quick-record"], [data-stage-key="lifelog-journal-detail"]))
+    [data-stage-key="lifelog-journal"] .lag-panel-frame {
+    width: min(820px, calc(100vw - 500px)) !important;
+    max-width: min(820px, calc(100vw - 500px)) !important;
+  }
+
+  .lag-journal-shell [data-stage-key="lifelog-journal"] .lag-panel-body,
+  .lag-journey-shell .lag-panel-body,
+  .lag-growth-shell .lag-panel-body {
+    max-height: min(60vh, 600px) !important;
+  }
+
+  .lag-growth-shell .lag-panel-title {
+    overflow: visible;
+    white-space: normal;
+    text-align: center;
+    text-overflow: clip;
+  }
+}
+
+@media (min-width: 1500px) {
+  .lag-journey-shell:not(:has([data-stage-key="journey-detail"]))
+    [data-stage-key="journey-root"] {
+    width: 280px;
+    max-width: 280px;
+  }
+
+  .lag-journey-shell:not(:has([data-stage-key="journey-detail"]))
+    [data-stage-key="journey-root"] .lag-panel-frame {
+    width: 280px !important;
+    max-width: 280px !important;
+  }
+
+  .lag-journey-shell:not(:has([data-stage-key="journey-detail"]))
+    [data-stage-key="journey-list"] {
+    width: 760px;
+    max-width: 760px;
+  }
+
+  .lag-journey-shell:not(:has([data-stage-key="journey-detail"]))
+    [data-stage-key="journey-list"] .lag-panel-frame {
+    width: 760px !important;
+    max-width: 760px !important;
+  }
+
+  .lag-workspace > div:has(> .lag-growth-shell):not(:has([data-stage-key="player-growth-change-detail"]))
+    > .lag-panel-rail[data-main="player"] [data-stage-key="player-stage-0"] {
+    width: 220px;
+    max-width: 220px;
+  }
+
+  .lag-workspace > div:has(> .lag-growth-shell):not(:has([data-stage-key="player-growth-change-detail"]))
+    > .lag-panel-rail[data-main="player"] .lag-panel-frame {
+    width: 220px !important;
+    max-width: 220px !important;
+  }
+
+  .lag-workspace > div:has(> .lag-growth-shell):not(:has([data-stage-key="player-growth-change-detail"]))
+    [data-stage-key="player-growth-profile"] {
+    width: 360px;
+    max-width: 360px;
+  }
+
+  .lag-workspace > div:has(> .lag-growth-shell):not(:has([data-stage-key="player-growth-change-detail"]))
+    [data-stage-key="player-growth-profile"] .lag-panel-frame {
+    width: 360px !important;
+    max-width: 360px !important;
+  }
+
+  .lag-workspace > div:has(> .lag-growth-shell):not(:has([data-stage-key="player-growth-change-detail"]))
+    [data-stage-key="player-growth-history"] {
+    width: 296px;
+    max-width: 296px;
+  }
+
+  .lag-workspace > div:has(> .lag-growth-shell):not(:has([data-stage-key="player-growth-change-detail"]))
+    [data-stage-key="player-growth-history"] .lag-panel-frame {
+    width: 296px !important;
+    max-width: 296px !important;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .lag-app-surface,
   .lag-orb-nav,

--- a/features/home/HomeShell.test.tsx
+++ b/features/home/HomeShell.test.tsx
@@ -204,6 +204,7 @@ describe("Home world summary를 표시할 때", () => {
     const css = readFileSync("app/globals.css", "utf8");
 
     expect(source).not.toContain("style=");
+    expect(css).toMatch(/@media \(min-width: 1200px\)[\s\S]*?\.lag-home-section-journey\s*\{[\s\S]*?grid-row: 1 \/ span 2/);
     expect(css).toMatch(/@media \(max-width: 980px\)[\s\S]*?\.lag-home-grid\s*\{[\s\S]*?grid-template-columns: minmax\(0, 1fr\)/);
     expect(css).toMatch(/@media \(max-width: 767px\)[\s\S]*?\.lag-home-role-summary,[\s\S]*?grid-template-columns: minmax\(0, 1fr\)/);
   });

--- a/features/lifelog/JournalShell.test.tsx
+++ b/features/lifelog/JournalShell.test.tsx
@@ -74,6 +74,7 @@ describe("LifeLog Journal v7 surface", () => {
 
     const css = readFileSync("app/globals.css", "utf8");
     expect(css).toContain('[data-stage-key="lifelog-journal"]');
+    expect(css).toContain('max-width: min(820px, calc(100vw - 500px))');
     expect(css).toContain("var(--lag-control-bg)");
     expect(css).toContain("@media (max-width: 767px)");
     expect(css).toContain(".lag-orb-column");

--- a/features/notification/NotificationBell.test.tsx
+++ b/features/notification/NotificationBell.test.tsx
@@ -103,6 +103,7 @@ describe("NotificationBell canonical surface", () => {
 
     const source = readFileSync("features/notification/NotificationBell.tsx", "utf8");
     expect(source).toContain("notificationPopupPosition");
+    expect(source).toContain("popup.offsetHeight");
     expect(source).toContain("ResizeObserver");
     const css = readFileSync("app/globals.css", "utf8");
     expect(css).toContain("bottom: calc(148px + env(safe-area-inset-bottom))");

--- a/features/notification/NotificationBell.tsx
+++ b/features/notification/NotificationBell.tsx
@@ -91,9 +91,9 @@ export function NotificationBell() {
 
   const placePopup = useCallback(() => {
     const anchor = triggerRef.current?.getBoundingClientRect();
-    const popup = popupRef.current?.getBoundingClientRect();
+    const popup = popupRef.current;
     if (!anchor || !popup) return;
-    setPopupPosition(notificationPopupPosition(anchor, { width: popup.width, height: popup.height }, { width: window.innerWidth, height: window.innerHeight }));
+    setPopupPosition(notificationPopupPosition(anchor, { width: popup.offsetWidth, height: popup.offsetHeight }, { width: window.innerWidth, height: window.innerHeight }));
   }, []);
 
   useLayoutEffect(() => {

--- a/features/player/GrowthShell.test.tsx
+++ b/features/player/GrowthShell.test.tsx
@@ -57,6 +57,7 @@ describe("v7 Growth surface를 사용할 때", () => {
     expect(growthCss).not.toMatch(/#[0-9a-f]{3,8}|rgba?\(/i);
     expect(css).toContain('@media (max-width: 767px)');
     expect(css).toContain('[data-stage-key="player-growth-change-detail"]');
+    expect(css).toMatch(/@media \(min-width: 1500px\)[\s\S]*?\[data-stage-key="player-growth-profile"\] \.lag-panel-frame\s*\{[\s\S]*?width: 360px/);
   });
 
   it("empty extra stats와 real history를 표시하되 첫 change를 자동 선택하지 않는다", async () => {

--- a/features/quests/JourneyShell.test.tsx
+++ b/features/quests/JourneyShell.test.tsx
@@ -182,6 +182,7 @@ describe("Journey에서 Quest와 QuestRoute를 볼 때", () => {
     const journeyCss = css.slice(css.indexOf("/* v7 Journey"), css.indexOf(".lag-state-error"));
     expect(journeyCss).toContain("var(--lag-muted-surface)");
     expect(journeyCss).not.toMatch(/#[0-9a-f]{3,8}|rgba?\(/i);
+    expect(css).toMatch(/@media \(min-width: 1500px\)[\s\S]*?\[data-stage-key="journey-list"\] \.lag-panel-frame\s*\{[\s\S]*?width: 760px/);
   });
 
   describe("Current Quest의 상태와 next action을 확인하면", () => {


### PR DESCRIPTION
## Purpose
Complete the next Consumer v7 desktop visual correction wave after the merged mobile shared correction.

## Scope
- Refine desktop Home hierarchy.
- Refine Journal desktop density and hierarchy.
- Refine Journey / QuestRoute visual hierarchy.
- Refine Growth desktop width/header hierarchy.
- Correct remaining desktop Notification bounds/focus presentation where applicable.

## Preserved
- PR #93 desktop safe-fit foundation.
- PR #96 mobile focus/safe-area/Quick Record/Notification behavior.
- Same-tree Warm Beige and Astral Neutral themes.
- Existing navigation, selection, scroll, product-policy, and capability gates.

## Excluded
Mobile redesign, Gear/API integration, content activation, Backend, Admin, and unrelated P2 polish.

## Validation
- Focused tests: PASS — 6 files / 63 tests (`HomeShell`, `JournalShell`, `JourneyShell`, `GrowthShell`, `NotificationBell`, viewport geometry).
- Affected regression tests: PASS — 2 files / 65 tests (`app/page`, shared stage camera).
- Production build: PASS — the single final `npm run build` compiled, type-checked, collected page data, and generated 9/9 static pages.
- Desktop dual-theme runtime evidence: PASS — 14 captures at 1600x1000 DPR1 (Home, Journal, Journey/QuestRoute detail, Growth, Notification, Quick Record, Role in Warm Beige and Astral); all geometry/hierarchy checks passed.
- Mobile regression evidence: PASS — 4 captures at 360x800 DPR1 (Quick Record and Notification in both themes); Save reachability, protected bottom bounds, keyboard-open, Escape, Close, detail-Back, and outside-dismiss checks passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Improved desktop layouts for Home, Journal, Journey, and Growth screens at wide viewport sizes.
  * Adjusted panel widths, spacing, and height limits for better readability.
  * Allowed Growth panel titles to wrap visibly.
  * Refined wide-screen Journey and Growth stage layouts.

* **Bug Fixes**
  * Improved notification popup positioning by using its rendered dimensions for placement.

* **Tests**
  * Added coverage to verify responsive layouts and notification popup positioning across supported screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->