### PR TITLE
[Visual] Refine mobile Home first-view priority

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -4668,6 +4668,26 @@ textarea.lag-journal-control {
   }
 }
 
+/* Issue 99 mobile Home first-view priority. */
+@media (max-width: 767px) {
+  .lag-home-section-journal .lag-home-section-header,
+  .lag-home-section-journey .lag-home-subsection-header {
+    align-items: center;
+    flex-direction: row;
+  }
+
+  .lag-home-section-journal .lag-home-action,
+  .lag-home-section-journey .lag-home-action {
+    width: auto;
+  }
+
+  .lag-home-section-journal .lag-home-list {
+    grid-auto-columns: 85%;
+    grid-auto-flow: column;
+    overflow-x: auto;
+  }
+}
+
 /* Issue 97 desktop hierarchy correction; mobile keeps the shared PR #96 contract. */
 @media (min-width: 1200px) {
   .lag-home-grid {

--- a/features/home/HomeShell.test.tsx
+++ b/features/home/HomeShell.test.tsx
@@ -207,5 +207,6 @@ describe("Home world summary를 표시할 때", () => {
     expect(css).toMatch(/@media \(min-width: 1200px\)[\s\S]*?\.lag-home-section-journey\s*\{[\s\S]*?grid-row: 1 \/ span 2/);
     expect(css).toMatch(/@media \(max-width: 980px\)[\s\S]*?\.lag-home-grid\s*\{[\s\S]*?grid-template-columns: minmax\(0, 1fr\)/);
     expect(css).toMatch(/@media \(max-width: 767px\)[\s\S]*?\.lag-home-role-summary,[\s\S]*?grid-template-columns: minmax\(0, 1fr\)/);
+    expect(css).toMatch(/@media \(max-width: 767px\)[\s\S]*?\.lag-home-section-journal \.lag-home-list\s*\{[\s\S]*?grid-auto-flow: column;[\s\S]*?overflow-x: auto/);
   });
 });


### PR DESCRIPTION
## Purpose
Close the remaining Consumer v7 mobile Home first-view priority/height correction without changing Home semantics or the merged PR #96 / PR #98 baselines.

## Change
- Keep the existing Home DOM, content order, callbacks, themes, and vertical page scroll.
- At `max-width: 767px`, place the Recent Journal cards in a native horizontal row so one complete recent-memory card remains visible while the remaining cards stay reachable.
- Keep the Recent Journal header and Current Journey subsection actions on readable single rows.
- Add one focused CSS contract assertion to the existing Home test.

## Validation
- Focused tests: PASS — 4 files / 76 tests.
  - `npm test -- --run features/home/HomeShell.test.tsx app/page.test.tsx shared/hooks/useStageCamera.test.ts shared/lib/viewport.test.ts`
- Production build: PASS — the single `npm run build` compiled, type-checked, and generated 9/9 static pages.
- Diff check: PASS — `git diff --check`.
- Runtime: PASS — 6/6 final-tree Home captures; no page errors, request failures, failed geometry checks, or theme DOM/geometry parity failures.
  - Warm Beige, 450x900 DPR2: PASS — first Journal bottom 420.09px; Open Quests bottom 538.17px; first Quest bottom 655.34px; protected bottom 793px.
  - Astral Neutral, 450x900 DPR2: PASS — identical geometry and component signature.
  - Warm Beige, 360x800 DPR1: PASS — first Journal bottom 420.09px; Open Quests bottom 538.17px; first Quest bottom 655.34px; protected bottom 693px.
  - Astral Neutral, 360x800 DPR1: PASS — identical geometry and component signature.
  - Warm Beige, 1600x1000 DPR1: PASS — PR #98 Journey-left / wider-than-Journal hierarchy preserved.
  - Astral Neutral, 1600x1000 DPR1: PASS — identical geometry and component signature.
- Reachability: PASS — the final Journal card is reachable horizontally and the final Role card is reachable vertically above the mobile OrbNav boundary in both themes/sizes.
- Browser note: the in-app browser reported no available session; evidence used the repository's existing Playwright/installed local Chrome fallback (Chrome 152.0.7977.77), with no added dependency.

## Evidence
- `.codex-local/issue-99/output/capture-results.json`
- `.codex-local/issue-99/output/captures/warm-beige/mobile-reference/WA-450x900_Home.png`
- `.codex-local/issue-99/output/captures/astral/mobile-reference/AS-450x900_Home.png`
- `.codex-local/issue-99/output/captures/warm-beige/mobile-narrow/WA-360x800_Home.png`
- `.codex-local/issue-99/output/captures/astral/mobile-narrow/AS-360x800_Home.png`
- `.codex-local/issue-99/output/captures/warm-beige/desktop-regression/WA-1600x1000_Home.png`
- `.codex-local/issue-99/output/captures/astral/desktop-regression/AS-1600x1000_Home.png`

## Repository state
- Branch: `fix/#99-mobile-home-first-view`
- Base HEAD: `24276c54bb34a7977253d988d77cf399ec3e419f`
- Changed tracked files: `app/globals.css`, `features/home/HomeShell.test.tsx`
- Diff stat: 2 files changed, 21 insertions(+), 0 deletions(-)
- Status: both tracked files modified and unstaged; no staged files.
- Selective staging command (not executed): `git add app/globals.css features/home/HomeShell.test.tsx`

## Verdict
PASS_READY_FOR_COMMIT


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the mobile Home layout with centered section headers and horizontally scrollable journal lists.
  * Adjusted mobile journal cards to use a wider, more touch-friendly layout.

* **Tests**
  * Added coverage to verify the horizontal scrolling behavior on small screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->